### PR TITLE
[aerospike] adding integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - DD_AGENT_BRANCH=master
   matrix:
     - TRAVIS_FLAVOR=default
+    - TRAVIS_FLAVOR=aerospike FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -1,0 +1,32 @@
+# Aerospike Integration
+
+## Overview
+
+Get metrics from aerospike service in real time to:
+
+* Visualize and monitor aerospike states
+* Be notified about aerospike failovers and events.
+
+## Installation
+
+Install the `dd-check-aerospike` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `aerospike.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        aerospike
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The aerospike check is compatible with all major platforms

--- a/aerospike/check.py
+++ b/aerospike/check.py
@@ -1,21 +1,77 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+# Aerospike agent check for Datadog Agent.
+# Copyright (C) 2015 Pippio, Inc. All rights reserved.
 
 # stdlib
-
-# 3rd party
+import socket
+from contextlib import closing
 
 # project
 from checks import AgentCheck
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'aerospike'
+SERVICE_CHECK_NAME = '%s.server_up' % EVENT_TYPE
 
 
 class AerospikeCheck(AgentCheck):
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self.connection_pool = {}
 
     def check(self, instance):
-        pass
+        """Run the Aerospike check for one instance."""
+
+        # Required parameters
+        host = instance['host']
+        port = int(instance['port'])
+
+        # Optional parameters
+        want_metrics = set(instance.get('metrics', []))
+        want_namespace_metrics = set(instance.get('namespace_metrics', []))
+        namespaces = instance.get('namespaces', None)
+
+        key = '%s:%d' % (host, port)
+        conn = self.connection_pool.get(key, None)
+
+        if conn is None:
+            conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            conn.connect((host, port))
+            self.connection_pool[key] = conn
+
+        try:
+            with closing(conn.makefile('r')) as fp:
+                if namespaces is None:
+                    # Probe all namespaces by default.
+                    conn.send('namespaces\r\n')
+                    namespaces = fp.readline().rstrip().split(';')
+
+                conn.send('statistics\r\n')
+                self._send_metrics(fp, want_metrics)
+
+                for n in namespaces:
+                    conn.send('namespace/%s\r\n' % n)
+                    tags = {'namespace': n}
+                    self._send_metrics(fp, want_namespace_metrics, tags)
+
+            self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK)
+        except socket.error:
+            self.log.exception('Error connecting to Aerospike at %s', key)
+            del self.connection_pool[key]
+
+    def _send_metrics(self, fp, only_keys=[], tags={}):
+        vals = dict(x.split('=', 1) for x in fp.readline().rstrip().split(';'))
+        if only_keys:
+            # Cherry pick only desired metrics, if they exist.
+            for skey in only_keys:
+                value = vals.get(skey, None)
+                if value and value.isdigit():
+                    self.gauge(self._make_key(skey), value, tags=tags)
+        else:
+            # Present all metrics.
+            for skey, value in vals.items():
+                if value.isdigit():
+                    self.gauge(self._make_key(skey), value, tags=tags)
+
+    @staticmethod
+    def _make_key(n):
+        return '%s.%s' % (EVENT_TYPE, n.replace('-', '_'))

--- a/aerospike/check.py
+++ b/aerospike/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'aerospike'
+
+
+class AerospikeCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/aerospike/ci/aerospike.rake
+++ b/aerospike/ci/aerospike.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def aerospike_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def aerospike_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/aerospike_#{aerospike_version}"
+end
+
+namespace :ci do
+  namespace :aerospike do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('aerospike/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name aerospike source/aerospike:aerospike_version)
+      # sh %(docker start aerospike)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'aerospike'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop aerospike)
+    #   sh %(docker rm aerospike)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/aerospike/conf.yaml.example
+++ b/aerospike/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/aerospike/conf.yaml.example
+++ b/aerospike/conf.yaml.example
@@ -2,10 +2,23 @@ init_config:
   # Any global configurable parameters should be added here
 
 instances:
-  #   A typical instance configuration might include a hostname and port
-  #   a set of customizable tags and other parameters we might need to
-  #   configure the behavior of our check.
-  #
-  # - host: localhost
-  #   port: 26379
-  #   tags: ['custom:tag']
+  - host: 127.0.0.1
+    port: 3003
+
+    # All metrics collected by default. You probably don't want to do this,
+    # so list the ones you do want here. Check with asinfo -v statistics -l
+    # and asinfo -v namespace/YOURNAMESPACE -l.
+
+    # metrics:
+    # - migrate_rx_objs
+    # - migrate_tx_objs
+    # namespace_metrics:
+    # - free-pct-disk
+    # - free-pct-memory
+    # - evicted-objects
+    # - expired-objects
+    # - master-objects
+    # - migrate-rx-partitions-initial
+    # - migrate-rx-partitions-remaining
+    # - migrate-tx-partitions-initial
+    # - migrate-tx-partitions-remaining

--- a/aerospike/manifest.json
+++ b/aerospike/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "aerospike",
+  "short_description": "aerospike description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/aerospike/metadata.csv
+++ b/aerospike/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/aerospike/requirements.txt
+++ b/aerospike/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/aerospike/test_aerospike.py
+++ b/aerospike/test_aerospike.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='aerospike')
+class TestAerospike(AgentCheckTest):
+    """Basic Test for aerospike integration."""
+    CHECK_NAME = 'aerospike'
+
+    def test_check(self):
+        """
+        Testing Aerospike check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[aerospike]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi


### PR DESCRIPTION
### What does this PR do?

Adds an integration check for Aerospike.

Originally written by @joshk0 (https://github.com/DataDog/dd-agent/pull/2219)

### Motivation

Add an AgentCheck for collecting statistics from the Aerospike key-value
store. It lets you pick and choose which metrics you want to track since
there are a very large number of metrics and statistics that Aerospike
provides. All get tracked as gauges.

This is a competing plugin to #1775, which I find to be dramatically too heavyweight for my needs.