### PR TITLE
[logstats] adding integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - DD_AGENT_BRANCH=master
   matrix:
     - TRAVIS_FLAVOR=default
+    - TRAVIS_FLAVOR=logstats FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[logstats]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/logstats/README.md
+++ b/logstats/README.md
@@ -1,0 +1,32 @@
+# Logstats Integration
+
+## Overview
+
+Get metrics from logstats service in real time to:
+
+* Visualize and monitor logstats states
+* Be notified about logstats failovers and events.
+
+## Installation
+
+Install the `dd-check-logstats` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `logstats.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        logstats
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The logstats check is compatible with all major platforms

--- a/logstats/check.py
+++ b/logstats/check.py
@@ -1,10 +1,11 @@
-# (C) Datadog, Inc. 2010-2016
+# (C) Chris Moultrie <chris@moultrie.org> 2016
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-# stdlib
 
-# 3rd party
+# stdlib
+import os
+import time
 
 # project
 from checks import AgentCheck
@@ -13,9 +14,130 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'logstats'
 
 
 class LogstatsCheck(AgentCheck):
+    """This check is for calculating stats on log lines containing key terms
+
+    WARNING: the user/group that dd-agent runs as must have access to stat the log specified
+
+    Config options:
+        "logfile" - string, the directory to gather stats for. required
+        "ignores" - list, ignore a log line if it contains this keyword
+    """
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
+    def _get_marker_filename(self, filename):
+        """Gets the filename which holds our last known position in the logfile"""
+        return os.path.join('/', 'tmp', "%s.ddmark" % (os.path.basename(filename),))
+
+    def _get_marker_pos(self, filename):
+        """Gets the last used position in the log file
+        Returns -1 if we don't have a marker
+        """
+        marker_path = self._get_marker_filename(filename)
+        marker_pos = -1
+
+        if os.path.exists(marker_path):
+            with open(marker_path, 'r') as marker_file:
+                marker_pos = marker_file.read()
+                marker_pos = int(marker_pos)
+
+        if marker_pos == -1:
+            self.log.info("No marker file found, setting marker to end of file.")
+
+        return marker_pos
+
+    def _set_marker_pos(self, filename, position):
+        """Sets the position that we finished parsing the log file at"""
+        marker_path = self._get_marker_filename(filename)
+        self.log.debug("Writing marker for file: %s @ %d", filename, position)
+        with open(marker_path, 'w+') as marker_file:
+            marker_file.write(str(position))
+
+    def _submit_event(self, filename, line, alert_type):
+        event = {
+            "timestamp": int(time.time()),
+            "event_type": "logstats",
+            "msg_title": "ERROR in %s" % (filename,),
+            "msg_text": line,
+            "alert_type": alert_type,
+            "source_type_name": "my apps",
+            "tags": ["filename:%s" % (os.path.basename(filename),)],
+        }
+        self.event(event)
+
+    def _count_items(self, filename, position, ignores):
+        """Count how many ERRORS and WARNINGS we see in the logs
+        filename is the name of the file to parse
+        position is where we should start parsing from
+        """
+        errors = 0
+        warnings = 0
+
+        with open(filename) as logfile:
+            # Find out how long the file is, we need to know if it rotated
+            logfile.seek(0, os.SEEK_END)
+            end = logfile.tell()
+            self.log.debug("End of log file is: %d, last position is %d", end, position)
+
+            # If our previous marker is greater than the possible positions in the file, it's
+            # rotated, we need to start over
+            if end < position:
+                self.log.debug("End of log file is: %d, last position is %d", end, position)
+                position = 0
+
+            # If we never had a position before, go to the end of the file, we'll start from there
+            # otherwise, we can start at the last place we ended
+            if position == -1:
+                logfile.seek(position, os.SEEK_END)
+            else:
+                logfile.seek(position, os.SEEK_SET)
+
+            # Iterate through the rest of the file, looking for ERROR or WARNING
+            for line in logfile:
+                skip_line = False
+                for ignore in ignores:
+                    if ignore in line:
+                        skip_line = True
+                        break
+                if skip_line:
+                    continue
+
+                if "ERROR" in line:
+                    errors += 1
+                    self._submit_event(filename, line, 'error')
+                elif "WARNING" in line:
+                    warnings += 1
+
+            # Update the marker file with our new end
+            self._set_marker_pos(filename, logfile.tell())
+        self.log.debug("Found %d errors and %d warnings in file %s", errors, warnings, filename)
+
+        return errors, warnings
+
     def check(self, instance):
-        pass
+        """This is the method we override from AgentCheck
+        It is called during the check and does the reporting
+        """
+        logfilename = instance.get('logfile')
+        ignores = instance.get('ignores', [])
+        if logfilename is None:
+            self.log.info('Skipping instance, No log file specified')
+            return
+
+        marker_pos = self._get_marker_pos(logfilename)
+        errors, warnings = self._count_items(logfilename, marker_pos, ignores)
+        self.increment('logstats.errors.count', errors, ["filename:%s" %
+                                                         (os.path.basename(logfilename))])
+        self.increment('logstats.warnings.count', warnings, ["filename:%s" %
+                                                             (os.path.basename(logfilename))])
+
+
+if __name__ == '__main__':
+    check, instances = LogstatsCheck.from_yaml('/etc/dd-agent/conf.d/logstats.yaml')
+    for instance in instances:
+        print "\nRunning the check against logfile: %s" % (instance['logfile'])
+        check.check(instance)
+        if check.has_events():
+            print 'Events: %s' % (check.get_events())
+        print 'Metrics: %s' % (check.get_metrics())

--- a/logstats/check.py
+++ b/logstats/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'logstats'
+
+
+class LogstatsCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/logstats/ci/logstats.rake
+++ b/logstats/ci/logstats.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def logstats_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def logstats_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/logstats_#{logstats_version}"
+end
+
+namespace :ci do
+  namespace :logstats do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('logstats/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name logstats source/logstats:logstats_version)
+      # sh %(docker start logstats)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'logstats'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop logstats)
+    #   sh %(docker rm logstats)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/logstats/conf.yaml.example
+++ b/logstats/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/logstats/conf.yaml.example
+++ b/logstats/conf.yaml.example
@@ -6,6 +6,7 @@ instances:
   #   a set of customizable tags and other parameters we might need to
   #   configure the behavior of our check.
   #
-  # - host: localhost
-  #   port: 26379
-  #   tags: ['custom:tag']
+  - logfile: /var/log/syslog
+    # ignores:
+    #   - log4j
+    #   - status unknown error on node

--- a/logstats/manifest.json
+++ b/logstats/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "logstats",
+  "short_description": "logstats description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/logstats/metadata.csv
+++ b/logstats/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/logstats/requirements.txt
+++ b/logstats/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/logstats/test_logstats.py
+++ b/logstats/test_logstats.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='logstats')
+class TestLogstats(AgentCheckTest):
+    """Basic Test for logstats integration."""
+    CHECK_NAME = 'logstats'
+
+    def test_check(self):
+        """
+        Testing Logstats check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()


### PR DESCRIPTION
### What does this PR do?

Adds an integration for log stats collection.

Originally written by @tebriel (https://github.com/DataDog/dd-agent/pull/2488).

### Motivation

I wrote this Agent Check to count frequency of instances of `ERROR` and `WARNING` in my logs. I know there's a log check, but that's not really what that check does. Before I modify this check more and add tests to the main repo, I wanted to submit this and start a conversation around it, see if it was something that could be merged in as a new check, and then clean it up/make it more general purpose.

Thanks.

Here's an example output from running it:

```
root@ddtesthost:/etc/dd-agent/checks.d# sudo -u dd-agent dd-agent check logstats
2016-05-10 21:37:50,664 | WARNING | dd.collector | checks.disk(disk.py:74) | Using `use_mount` in datadog.conf has been deprecated in favor of `use_mount` in disk.yaml
2016-05-10 21:37:50,694 | INFO | dd.collector | config(config.py:899) | initialized checks.d checks: ['network', 'ntp', 'logstats', 'mysql', 'redisdb', 'disk']
2016-05-10 21:37:50,694 | INFO | dd.collector | config(config.py:900) | initialization failed checks.d checks: []
2016-05-10 21:37:50,694 | INFO | dd.collector | checks.collector(collector.py:535) | Running check logstats
Metrics:
[('logstats.errors.count',
  1462916270,
  9.0,
  {'hostname': 'ddtesthost',
   'tags': ['filename:syslog'],
   'type': 'rate'}),
 ('logstats.warnings.count',
  1462916270,
  3.0,
  {'hostname': 'ddtesthost',
   'tags': ['filename:syslog'],
   'type': 'rate'})]
```