### PR TITLE
[nsq] adding integration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,11 +38,16 @@ dependencies:
 test:
     override:
         - bundle exec rake prep_travis_ci
+<<<<<<< HEAD
         - TRAVIS_FLAVOR="default" bundle exec rake ci:run
         - TRAVIS_FLAVOR="snmpwalk" bundle exec rake ci:run
         - TRAVIS_FLAVOR="hbase_master" bundle exec rake ci:run
         - TRAVIS_FLAVOR="hbase_regionserver" bundle exec rake ci:run
         - TRAVIS_FLAVOR="redis_sentinel" FLAVOR_VERSION="latest" bundle exec rake ci:run
+=======
+        - rake ci:run[default]
+        - rake ci:run[nsq]
+>>>>>>> [nsq] adding integration skeleton
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/nsq/README.md
+++ b/nsq/README.md
@@ -1,0 +1,32 @@
+# Nsq Integration
+
+## Overview
+
+Get metrics from nsq service in real time to:
+
+* Visualize and monitor nsq states
+* Be notified about nsq failovers and events.
+
+## Installation
+
+Install the `dd-check-nsq` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `nsq.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        nsq
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The nsq check is compatible with all major platforms

--- a/nsq/check.py
+++ b/nsq/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'nsq'
+
+
+class NsqCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/nsq/check.py
+++ b/nsq/check.py
@@ -1,10 +1,9 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
-
 # stdlib
+import time
+from urlparse import urljoin
 
 # 3rd party
+import requests
 
 # project
 from checks import AgentCheck
@@ -14,8 +13,137 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'nsq'
 
 class NsqCheck(AgentCheck):
 
+    DEFAULT_TIMEOUT = 5
+    CONNECT_CHECK_NAME = 'nsq.can_connect'
+    HEALTH_CHECK_NAME = 'nsq.healthy'
+
+    TOPIC_GAUGES = [
+        'depth',
+        'backend_depth' # Depth on disk as opposed to in memory
+    ]
+    TOPIC_COUNTS = [
+        'message_count'
+    ]
+
+    CHANNEL_GAUGES = [
+        'depth',
+        'backend_depth',
+        'in_flight_count',
+        'deferred_count',
+    ]
+    CHANNEL_COUNTS = [
+        'message_count',
+        'requeue_count',
+        'timeout_count'
+    ]
+
+    CLIENT_GAUGES = [
+        'ready_count',
+        'in_flight_count',
+        'finish_count'
+    ]
+    CLIENT_COUNTS = [
+        'message_count',
+        'requeue_count'
+    ]
+
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
     def check(self, instance):
-        pass
+        if 'url' not in instance:
+            raise Exception('NSQ instance missing "url" value.')
+
+        # Load values from the instance config
+        url = instance['url']
+        instance_tags = instance.get('tags', [])
+        default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
+        timeout = float(instance.get('timeout', default_timeout))
+
+        response = self.get_json(urljoin(url, "/stats?format=json"), timeout)
+        if response is not None:
+            health = response['data']['health']
+            if health == 'OK':
+                self.service_check(self.HEALTH_CHECK_NAME, AgentCheck.OK,
+                    tags = ["url:{0}".format(url)]
+                )
+            else:
+                self.service_check(self.HEALTH_CHECK_NAME, AgentCheck.CRITICAL,
+                    message='%s returned a health of %s' % (url, health),
+                    tags = ["url:{0}".format(url)]
+                )
+
+
+            self.gauge('nsq.topic_count', len(response['data']['topics']), tags=instance_tags)
+
+
+            # Descend in to topic
+            for topic in response['data']['topics']:
+                self.gauge('nsq.topic.channel_count', len(topic['channels']), instance_tags)
+
+                topic_tags = ['topic_name:' + topic['topic_name']] + instance_tags
+                for attr in self.TOPIC_GAUGES:
+                    self.gauge('nsq.topic.' + attr, topic[attr], tags=topic_tags)
+                for attr in self.TOPIC_COUNTS:
+                    self.monotonic_count('nsq.topic.' + attr, topic[attr], tags=topic_tags)
+
+
+                # Descend in to channels
+                for channel in topic['channels']:
+                    channel_tags = ['channel_name:' + channel['channel_name']] + topic_tags
+
+                    for attr in self.CHANNEL_GAUGES:
+                        self.gauge('nsq.topic.channel.' + attr, channel[attr], tags=channel_tags)
+                    for attr in self.CHANNEL_COUNTS:
+                        self.monotonic_count('nsq.topic.channel.' + attr, channel[attr], tags=channel_tags)
+
+                    # Descend in to clients
+                    self.gauge('nsq.topic.channel.client_count', len(channel['clients']), tags=channel_tags)
+                    for client in channel['clients']:
+                        client_tags = [
+                            'client_id:' + client['client_id'],
+                            'client_version:' + client['version'],
+                            'tls:' + str(client['tls']),
+                            'user_agent:' + client['user_agent'],
+                            'deflate:' + str(client['deflate']),
+                            'snappy:' + str(client['snappy'])
+                        ] + channel_tags
+                        for attr in self.CLIENT_GAUGES:
+                            self.gauge('nsq.topic.channel.client.' + attr, client[attr], tags=client_tags)
+                        for attr in self.CLIENT_COUNTS:
+                            self.monotonic_count('nsq.topic.channel.client.' + attr, client[attr], tags=client_tags)
+
+                    for latency in channel['e2e_processing_latency']['percentiles']:
+                        # NSQ does not zero pad the quantile's numberic representation,
+                        # so we'll do that by splitting on the . and left-justifying up to
+                        # 2 spaces, filling with 0. Note that `ljust` returns the whole strong
+                        # if it is >= the length. This converts 0.5 in to '50' and .9999 in to '9999'
+                        quantile = str(latency['quantile']).split(".")[1].ljust(2, "0")
+                        self.gauge('nsq.topic.channel.e2e_processing_latency.p' + quantile, latency['value'], tags=channel_tags)
+
+    def get_json(self, url, timeout):
+        try:
+            start_time = time.time()
+            r = requests.get(url, timeout=timeout)
+            r.raise_for_status()
+            elapsed_time = time.time() - start_time
+            self.histogram('nsq.stats_fetch_duration_seconds', int(elapsed_time))
+        except requests.exceptions.Timeout:
+            # If there's a timeout
+            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
+                message='%s timed out after %s seconds.' % (url, timeout),
+                tags = ["url:{0}".format(url)])
+            raise Exception("Timeout when hitting %s" % url)
+
+        except requests.exceptions.HTTPError:
+            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.CRITICAL,
+                message='%s returned a status of %s' % (url, r.status_code),
+                tags = ["url:{0}".format(url)])
+            raise Exception("Got %s when hitting %s" % (r.status_code, url))
+
+        else:
+            self.service_check(self.CONNECT_CHECK_NAME, AgentCheck.OK,
+                tags = ["url:{0}".format(url)]
+            )
+
+        return r.json()

--- a/nsq/ci/fixtures/nsq_stats.json
+++ b/nsq/ci/fixtures/nsq_stats.json
@@ -1,0 +1,105 @@
+{
+  "status_code": 200,
+  "status_txt": "OK",
+  "data": {
+    "version": "0.2.31",
+    "health": "OK",
+    "topics": [
+      {
+        "topic_name": "bapi_events",
+        "channels": [
+          {
+            "channel_name": "nsq_to_file",
+            "depth": 0,
+            "backend_depth": 0,
+            "in_flight_count": 0,
+            "deferred_count": 0,
+            "message_count": 685,
+            "requeue_count": 0,
+            "timeout_count": 0,
+            "clients": [
+              {
+                "name": "nsqsink2",
+                "client_id": "nsqsink2",
+                "hostname": "nsqsink2.northwest.example.com",
+                "version": "V2",
+                "remote_address": "10.68.25.230:48495",
+                "state": 3,
+                "ready_count": 6,
+                "in_flight_count": 0,
+                "message_count": 205,
+                "finish_count": 205,
+                "requeue_count": 0,
+                "connect_ts": 1456356910,
+                "sample_rate": 0,
+                "deflate": false,
+                "snappy": false,
+                "user_agent": "nsq_to_file\/0.2.31 go-nsq\/1.0.1-alpha",
+                "tls": false,
+                "tls_cipher_suite": "",
+                "tls_version": "",
+                "tls_negotiated_protocol": "",
+                "tls_negotiated_protocol_is_mutual": false
+              }
+            ],
+            "paused": false,
+            "e2e_processing_latency": {
+              "count": 6,
+              "percentiles": [
+                {
+                  "quantile": 0.5,
+                  "value": 709396048
+                },
+                {
+                  "quantile": 0.95,
+                  "value": 8506929254
+                },
+                {
+                  "quantile": 0.99,
+                  "value": 8506929254
+                },
+                {
+                  "quantile": 0.999,
+                  "value": 8506929254
+                },
+                {
+                  "quantile": 0.9999,
+                  "value": 8506929254
+                }
+              ]
+            }
+          }
+        ],
+        "depth": 0,
+        "backend_depth": 0,
+        "message_count": 685,
+        "paused": false,
+        "e2e_processing_latency": {
+          "count": 6,
+          "percentiles": [
+            {
+              "quantile": 0.5,
+              "value": 709396048
+            },
+            {
+              "quantile": 0.95,
+              "value": 8506929254
+            },
+            {
+              "quantile": 0.99,
+              "value": 8506929254
+            },
+            {
+              "quantile": 0.999,
+              "value": 8506929254
+            },
+            {
+              "quantile": 0.9999,
+              "value": 8506929254
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/nsq/ci/nsq.rake
+++ b/nsq/ci/nsq.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def nsq_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def nsq_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/nsq_#{nsq_version}"
+end
+
+namespace :ci do
+  namespace :nsq do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('nsq/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name nsq source/nsq:nsq_version)
+      # sh %(docker start nsq)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'nsq'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop nsq)
+    #   sh %(docker rm nsq)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/nsq/conf.yaml.example
+++ b/nsq/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/nsq/conf.yaml.example
+++ b/nsq/conf.yaml.example
@@ -1,11 +1,7 @@
 init_config:
-  # Any global configurable parameters should be added here
+  # This check takes no init_config
 
 instances:
-  #   A typical instance configuration might include a hostname and port
-  #   a set of customizable tags and other parameters we might need to
-  #   configure the behavior of our check.
-  #
-  # - host: localhost
-  #   port: 26379
-  #   tags: ['custom:tag']
+    # Where your NSQD HTTP Server Lives
+    # Remind to use https instead of http if your Consul setup is configured to do so.
+    - url: http://localhost:4151

--- a/nsq/manifest.json
+++ b/nsq/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "nsq",
+  "short_description": "nsq description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/nsq/metadata.csv
+++ b/nsq/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/nsq/requirements.txt
+++ b/nsq/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/nsq/test_nsq.py
+++ b/nsq/test_nsq.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
-from nose.plugins.attrib import attr
+import os
 
 # 3p
 import simplejson as json
@@ -11,15 +11,15 @@ import simplejson as json
 # project
 from tests.checks.common import AgentCheckTest, Fixtures
 
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'ci')
 
-@attr(requires='nsq')
 class TestNsq(AgentCheckTest):
     """Basic Test for nsq integration."""
     CHECK_NAME = 'nsq'
 
     def test_simple_metrics(self):
         mocks = {
-            'get_json': lambda x,y: json.loads(Fixtures.read_file('nsq_stats.json')),
+            'get_json': lambda x,y: json.loads(Fixtures.read_file('nsq_stats.json', sdk_dir=FIXTURE_DIR)),
         }
         config = {
             'instances': [{'url': 'http://localhost:44151'}]

--- a/nsq/test_nsq.py
+++ b/nsq/test_nsq.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='nsq')
+class TestNsq(AgentCheckTest):
+    """Basic Test for nsq integration."""
+    CHECK_NAME = 'nsq'
+
+    def test_check(self):
+        """
+        Testing Nsq check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()

--- a/nsq/test_nsq.py
+++ b/nsq/test_nsq.py
@@ -6,33 +6,40 @@
 from nose.plugins.attrib import attr
 
 # 3p
+import simplejson as json
 
 # project
-from tests.checks.common import AgentCheckTest
+from tests.checks.common import AgentCheckTest, Fixtures
 
-
-instance = {
-    'host': 'localhost',
-    'port': 26379,
-    'password': 'datadog-is-devops-best-friend'
-}
-
-
-# NOTE: Feel free to declare multiple test classes if needed
 
 @attr(requires='nsq')
 class TestNsq(AgentCheckTest):
     """Basic Test for nsq integration."""
     CHECK_NAME = 'nsq'
 
-    def test_check(self):
-        """
-        Testing Nsq check.
-        """
-        self.load_check({}, {})
+    def test_simple_metrics(self):
+        mocks = {
+            'get_json': lambda x,y: json.loads(Fixtures.read_file('nsq_stats.json')),
+        }
+        config = {
+            'instances': [{'url': 'http://localhost:44151'}]
+        }
 
-        # run your actual tests...
+        self.run_check(config, mocks=mocks, force_reload=True)
 
-        self.assertTrue(True)
-        # Raises when COVERAGE=true and coverage < 100%
-        self.coverage_report()
+        expected_metrics = ['nsq.topic_count']
+
+        for metric in expected_metrics:
+            self.assertMetric(metric, count=1, tags=[])
+
+        topic_expected_metrics = ['depth', 'backend_depth', 'message_count']
+        for metric in topic_expected_metrics:
+            self.assertMetric('nsq.topic.' + metric, count=1, tags=['topic_name:bapi_events'])
+
+        channel_expected_metrics = ['depth', 'backend_depth', 'message_count', 'in_flight_count', 'deferred_count', 'requeue_count', 'timeout_count', 'e2e_processing_latency.p50']
+        for metric in channel_expected_metrics:
+            self.assertMetric('nsq.topic.channel.' + metric, count=1, tags=['topic_name:bapi_events', 'channel_name:nsq_to_file'])
+
+        client_expected_metrics = ['ready_count', 'in_flight_count', 'message_count', 'finish_count', 'requeue_count']
+        for metric in client_expected_metrics:
+            self.assertMetric('nsq.topic.channel.client.' + metric, count=1, tags=['topic_name:bapi_events', 'channel_name:nsq_to_file', 'client_id:nsqsink2', 'client_version:V2', 'tls:False', 'user_agent:nsq_to_file/0.2.31 go-nsq/1.0.1-alpha', 'deflate:False', 'snappy:False'])


### PR DESCRIPTION
# What's this PR do?

Adds an NSQ integration

Orginally written by @gphat aka @cory-stripe (https://github.com/DataDog/dd-agent/pull/2281)

# Information About The Integration

Adds the following metrics by polling NSQ's `/stats` endpoint:
- `nsq.topic_count`
- `nsq.topic.channel_count`
- `nsq.topic` (all tagged with `topic_name`):
  - `depth`
  - `backend_depth`
  - `message_count` (count, not gauge)
- `nsq.topic.channel` (all tagged with `topic_name` and `channel_name`):
  - `depth`
  - `backend_depth`
  - `in_flight_count`
  - `deferred_count`
  - `message_count` (count, not gauge)
  - `requeue_count`
  - `timeout_count`
  - `e2e_processing_latency.p50` (nanoseconds)
  - `e2e_processing_latency.p95` (nanoseconds)
  - `e2e_processing_latency.p99` (nanoseconds)
  - `e2e_processing_latency.p999` (nanoseconds)
  - `e2e_processing_latency.p9999` (nanoseconds)
- `nsq.topic.channel.client` (all tagged with `topic_name`, `channel_name` and `client_id`, `client_version`, `tls`, `user_agent`, `deflate` and `snappy`):
  - `ready_count`
  - `in_flight_count`
  - `message_count` (count, not gauge)
  - `finish_count`
  - `requeue_count`
# Notes
- Should this be `nsq` or `nsqd`? 
- We'll need to do a pass with @danielhfrank and verify we got everything
- This is working locally on a single test machine atm.
- More information to come, notably a summary of metrics.

r? @rhwlo @danielhfrank @smarden1
cc @remh 
