### PR TITLE
Adding rbenv .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ embedded/
 .bundle/
 Gemfile.lock
 .ropeproject/
+.ruby-version


### PR DESCRIPTION
rbenv stores the local ruby version in .ruby-version