### PR TITLE
[sidekiq] adding integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - DD_AGENT_BRANCH=master
   matrix:
     - TRAVIS_FLAVOR=default
+    - TRAVIS_FLAVOR=sidekiq FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[sidekiq]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -1,0 +1,32 @@
+# Sidekiq Integration
+
+## Overview
+
+Get metrics from sidekiq service in real time to:
+
+* Visualize and monitor sidekiq states
+* Be notified about sidekiq failovers and events.
+
+## Installation
+
+Install the `dd-check-sidekiq` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `sidekiq.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        sidekiq
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The sidekiq check is compatible with all major platforms

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -28,7 +28,6 @@ class Stats:
     # KEYS[5] = 'dead'
     # KEYS[6] = 'processes'
     # KEYS[7] = 'queues'
-    # KEYS[8] = 'queue:*'
     #
     # Returns an array of results. The array follows the following format:
     # [
@@ -58,46 +57,31 @@ class Stats:
         s = """
         local processed = redis.call("GET", KEYS[1])
         local failed = redis.call("GET", KEYS[2])
-        local scheduled_size = redis.call("GET", KEYS[3])
-        local retry_size = redis.call("GET", KEYS[4])
-        local dead_size = redis.call("GET", KEYS[5])
+        local scheduled_size = redis.call("ZCARD", KEYS[3])
+        local retry_size = redis.call("ZCARD", KEYS[4])
+        local dead_size = redis.call("ZCARD", KEYS[5])
         local processes_size = redis.call("SCARD", KEYS[6])
         local processes = redis.call("SMEMBERS", KEYS[6])
 
         local workers_size = 0
         for i, pkey in ipairs(processes) do
-          workers_size = workers_size + tonumber(redis.call("HGET", pkey, "busy"))
+            nspkey = ARGV[1] == "None" and pkey or (ARGV[1] .. ":" .. pkey)
+            workers_size = workers_size + tonumber(redis.call("HGET", nspkey, "busy"))
         end
 
         local queues = redis.call("SMEMBERS", KEYS[7])
-        local all_queues = redis.call("KEYS", KEYS[8])
-        local all_queue_lengths = {}
-        local all_queue_latencies = {}
-        for i, qkey in ipairs(all_queues) do
-            all_queue_lengths[qkey] = tonumber(redis.call("LLEN", qkey))
-            local last = redis.call("LRANGE", qkey, -1, -1)[0]
-            if not last == nil then
-                all_queue_latencies[qkey] = tonumber(cjson.decode(last)["enqueued_at"])
-            else
-                all_queue_latencies[qkey] = 0.0
-            end
-        end
-
         local queue_lengths = {}
         local queue_latencies = {}
-        for i, qname in ipairs(queues) do
-            queue_lengths[qname] = 0
-            queue_latencies[qname] = 0
+        for i, qkey in ipairs(queues) do
+            local nsqkey = "queue:" .. qkey
+            nsqkey = ARGV[1] == "None" and nsqkey or (ARGV[1] .. ":" .. nsqkey)
 
-            local pattern1 = "queue:" .. qname .. "$"
-            local pattern2 = "queue:" .. qname .. "_.+"
-            for j, sqname in ipairs(all_queues) do
-                if not (string.match(sqname, pattern1) == nil and string.match(sqname, pattern2) == nil) then
-                    queue_lengths[qname] = queue_lengths[qname] + all_queue_lengths[sqname]
-                    if all_queue_latencies[sqname] > queue_latencies[qname] then
-                      queue_latencies[qname] = all_queue_latencies[sqname]
-                    end
-                end
+            queue_lengths[qkey] = redis.call("LLEN", nsqkey)
+            local last = redis.call("LRANGE", nsqkey, -1, -1)[0]
+            if not last == nil then
+                queue_latencies[qkey] = tonumber(cjson.decode(last)["enqueued_at"])
+            else
+                queue_latencies[qkey] = 0.0
             end
         end
 
@@ -122,8 +106,10 @@ class Stats:
                             self.key('retry'),
                             self.key('dead'),
                             self.key('processes'),
-                            self.key('queues'),
-                            self.key('queue:*')])
+                            self.key('queues')],
+                            args=[
+                                self.namespace,
+                            ])
 
     def _check_stats(self):
         res = self._run_script()

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -62,28 +62,36 @@ class Stats:
         for queue in queues:
             self.queues[queue] = {'length': 0, 'latency': 0.0}
 
+    # Sum length of all sub queues for each queue
     def _check_queue_lengths(self, queues):
-        pipe = self.conn.pipeline()
-
         for queue in queues:
-            pipe.llen(self.key('queue:%s' % queue))
-        res = pipe.execute()
+            qname = 'queue:%s' % queue
+            subqueues = [self.key(qname)] + self.conn.keys('%s_*' % self.key(qname))
+            pipe = self.conn.pipeline()
 
-        for i in range(len(res)):
-            self.queues[queues[i]]['length'] = res[i]
+            for sq_key in subqueues:
+                pipe.llen(sq_key)
+            res = pipe.execute()
+            self.queues[queue]['length'] = sum([int(x) for x in res])
 
+    # Find max latency of sub queues for each queue
     def _check_queue_latencies(self, queues):
-        pipe = self.conn.pipeline()
 
         for queue in queues:
-            pipe.lrange(self.key('queue:%s' % queue), -1, -1)
-        res = pipe.execute()
+            qname = 'queue:%s' % queue
+            subqueues = [self.key(qname)] + self.conn.keys('%s_*' % self.key(qname))
+            pipe = self.conn.pipeline()
 
-        for i in range(len(res)):
-            entry = res[i]
-            if len(entry) > 0:
-                latency = time.time() - float(json.loads(entry[0])['enqueued_at'])
-                self.queues[queues[i]]['latency'] = latency
+            for sq_key in subqueues:
+                pipe.lrange(sq_key, -1, -1)
+            res = pipe.execute()
+
+            for i in range(len(res)):
+                entry = res[i]
+                if len(entry) > 0:
+                    latency = time.time() - float(json.loads(entry[0])['enqueued_at'])
+                    if latency > self.queues[queue]['latency']:
+                        self.queues[queue]['latency'] = latency
 
     def key(self, name):
         return "%s:%s" % (self.namespace, name) if self.namespace else name

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -108,8 +108,7 @@ class Stats:
                             self.key('processes'),
                             self.key('queues')],
                             args=[
-                                self.namespace,
-                            ])
+                                self.namespace])
 
     def _check_stats(self):
         res = self._run_script()

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -3,8 +3,6 @@ Sidekiq checks
 '''
 # stdlib
 import time
-import json
-import re
 
 # 3rd party
 import redis
@@ -19,83 +17,133 @@ class Stats:
     def __init__(self, conn, namespace):
         self.conn = conn
         self.namespace = namespace
+        self._script = self._register_script()
         self._check_stats()
 
-    def _check_stats(self):
-        # Check sidekiq stats
-        pipe = self.conn.pipeline()
-        pipe.get(self.key('stat:processed'))
-        pipe.get(self.key('stat:failed'))
-        pipe.zcard(self.key('schedule'))
-        pipe.zcard(self.key('retry'))
-        pipe.zcard(self.key('dead'))
-        pipe.scard(self.key('processes'))
-        pipe.smembers(self.key('processes'))
-        pipe.smembers(self.key('queues'))
-        res = pipe.execute()
+    # This script collects all the sidekiq related stats in one go.
+    # KEYS[1] = 'stat:processed'
+    # KEYS[2] = 'stat:failed'
+    # KEYS[3] = 'schedule'
+    # KEYS[4] = 'retry'
+    # KEYS[5] = 'dead'
+    # KEYS[6] = 'processes'
+    # KEYS[7] = 'queues'
+    # KEYS[8] = 'queue:*'
+    #
+    # Returns an array of results. The array follows the following format:
+    # [
+    #   processed,
+    #   failed,
+    #   scheduled_size,
+    #   retry_size,
+    #   dead_size,
+    #   processes_size,
+    #   workers_size,
+    #   number_of_queues,
+    #   queue name 1,
+    #   queue name 2,
+    #   ...,
+    #   queue name n,
+    #   queue length 1,
+    #   queue length 2,
+    #   ...,
+    #   queue length n,
+    #   queue latency 1,
+    #   queue latency 2,
+    #   ...,
+    #   queue latency n
+    # ]
+    #
+    def _register_script(self):
+        s = """
+        local processed = redis.call("GET", KEYS[1])
+        local failed = redis.call("GET", KEYS[2])
+        local scheduled_size = redis.call("GET", KEYS[3])
+        local retry_size = redis.call("GET", KEYS[4])
+        local dead_size = redis.call("GET", KEYS[5])
+        local processes_size = redis.call("SCARD", KEYS[6])
+        local processes = redis.call("SMEMBERS", KEYS[6])
 
+        local workers_size = 0
+        for i, pkey in ipairs(processes) do
+          workers_size = workers_size + tonumber(redis.call("HGET", pkey, "busy"))
+        end
+
+        local queues = redis.call("SMEMBERS", KEYS[7])
+        local all_queues = redis.call("KEYS", KEYS[8])
+        local all_queue_lengths = {}
+        local all_queue_latencies = {}
+        for i, qkey in ipairs(all_queues) do
+            all_queue_lengths[qkey] = tonumber(redis.call("LLEN", qkey))
+            local last = redis.call("LRANGE", qkey, -1, -1)[0]
+            if not last == nil then
+                all_queue_latencies[qkey] = tonumber(cjson.decode(last)["enqueued_at"])
+            else
+                all_queue_latencies[qkey] = 0.0
+            end
+        end
+
+        local queue_lengths = {}
+        local queue_latencies = {}
+        for i, qname in ipairs(queues) do
+            queue_lengths[qname] = 0
+            queue_latencies[qname] = 0
+
+            local pattern1 = "queue:" .. qname .. "$"
+            local pattern2 = "queue:" .. qname .. "_.+"
+            for j, sqname in ipairs(all_queues) do
+                if not (string.match(sqname, pattern1) == nil and string.match(sqname, pattern2) == nil) then
+                    queue_lengths[qname] = queue_lengths[qname] + all_queue_lengths[sqname]
+                    if all_queue_latencies[sqname] > queue_latencies[qname] then
+                      queue_latencies[qname] = all_queue_latencies[sqname]
+                    end
+                end
+            end
+        end
+
+        local offset = 8
+        local result = {processed,failed,scheduled_size,retry_size,dead_size,processes_size,workers_size}
+        local n = table.getn(queues)
+        result[offset] = n
+        for i, q in ipairs(queues) do
+            result[offset + i] = q
+            result[offset + i + n] = queue_lengths[q]
+            result[offset + i + n + n] = queue_latencies[q]
+        end
+        return result
+        """
+        return self.conn.register_script(s)
+
+    def _run_script(self):
+        return self._script(keys=[
+                            self.key('stat:processed'),
+                            self.key('stat:failed'),
+                            self.key('schedule'),
+                            self.key('retry'),
+                            self.key('dead'),
+                            self.key('processes'),
+                            self.key('queues'),
+                            self.key('queue:*')])
+
+    def _check_stats(self):
+        res = self._run_script()
         self.processed = int(res[0])
         self.failed = int(res[1])
         self.scheduled_size = res[2]
         self.retry_size = res[3]
         self.dead_size = res[4]
         self.processes_size = res[5]
+        self.workers_size = res[6]
+        num_queues = res[7]
 
-        procs = list(res[6])
-        queues = list(res[7])
-
-        self._check_processes(procs)
-        self._init_queue_stats(queues)
-        self._check_queue_stats(queues)
-
-    def _check_processes(self, procs):
-        pipe = self.conn.pipeline()
-
-        for proc in procs:
-            pipe.hget(self.key(proc), 'busy')
-        res = pipe.execute()
-
-        self.workers_size = sum([int(x) for x in res])
-
-    def _init_queue_stats(self, queues):
+        offset = 8
         self.queue_stats = {}
-        for queue in queues:
-            self.queue_stats[queue] = {'length': 0, 'latency': 0.0}
-
-    def _check_queue_stats(self, queues):
-        # Select all queue keys (with reliable fetch, every worker has their
-        # own sub queue per queue)
-        queues_and_subqueues = self.conn.keys(self.key('queue:*'))
-        pipe = self.conn.pipeline()
-        for qkey in queues_and_subqueues:
-            pipe.llen(qkey) # Get length of queue
-            pipe.lrange(qkey, -1, -1) # Get last entry in queue
-        res = pipe.execute()
-
-        # Move stats into a dict for easy lookup
-        lengths = {}
-        latencies = {}
-        now = time.time()
-        for i in range(len(queues_and_subqueues)):
-            llen_idx = i * 2
-            lrange_idx = llen_idx + 1
-
-            lengths[queues_and_subqueues[i]] = int(res[llen_idx])
-
-            entries = res[lrange_idx]
-            if len(entries) > 0:
-                latency = now - float(json.loads(entries[0])['enqueued_at'])
-            else:
-                latency = 0.0
-            latencies[queues_and_subqueues[i]] = latency
-
-        # Roll up stats from sub queues into their parent queues
-        for q in queues:
-            pattern = self.key('queue:%s(|_.+)?' % q)
-            sub_queues = [x for x in queues_and_subqueues if re.match(pattern, x)]
-            if len(sub_queues) > 0:
-                self.queue_stats[q]['length'] = sum([lengths[x] for x in sub_queues])
-                self.queue_stats[q]['latency'] = max([latencies[x] for x in sub_queues])
+        for i in range(num_queues):
+            qname = res[offset + i]
+            self.queue_stats[qname] = {
+                'length': res[offset + i + num_queues],
+                'latency': res[offset + i + num_queues + num_queues]
+            }
 
     def key(self, name):
         return "%s:%s" % (self.namespace, name) if self.namespace else name

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -65,7 +65,7 @@ class Stats:
 
         local workers_size = 0
         for i, pkey in ipairs(processes) do
-            nspkey = ARGV[1] == "None" and pkey or (ARGV[1] .. ":" .. pkey)
+            local nspkey = ARGV[1] == "None" and pkey or (ARGV[1] .. ":" .. pkey)
             workers_size = workers_size + tonumber(redis.call("HGET", nspkey, "busy"))
         end
 

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -3,6 +3,7 @@ Sidekiq checks
 '''
 # stdlib
 import time
+import json
 
 # 3rd party
 import redis
@@ -13,7 +14,83 @@ from checks import AgentCheck
 EVENT_TYPE = SOURCE_TYPE_NAME = 'sidekiq'
 
 
+class Stats:
+    def __init__(self, conn, namespace):
+        self.conn = conn
+        self.namespace = namespace
+        self._check_stats()
+
+    def _check_stats(self):
+        # Check sidekiq stats
+        pipe = self.conn.pipeline()
+        pipe.get(self.key('stat:processed'))
+        pipe.get(self.key('stat:failed'))
+        pipe.zcard(self.key('schedule'))
+        pipe.zcard(self.key('retry'))
+        pipe.zcard(self.key('dead'))
+        pipe.scard(self.key('processes'))
+        pipe.smembers(self.key('processes'))
+        pipe.smembers(self.key('queues'))
+        res = pipe.execute()
+
+        self.processed = int(res[0])
+        self.failed = int(res[1])
+        self.scheduled_size = res[2]
+        self.retry_size = res[3]
+        self.dead_size = res[4]
+        self.processes_size = res[5]
+
+        procs = res[6]
+        queues = list(res[7])
+
+        self._check_processes(procs)
+        self._init_queue_stats(queues)
+        self._check_queue_lengths(queues)
+        self._check_queue_latencies(queues)
+
+    def _check_processes(self, procs):
+        pipe = self.conn.pipeline()
+
+        for proc in procs:
+            pipe.hget(self.key(proc), 'busy')
+        res = pipe.execute()
+
+        self.workers_size = sum([int(x) for x in res])
+
+    def _init_queue_stats(self, queues):
+        self.queues = {}
+        for queue in queues:
+            self.queues[queue] = {'length': 0, 'latency': 0.0}
+
+    def _check_queue_lengths(self, queues):
+        pipe = self.conn.pipeline()
+
+        for queue in queues:
+            pipe.llen(self.key('queue:%s' % queue))
+        res = pipe.execute()
+
+        for i in range(len(res)):
+            self.queues[queues[i]]['length'] = res[i]
+
+    def _check_queue_latencies(self, queues):
+        pipe = self.conn.pipeline()
+
+        for queue in queues:
+            pipe.lrange(self.key('queue:%s' % queue), -1, -1)
+        res = pipe.execute()
+
+        for i in range(len(res)):
+            entry = res[i]
+            if len(entry) > 0:
+                latency = time.time() - float(json.loads(entry[0])['enqueued_at'])
+                self.queues[queues[i]]['latency'] = latency
+
+    def key(self, name):
+        return "%s:%s" % (self.namespace, name) if self.namespace else name
+
+
 class SidekiqCheck(AgentCheck):
+    SOURCE_TYPE_NAME = 'sidekiq'
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
@@ -102,10 +179,22 @@ class SidekiqCheck(AgentCheck):
         latency_ms = round((time.time() - start) * 1000, 2)
         self.gauge('sidekiq.redis.info.latency_ms', latency_ms, tags=tags)
 
-        # Check all sidekiq queue lengths
-        for queue in conn.smembers(self._key(instance, 'queues')):
+        stats = Stats(conn, instance.get('namespace'))
+
+        # Check global sidekiq stats
+        self.gauge('sidekiq.processed', stats.processed, tags=tags)
+        self.gauge('sidekiq.failed', stats.failed, tags=tags)
+        self.gauge('sidekiq.scheduled_size', stats.scheduled_size, tags=tags)
+        self.gauge('sidekiq.retry_size', stats.retry_size, tags=tags)
+        self.gauge('sidekiq.dead_size', stats.dead_size, tags=tags)
+        self.gauge('sidekiq.processes_size', stats.processes_size, tags=tags)
+        self.gauge('sidekiq.workers_size', stats.workers_size, tags=tags)
+
+        # Check queue stats
+        for queue, stat in stats.queues.iteritems():
             queue_tags = tags + ['queue:' + queue]
-            self.gauge('sidekiq.queue.length', conn.llen(self._key(instance, 'queue:%s' % queue)), tags=queue_tags)
+            self.gauge('sidekiq.queue.length', stat['length'], tags=queue_tags)
+            self.gauge('sidekiq.queue.latency', stat['latency'], tags=queue_tags)
 
     def check(self, instance):
         if ("host" not in instance or "port" not in instance) and "unix_socket_path" not in instance:

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -1,10 +1,11 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
-
+'''
+Sidekiq checks
+'''
 # stdlib
+import time
 
 # 3rd party
+import redis
 
 # project
 from checks import AgentCheck
@@ -16,6 +17,95 @@ class SidekiqCheck(AgentCheck):
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self.connections = {}
+
+    # Taken from redisdb.py, returns custom tags and redis tags for redis connection.
+    def _get_tags(self, custom_tags, instance):
+        tags = set(custom_tags or [])
+
+        if 'unix_socket_path' in instance:
+            tags_to_add = [
+                "redis_host:%s" % instance.get("unix_socket_path"),
+                "redis_port:unix_socket",
+            ]
+        else:
+            tags_to_add = [
+                "redis_host:%s" % instance.get('host'),
+                "redis_port:%s" % instance.get('port')
+            ]
+
+        tags = sorted(tags.union(tags_to_add))
+
+        return tags, tags_to_add
+
+    # Taken from redisdb.py, generates a uniq key to cache redis connections.
+    def _generate_instance_key(self, instance):
+        if 'unix_socket_path' in instance:
+            return (instance.get('unix_socket_path'), instance.get('db'))
+        else:
+            return (instance.get('host'), instance.get('port'), instance.get('db'))
+
+    # Taken from redisdb.py, collects metadata from the redis server.
+    def _collect_metadata(self, info):
+        if info and 'redis_version' in info:
+            self.service_metadata('version', info['redis_version'])
+
+    # Taken from redisdb.py, retrieves a cached redis connection.
+    def _get_conn(self, instance):
+        key = self._generate_instance_key(instance)
+        if key not in self.connections:
+            try:
+
+                # Only send useful parameters to the redis client constructor
+                list_params = ['host', 'port', 'db', 'password', 'socket_timeout',
+                               'connection_pool', 'charset', 'errors', 'unix_socket_path']
+
+                # Set a default timeout (in seconds) if no timeout is specified in the instance config
+                instance['socket_timeout'] = instance.get('socket_timeout', 5)
+
+                connection_params = dict((k, instance[k]) for k in list_params if k in instance)
+
+                self.connections[key] = redis.Redis(**connection_params)
+
+            except TypeError:
+                raise Exception("You need a redis library that supports authenticated connections. Try sudo easy_install redis.")
+
+        return self.connections[key]
+
+    def _check_sidekiq(self, instance, custom_tags):
+        conn = self._get_conn(instance)
+
+        tags, tags_to_add = self._get_tags(custom_tags, instance)
+
+        # Ping the database for info, and track the latency.
+        # Process the service check: the check passes if we can connect to Redis
+        start = time.time()
+        info = None
+        try:
+            info = conn.info()
+            status = AgentCheck.OK
+            self.service_check('sidekiq.redis.can_connect', status, tags=tags_to_add)
+            self._collect_metadata(info)
+        except ValueError, e:
+            status = AgentCheck.CRITICAL
+            self.service_check('sidekiq.redis.can_connect', status, tags=tags_to_add)
+            raise
+        except Exception, e:
+            status = AgentCheck.CRITICAL
+            self.service_check('sidekiq.redis.can_connect', status, tags=tags_to_add)
+            raise
+
+        latency_ms = round((time.time() - start) * 1000, 2)
+        self.gauge('sidekiq.redis.info.latency_ms', latency_ms, tags=tags)
+
+        # Check all sidekiq queue lengths
+        for queue in conn.smembers('queues'):
+            queue_tags = tags + ['queue:' + queue]
+            self.gauge('sidekiq.queue.length', conn.llen('queue:%s' % queue), tags=queue_tags)
 
     def check(self, instance):
-        pass
+        if ("host" not in instance or "port" not in instance) and "unix_socket_path" not in instance:
+            raise Exception("You must specify a host/port couple or a unix_socket_path")
+        custom_tags = instance.get('tags', [])
+
+        self._check_sidekiq(instance, custom_tags)

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -19,6 +19,10 @@ class SidekiqCheck(AgentCheck):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         self.connections = {}
 
+    def _key(self, instance, name):
+        ns = instance.get('namespace')
+        return "%s:%s" % (ns, name) if ns else name
+
     # Taken from redisdb.py, returns custom tags and redis tags for redis connection.
     def _get_tags(self, custom_tags, instance):
         tags = set(custom_tags or [])
@@ -99,9 +103,9 @@ class SidekiqCheck(AgentCheck):
         self.gauge('sidekiq.redis.info.latency_ms', latency_ms, tags=tags)
 
         # Check all sidekiq queue lengths
-        for queue in conn.smembers('queues'):
+        for queue in conn.smembers(self._key(instance, 'queues')):
             queue_tags = tags + ['queue:' + queue]
-            self.gauge('sidekiq.queue.length', conn.llen('queue:%s' % queue), tags=queue_tags)
+            self.gauge('sidekiq.queue.length', conn.llen(self._key(instance, 'queue:%s' % queue)), tags=queue_tags)
 
     def check(self, instance):
         if ("host" not in instance or "port" not in instance) and "unix_socket_path" not in instance:

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -4,6 +4,7 @@ Sidekiq checks
 # stdlib
 import time
 import json
+import re
 
 # 3rd party
 import redis
@@ -40,13 +41,12 @@ class Stats:
         self.dead_size = res[4]
         self.processes_size = res[5]
 
-        procs = res[6]
+        procs = list(res[6])
         queues = list(res[7])
 
         self._check_processes(procs)
         self._init_queue_stats(queues)
-        self._check_queue_lengths(queues)
-        self._check_queue_latencies(queues)
+        self._check_queue_stats(queues)
 
     def _check_processes(self, procs):
         pipe = self.conn.pipeline()
@@ -58,40 +58,44 @@ class Stats:
         self.workers_size = sum([int(x) for x in res])
 
     def _init_queue_stats(self, queues):
-        self.queues = {}
+        self.queue_stats = {}
         for queue in queues:
-            self.queues[queue] = {'length': 0, 'latency': 0.0}
+            self.queue_stats[queue] = {'length': 0, 'latency': 0.0}
 
-    # Sum length of all sub queues for each queue
-    def _check_queue_lengths(self, queues):
-        for queue in queues:
-            qname = 'queue:%s' % queue
-            subqueues = [self.key(qname)] + self.conn.keys('%s_*' % self.key(qname))
-            pipe = self.conn.pipeline()
+    def _check_queue_stats(self, queues):
+        # Select all queue keys (with reliable fetch, every worker has their
+        # own sub queue per queue)
+        queues_and_subqueues = self.conn.keys(self.key('queue:*'))
+        pipe = self.conn.pipeline()
+        for qkey in queues_and_subqueues:
+            pipe.llen(qkey) # Get length of queue
+            pipe.lrange(qkey, -1, -1) # Get last entry in queue
+        res = pipe.execute()
 
-            for sq_key in subqueues:
-                pipe.llen(sq_key)
-            res = pipe.execute()
-            self.queues[queue]['length'] = sum([int(x) for x in res])
+        # Move stats into a dict for easy lookup
+        lengths = {}
+        latencies = {}
+        now = time.time()
+        for i in range(len(queues_and_subqueues)):
+            llen_idx = i * 2
+            lrange_idx = llen_idx + 1
 
-    # Find max latency of sub queues for each queue
-    def _check_queue_latencies(self, queues):
+            lengths[queues_and_subqueues[i]] = int(res[llen_idx])
 
-        for queue in queues:
-            qname = 'queue:%s' % queue
-            subqueues = [self.key(qname)] + self.conn.keys('%s_*' % self.key(qname))
-            pipe = self.conn.pipeline()
+            entries = res[lrange_idx]
+            if len(entries) > 0:
+                latency = now - float(json.loads(entries[0])['enqueued_at'])
+            else:
+                latency = 0.0
+            latencies[queues_and_subqueues[i]] = latency
 
-            for sq_key in subqueues:
-                pipe.lrange(sq_key, -1, -1)
-            res = pipe.execute()
-
-            for i in range(len(res)):
-                entry = res[i]
-                if len(entry) > 0:
-                    latency = time.time() - float(json.loads(entry[0])['enqueued_at'])
-                    if latency > self.queues[queue]['latency']:
-                        self.queues[queue]['latency'] = latency
+        # Roll up stats from sub queues into their parent queues
+        for q in queues:
+            pattern = self.key('queue:%s(|_.+)?' % q)
+            sub_queues = [x for x in queues_and_subqueues if re.match(pattern, x)]
+            if len(sub_queues) > 0:
+                self.queue_stats[q]['length'] = sum([lengths[x] for x in sub_queues])
+                self.queue_stats[q]['latency'] = max([latencies[x] for x in sub_queues])
 
     def key(self, name):
         return "%s:%s" % (self.namespace, name) if self.namespace else name
@@ -199,7 +203,7 @@ class SidekiqCheck(AgentCheck):
         self.gauge('sidekiq.workers_size', stats.workers_size, tags=tags)
 
         # Check queue stats
-        for queue, stat in stats.queues.iteritems():
+        for queue, stat in stats.queue_stats.iteritems():
             queue_tags = tags + ['queue:' + queue]
             self.gauge('sidekiq.queue.length', stat['length'], tags=queue_tags)
             self.gauge('sidekiq.queue.latency', stat['latency'], tags=queue_tags)

--- a/sidekiq/check.py
+++ b/sidekiq/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'sidekiq'
+
+
+class SidekiqCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/sidekiq/ci/sidekiq.rake
+++ b/sidekiq/ci/sidekiq.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def sidekiq_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def sidekiq_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/sidekiq_#{sidekiq_version}"
+end
+
+namespace :ci do
+  namespace :sidekiq do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('sidekiq/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name sidekiq source/sidekiq:sidekiq_version)
+      # sh %(docker start sidekiq)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'sidekiq'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop sidekiq)
+    #   sh %(docker rm sidekiq)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/sidekiq/conf.yaml.example
+++ b/sidekiq/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/sidekiq/conf.yaml.example
+++ b/sidekiq/conf.yaml.example
@@ -2,10 +2,24 @@ init_config:
   # Any global configurable parameters should be added here
 
 instances:
-  #   A typical instance configuration might include a hostname and port
-  #   a set of customizable tags and other parameters we might need to
-  #   configure the behavior of our check.
-  #
-  # - host: localhost
-  #   port: 26379
-  #   tags: ['custom:tag']
+  - host: localhost
+    port: 6379
+
+    # Can be used in lieu of host/port
+    #
+    # unix_socket_path: /var/run/redis/redis.sock # optional, can be used in lieu of host/port
+
+    # Addional connection options
+    #
+    # db: 0
+    # password: mypassword
+    # socket_timeout: 5
+
+    # Optional extra tags added to all sidekiq metrics
+    # tags:
+    #   - optional_tag1
+    #   - optional_tag2
+    #
+
+    # Optional namespace (if sidekiq keys are namespaced in redis)
+    # namespace: sidekiq

--- a/sidekiq/manifest.json
+++ b/sidekiq/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "sidekiq",
+  "short_description": "sidekiq description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/sidekiq/metadata.csv
+++ b/sidekiq/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/sidekiq/requirements.txt
+++ b/sidekiq/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/sidekiq/test_sidekiq.py
+++ b/sidekiq/test_sidekiq.py
@@ -20,7 +20,7 @@ SLAVE_HEALTHY_PORT = 36379
 SLAVE_UNHEALTHY_PORT = 46379
 DEFAULT_PORT = 6379
 MISSING_KEY_TOLERANCE = 0.6
-
+TEST_DB = 14
 
 # NOTE: Feel free to declare multiple test classes if needed
 
@@ -30,16 +30,13 @@ class TestSidekiq(AgentCheckTest):
     CHECK_NAME = 'sidekiq'
 
     def test_sidekiq_default(self):
-        port = NOAUTH_PORT
-        db = 14 # Datadog's test db
-
         instance = {
             'host': 'localhost',
-            'port': port,
-            'db': db
+            'port': NOAUTH_PORT,
+            'db': TEST_DB
         }
 
-        db = redis.Redis(port=port, db=db)
+        db = redis.Redis(port=NOAUTH_PORT, db=TEST_DB)
         db.flushdb()
         self._reset_sidekiq(db)
         db.set('stat:processed', '123')
@@ -58,7 +55,7 @@ class TestSidekiq(AgentCheckTest):
             assert isinstance(m[1], int)    # timestamp
             assert isinstance(m[2], (int, float, long))  # value
             tags = m[3]["tags"]
-            expected_tags = ["redis_host:localhost", "redis_port:%s" % port]
+            expected_tags = ["redis_host:localhost", "redis_port:%s" % NOAUTH_PORT]
             for e in expected_tags:
                 assert e in tags
 
@@ -84,18 +81,41 @@ class TestSidekiq(AgentCheckTest):
         m = self._metric(metrics, 'sidekiq.queue.latency', 'queue:bar')
         assert m, "No sidekiq.queue.latecy metric returned for queue:bar"
 
-    def test_sidekiq_namespace(self):
-        port = NOAUTH_PORT
-        db = 14 # Datadog's test db
-
+    def test_reliable_queueing(self):
         instance = {
             'host': 'localhost',
-            'port': port,
-            'db': db,
+            'port': NOAUTH_PORT,
+            'db': TEST_DB
+        }
+
+        db = redis.Redis(port=NOAUTH_PORT, db=TEST_DB)
+        db.flushdb()
+        self._reset_sidekiq(db)
+        db.set('stat:processed', '123')
+        db.set('stat:failed', '456')
+        db.sadd("queues", "reliable")
+        db.lpush("queue:reliable", self._job())
+        db.lpush("queue:reliable_host1", self._job())
+        db.lpush("queue:reliable_host2", self._job(), self._job())
+
+        r = load_check('sidekiq', {}, {})
+        r.check(instance)
+        metrics = self._sort_metrics(r.get_metrics())
+        assert metrics, "No metrics returned"
+
+        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:reliable')
+        self.assertEquals(1, len(m))
+        self.assertEquals(4, m[0][2]) # Sum of queues for foo (1 + 1 + 2)
+
+    def test_sidekiq_namespace(self):
+        instance = {
+            'host': 'localhost',
+            'port': NOAUTH_PORT,
+            'db': TEST_DB,
             'namespace': 'ns'
         }
 
-        db = redis.Redis(port=port, db=db)
+        db = redis.Redis(port=NOAUTH_PORT, db=TEST_DB)
         db.flushdb()
         self._reset_sidekiq(db, 'ns')
         db.sadd("ns:queues", "foo", "bar")

--- a/sidekiq/test_sidekiq.py
+++ b/sidekiq/test_sidekiq.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='sidekiq')
+class TestSidekiq(AgentCheckTest):
+    """Basic Test for sidekiq integration."""
+    CHECK_NAME = 'sidekiq'
+
+    def test_check(self):
+        """
+        Testing Sidekiq check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()

--- a/sidekiq/test_sidekiq.py
+++ b/sidekiq/test_sidekiq.py
@@ -27,7 +27,7 @@ class TestSidekiq(AgentCheckTest):
     """Basic Test for sidekiq integration."""
     CHECK_NAME = 'sidekiq'
 
-    def test_redis_default(self):
+    def test_sidekiq_default(self):
         port = NOAUTH_PORT
         db = 14 # Datadog's test db
 
@@ -57,11 +57,52 @@ class TestSidekiq(AgentCheckTest):
                 assert e in tags
 
         # Assert queue length metrics are correct
-        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:foo')[0]
-        self.assertEquals(1, m[2])
+        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:foo')
+        self.assertEquals(1, len(m))
+        self.assertEquals(1, m[0][2])
 
-        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:bar')[0]
-        self.assertEquals(2, m[2])
+        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:bar')
+        self.assertEquals(1, len(m))
+        self.assertEquals(2, m[0][2])
+
+    def test_sidekiq_namespace(self):
+        port = NOAUTH_PORT
+        db = 14 # Datadog's test db
+
+        instance = {
+            'host': 'localhost',
+            'port': port,
+            'db': db,
+            'namespace': 'ns'
+        }
+
+        db = redis.Redis(port=port, db=db)
+        db.flushdb()
+        db.sadd("ns:queues", "foo", "bar")
+        db.lpush("ns:queue:foo", "item1")
+        db.lpush("ns:queue:bar", "item1", "item2")
+
+        r = load_check('sidekiq', {}, {})
+        r.check(instance)
+        metrics = self._sort_metrics(r.get_metrics())
+        assert metrics, "No metrics returned"
+        # Assert we have values, timestamps and tags for each metric.
+        for m in metrics:
+            assert isinstance(m[1], int)    # timestamp
+            assert isinstance(m[2], (int, float, long))  # value
+            tags = m[3]["tags"]
+            expected_tags = ["redis_host:localhost", "redis_port:%s" % port]
+            for e in expected_tags:
+                assert e in tags
+
+        # Assert queue length metrics are correct
+        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:foo')
+        self.assertEquals(1, len(m))
+        self.assertEquals(1, m[0][2])
+
+        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:bar')
+        self.assertEquals(1, len(m))
+        self.assertEquals(2, m[0][2])
 
     def _sort_metrics(self, metrics):
         def sort_by(m):

--- a/sidekiq/test_sidekiq.py
+++ b/sidekiq/test_sidekiq.py
@@ -1,5 +1,7 @@
 # stdlib
 import logging
+import time
+import json
 
 # 3p
 from nose.plugins.attrib import attr
@@ -39,14 +41,18 @@ class TestSidekiq(AgentCheckTest):
 
         db = redis.Redis(port=port, db=db)
         db.flushdb()
+        self._reset_sidekiq(db)
+        db.set('stat:processed', '123')
+        db.set('stat:failed', '456')
         db.sadd("queues", "foo", "bar")
-        db.lpush("queue:foo", "item1")
-        db.lpush("queue:bar", "item1", "item2")
+        db.lpush("queue:foo", self._job())
+        db.lpush("queue:bar", self._job(), self._job())
 
         r = load_check('sidekiq', {}, {})
         r.check(instance)
         metrics = self._sort_metrics(r.get_metrics())
         assert metrics, "No metrics returned"
+
         # Assert we have values, timestamps and tags for each metric.
         for m in metrics:
             assert isinstance(m[1], int)    # timestamp
@@ -56,6 +62,12 @@ class TestSidekiq(AgentCheckTest):
             for e in expected_tags:
                 assert e in tags
 
+        # Assert global stats exist
+        m = self._metric(metrics, 'sidekiq.processed')
+        self.assertEquals(123, m[0][2])
+        m = self._metric(metrics, 'sidekiq.failed')
+        self.assertEquals(456, m[0][2])
+
         # Assert queue length metrics are correct
         m = self._metric(metrics, 'sidekiq.queue.length', 'queue:foo')
         self.assertEquals(1, len(m))
@@ -64,6 +76,13 @@ class TestSidekiq(AgentCheckTest):
         m = self._metric(metrics, 'sidekiq.queue.length', 'queue:bar')
         self.assertEquals(1, len(m))
         self.assertEquals(2, m[0][2])
+
+        # Assert queue latency metrics exist
+        m = self._metric(metrics, 'sidekiq.queue.latency', 'queue:foo')
+        assert m, "No sidekiq.queue.latecy metric returned for queue:foo"
+
+        m = self._metric(metrics, 'sidekiq.queue.latency', 'queue:bar')
+        assert m, "No sidekiq.queue.latecy metric returned for queue:bar"
 
     def test_sidekiq_namespace(self):
         port = NOAUTH_PORT
@@ -78,31 +97,27 @@ class TestSidekiq(AgentCheckTest):
 
         db = redis.Redis(port=port, db=db)
         db.flushdb()
+        self._reset_sidekiq(db, 'ns')
         db.sadd("ns:queues", "foo", "bar")
-        db.lpush("ns:queue:foo", "item1")
-        db.lpush("ns:queue:bar", "item1", "item2")
+        db.lpush("ns:queue:foo", self._job())
 
         r = load_check('sidekiq', {}, {})
         r.check(instance)
         metrics = self._sort_metrics(r.get_metrics())
         assert metrics, "No metrics returned"
-        # Assert we have values, timestamps and tags for each metric.
-        for m in metrics:
-            assert isinstance(m[1], int)    # timestamp
-            assert isinstance(m[2], (int, float, long))  # value
-            tags = m[3]["tags"]
-            expected_tags = ["redis_host:localhost", "redis_port:%s" % port]
-            for e in expected_tags:
-                assert e in tags
 
         # Assert queue length metrics are correct
         m = self._metric(metrics, 'sidekiq.queue.length', 'queue:foo')
         self.assertEquals(1, len(m))
         self.assertEquals(1, m[0][2])
 
-        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:bar')
-        self.assertEquals(1, len(m))
-        self.assertEquals(2, m[0][2])
+    def _reset_sidekiq(self, db, namespace=None):
+        def k(n):
+            return "%s:%s" % (namespace, n) if namespace else n
+
+        db.delete(k('queues'), k('processes'), k('schedule'), k('retry'), k('dead'))
+        db.set(k('stat:processed'), '0')
+        db.set(k('stat:failed'), '0')
 
     def _sort_metrics(self, metrics):
         def sort_by(m):
@@ -112,5 +127,8 @@ class TestSidekiq(AgentCheckTest):
     def _metric(self, metrics, name, tag=None):
         res = [m for m in metrics if m[0] == name]
         if tag:
-            res = [m for m in metrics if tag in m[3]["tags"]]
+            res = [m for m in res if tag in m[3]["tags"]]
         return self._sort_metrics(res)
+
+    def _job(self):
+        return json.dumps({'enqueued_at': time.time()})

--- a/sidekiq/test_sidekiq.py
+++ b/sidekiq/test_sidekiq.py
@@ -76,36 +76,10 @@ class TestSidekiq(AgentCheckTest):
 
         # Assert queue latency metrics exist
         m = self._metric(metrics, 'sidekiq.queue.latency', 'queue:foo')
-        assert m, "No sidekiq.queue.latecy metric returned for queue:foo"
+        assert m, "No sidekiq.queue.latency metric returned for queue:foo"
 
         m = self._metric(metrics, 'sidekiq.queue.latency', 'queue:bar')
-        assert m, "No sidekiq.queue.latecy metric returned for queue:bar"
-
-    def test_reliable_queueing(self):
-        instance = {
-            'host': 'localhost',
-            'port': NOAUTH_PORT,
-            'db': TEST_DB
-        }
-
-        db = redis.Redis(port=NOAUTH_PORT, db=TEST_DB)
-        db.flushdb()
-        self._reset_sidekiq(db)
-        db.set('stat:processed', '123')
-        db.set('stat:failed', '456')
-        db.sadd("queues", "reliable")
-        db.lpush("queue:reliable", self._job())
-        db.lpush("queue:reliable_host1", self._job())
-        db.lpush("queue:reliable_host2", self._job(), self._job())
-
-        r = load_check('sidekiq', {}, {})
-        r.check(instance)
-        metrics = self._sort_metrics(r.get_metrics())
-        assert metrics, "No metrics returned"
-
-        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:reliable')
-        self.assertEquals(1, len(m))
-        self.assertEquals(4, m[0][2]) # Sum of queues for foo (1 + 1 + 2)
+        assert m, "No sidekiq.queue.latency metric returned for queue:bar"
 
     def test_sidekiq_namespace(self):
         instance = {

--- a/sidekiq/test_sidekiq.py
+++ b/sidekiq/test_sidekiq.py
@@ -1,21 +1,23 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
-
 # stdlib
-from nose.plugins.attrib import attr
+import logging
 
 # 3p
+from nose.plugins.attrib import attr
+import redis
 
 # project
-from tests.checks.common import AgentCheckTest
+from tests.checks.common import AgentCheckTest, load_check
 
 
-instance = {
-    'host': 'localhost',
-    'port': 26379,
-    'password': 'datadog-is-devops-best-friend'
-}
+logger = logging.getLogger()
+
+MAX_WAIT = 20
+NOAUTH_PORT = 16379
+AUTH_PORT = 26379
+SLAVE_HEALTHY_PORT = 36379
+SLAVE_UNHEALTHY_PORT = 46379
+DEFAULT_PORT = 6379
+MISSING_KEY_TOLERANCE = 0.6
 
 
 # NOTE: Feel free to declare multiple test classes if needed
@@ -25,14 +27,49 @@ class TestSidekiq(AgentCheckTest):
     """Basic Test for sidekiq integration."""
     CHECK_NAME = 'sidekiq'
 
-    def test_check(self):
-        """
-        Testing Sidekiq check.
-        """
-        self.load_check({}, {})
+    def test_redis_default(self):
+        port = NOAUTH_PORT
+        db = 14 # Datadog's test db
 
-        # run your actual tests...
+        instance = {
+            'host': 'localhost',
+            'port': port,
+            'db': db
+        }
 
-        self.assertTrue(True)
-        # Raises when COVERAGE=true and coverage < 100%
-        self.coverage_report()
+        db = redis.Redis(port=port, db=db)
+        db.flushdb()
+        db.sadd("queues", "foo", "bar")
+        db.lpush("queue:foo", "item1")
+        db.lpush("queue:bar", "item1", "item2")
+
+        r = load_check('sidekiq', {}, {})
+        r.check(instance)
+        metrics = self._sort_metrics(r.get_metrics())
+        assert metrics, "No metrics returned"
+        # Assert we have values, timestamps and tags for each metric.
+        for m in metrics:
+            assert isinstance(m[1], int)    # timestamp
+            assert isinstance(m[2], (int, float, long))  # value
+            tags = m[3]["tags"]
+            expected_tags = ["redis_host:localhost", "redis_port:%s" % port]
+            for e in expected_tags:
+                assert e in tags
+
+        # Assert queue length metrics are correct
+        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:foo')[0]
+        self.assertEquals(1, m[2])
+
+        m = self._metric(metrics, 'sidekiq.queue.length', 'queue:bar')[0]
+        self.assertEquals(2, m[2])
+
+    def _sort_metrics(self, metrics):
+        def sort_by(m):
+            return m[0], m[1], m[3]
+        return sorted(metrics, key=sort_by)
+
+    def _metric(self, metrics, name, tag=None):
+        res = [m for m in metrics if m[0] == name]
+        if tag:
+            res = [m for m in metrics if tag in m[3]["tags"]]
+        return self._sort_metrics(res)


### PR DESCRIPTION
### What does this PR do?

Add the sidekiq integration.

Originally written by @bmarini (https://github.com/DataDog/dd-agent/pull/2066)

### Motivation

This adds a metric for the length of each sidekiq queue. This also supports collecting stats for queues when using reliable fetch, where each queue has a sub queues per worker.

The following stats are collected:

```
sidekiq.processed
sidekiq.failed
sidekiq.scheduled_size
sidekiq.retry_size
sidekiq.dead_size
sidekiq.processes_size
sidekiq.workers_size

Per queue:
  sidekiq.queue.length tag=queue:<queue name>
  sidekiq.queue.latency tag=queue:<queue name>
```
