### PR TITLE
adds pylint to test requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ nose==1.3.4
 flake8==2.5.1
 mock==1.0.1
 pep8==1.5.7
+pylint==1.5.5


### PR DESCRIPTION
Pylint isn't in the test requirements, which produces (because the command itself is a bit enigmatic) an extremely enigmatic error when you try to run rake. This fixes that by adding pylint to test-requirements.txt.