### PR TITLE
[filebeat] adding integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - DD_AGENT_BRANCH=master
   matrix:
     - TRAVIS_FLAVOR=default
+    - TRAVIS_FLAVOR=filebeat FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[filebeat]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/conf.d/filebeat.yaml.example
+++ b/conf.d/filebeat.yaml.example
@@ -1,0 +1,7 @@
+init_config:
+
+instances:
+  # The absolute path to the registry file used by filebeat
+  # See https://www.elastic.co/guide/en/beats/filebeat/current/migration-registry-file.html
+
+  - registry_file_path: /var/lib/filebeat/registry

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -1,0 +1,32 @@
+# Filebeat Integration
+
+## Overview
+
+Get metrics from filebeat service in real time to:
+
+* Visualize and monitor filebeat states
+* Be notified about filebeat failovers and events.
+
+## Installation
+
+Install the `dd-check-filebeat` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `filebeat.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        filebeat
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The filebeat check is compatible with all major platforms

--- a/filebeat/check.py
+++ b/filebeat/check.py
@@ -5,9 +5,12 @@
 # stdlib
 
 # 3rd party
+import json
+import os
 
 # project
 from checks import AgentCheck
+
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'filebeat'
 
@@ -18,4 +21,39 @@ class FilebeatCheck(AgentCheck):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
     def check(self, instance):
-        pass
+        registry_file_path = instance.get('registry_file_path')
+        if registry_file_path is None:
+            raise Exception('An absolute path to a filebeat registry path must be specified')
+
+        registry_contents = self._parse_registry_file(registry_file_path)
+
+        for item in registry_contents.itervalues():
+            self._process_registry_item(item)
+
+    def _parse_registry_file(self, registry_file_path):
+        try:
+            with open(registry_file_path) as registry_file:
+                return json.load(registry_file)
+        except IOError:
+            self.log.warn('No filebeat registry file found at %s' % (registry_file_path, ))
+            return {}
+
+    def _process_registry_item(self, item):
+        source = item['source']
+        offset = item['offset']
+
+        try:
+            stats = os.stat(source)
+
+            if self._is_same_file(stats, item['FileStateOS']):
+                unprocessed_bytes = stats.st_size - offset
+
+                self.gauge('filebeat.registry.unprocessed_bytes', unprocessed_bytes,
+                           tags=["source:{0}".format(source)])
+            else:
+                self.log.debug("Filebeat source %s appears to have changed" % (source, ))
+        except OSError:
+            self.log.debug("Unable to get stats on filebeat source %s" % (source, ))
+
+    def _is_same_file(self, stats, file_state_os):
+        return stats.st_dev == file_state_os['device'] and stats.st_ino == file_state_os['inode']

--- a/filebeat/check.py
+++ b/filebeat/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'filebeat'
+
+
+class FilebeatCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/filebeat/ci/filebeat.rake
+++ b/filebeat/ci/filebeat.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def filebeat_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def filebeat_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/filebeat_#{filebeat_version}"
+end
+
+namespace :ci do
+  namespace :filebeat do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('filebeat/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name filebeat source/filebeat:filebeat_version)
+      # sh %(docker start filebeat)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'filebeat'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop filebeat)
+    #   sh %(docker rm filebeat)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/filebeat/ci/resources/fixtures/happy_path_registry.json
+++ b/filebeat/ci/resources/fixtures/happy_path_registry.json
@@ -1,0 +1,18 @@
+{
+    "/test_dd_agent/var/log/nginx/access.log": {
+        "source": "/test_dd_agent/var/log/nginx/access.log",
+        "offset": 391747,
+        "FileStateOS": {
+            "inode": 277025,
+            "device": 51713
+        }
+    },
+    "/test_dd_agent/var/log/syslog": {
+        "source": "/test_dd_agent/var/log/syslog",
+        "offset": 1024917,
+        "FileStateOS": {
+            "inode": 152172,
+            "device": 51713
+        }
+    }
+}

--- a/filebeat/ci/resources/fixtures/missing_source_file_registry.json
+++ b/filebeat/ci/resources/fixtures/missing_source_file_registry.json
@@ -1,0 +1,10 @@
+{
+    "/i/sure/dont/exist.log": {
+        "source": "/i/sure/dont/exist.log",
+        "offset": 391747,
+        "FileStateOS": {
+            "inode": 277025,
+            "device": 51713
+        }
+    }
+}

--- a/filebeat/ci/resources/fixtures/single_source_registry.json
+++ b/filebeat/ci/resources/fixtures/single_source_registry.json
@@ -1,0 +1,10 @@
+{
+    "/test_dd_agent/var/log/syslog": {
+        "source": "/test_dd_agent/var/log/syslog",
+        "offset": 1024917,
+        "FileStateOS": {
+            "inode": 152172,
+            "device": 51713
+        }
+    }
+}

--- a/filebeat/conf.yaml.example
+++ b/filebeat/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "filebeat",
+  "short_description": "filebeat description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/filebeat/metadata.csv
+++ b/filebeat/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/filebeat/requirements.txt
+++ b/filebeat/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/filebeat/test_filebeat.py
+++ b/filebeat/test_filebeat.py
@@ -4,35 +4,90 @@
 
 # stdlib
 from nose.plugins.attrib import attr
+from collections import namedtuple
+import os
 
 # 3p
+from mock import patch
 
 # project
 from tests.checks.common import AgentCheckTest
 
 
-instance = {
-    'host': 'localhost',
-    'port': 26379,
-    'password': 'datadog-is-devops-best-friend'
-}
+mocked_file_stats = namedtuple('mocked_file_stats', ['st_size', 'st_ino', 'st_dev'])
 
 
-# NOTE: Feel free to declare multiple test classes if needed
+# allows mocking `os.stat` only for certain paths; for all others it will call
+# the actual function - needed as a number of test helpers do make calls to it
+def with_mocked_os_stat(mocked_paths_and_stats):
+    vanilla_os_stat = os.stat
+
+    def internal_mock(path):
+        if path in mocked_paths_and_stats:
+            return mocked_paths_and_stats[path]
+        return vanilla_os_stat(path)
+
+    def external_wrapper(function):
+        # silly, but this _must_ start with `test_` for nose to pick it up as a
+        # test when used below
+        def test_wrapper(*args, **kwargs):
+            with patch.object(os, 'stat') as patched_os_stat:
+                patched_os_stat.side_effect = internal_mock
+                return function(*args, **kwargs)
+        return test_wrapper
+
+    return external_wrapper
+
 
 @attr(requires='filebeat')
 class TestFilebeat(AgentCheckTest):
     """Basic Test for filebeat integration."""
     CHECK_NAME = 'filebeat'
 
-    def test_check(self):
-        """
-        Testing Filebeat check.
-        """
-        self.load_check({}, {})
+    def _build_config(self, name):
+        return {
+            'init_config': None,
+            'instances': [
+                {
+                    'registry_file_path': Fixtures.file(name + '_registry.json')
+                }
+            ]
+        }
 
-        # run your actual tests...
+    @with_mocked_os_stat({'/test_dd_agent/var/log/nginx/access.log': mocked_file_stats(394154, 277025, 51713),
+                          '/test_dd_agent/var/log/syslog': mocked_file_stats(1024917, 152172, 51713)})
+    def test_happy_path(self):
+        self.run_check(self._build_config('happy_path'))
 
-        self.assertTrue(True)
-        # Raises when COVERAGE=true and coverage < 100%
-        self.coverage_report()
+        self.assertMetric('filebeat.registry.unprocessed_bytes', value=2407, tags=['source:/test_dd_agent/var/log/nginx/access.log'])
+        self.assertMetric('filebeat.registry.unprocessed_bytes', value=0, tags=['source:/test_dd_agent/var/log/syslog'])
+
+    def test_bad_config(self):
+        bad_config = {
+            'init_config': None,
+            'instances': [{}]
+        }
+
+        self.assertRaises(
+            Exception,
+            lambda: self.run_check(bad_config)
+        )
+
+    def test_missing_registry_file(self):
+        # tests that it simply silently ignores it
+        self.run_check(self._build_config('i_dont_exist'))
+        self.assertMetric('filebeat.registry.unprocessed_bytes', count=0)
+
+    def test_missing_source_file(self):
+        self.run_check(self._build_config('missing_source_file'))
+        self.assertMetric('filebeat.registry.unprocessed_bytes', count=0)
+
+    @with_mocked_os_stat({'/test_dd_agent/var/log/syslog': mocked_file_stats(1024917, 152171, 51713)})
+    def test_source_file_inode_has_changed(self):
+        self.run_check(self._build_config('single_source'))
+        self.assertMetric('filebeat.registry.unprocessed_bytes', count=0)
+
+    @with_mocked_os_stat({'/test_dd_agent/var/log/syslog': mocked_file_stats(1024917, 152172, 51714)})
+    def test_source_file_device_has_changed(self):
+        self.run_check(self._build_config('single_source'))
+        self.assertMetric('filebeat.registry.unprocessed_bytes', count=0)

--- a/filebeat/test_filebeat.py
+++ b/filebeat/test_filebeat.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='filebeat')
+class TestFilebeat(AgentCheckTest):
+    """Basic Test for filebeat integration."""
+    CHECK_NAME = 'filebeat'
+
+    def test_check(self):
+        """
+        Testing Filebeat check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()


### PR DESCRIPTION
### What does this PR do?

Adds a check for filebeat

Originally written by @wk8 (https://github.com/DataDog/dd-agent/pull/3062)

### Motivation

Filebeat (https://github.com/elastic/beats) is a deamon tailing and processing
log files, for example to send them to Logstash.

It maintains a _registry file_, in which it keeps track of which log files it's
currently tailing, and up to what point it has processed them.

This patch adds an agent check that leverages that registry file to gauge
filebat's progress; more specifically, it pushes how many bytes are currently
left to process for filebeat.

This metric would be useful for example to create a monitor alerting when
filebeat falls too far behind.

### Testing

A Testcase is provided here: tests/checks/mock/test_filebeat.py
It contains 6 tests, which provide 100% code coverage on the new check.