### PR TITLE
[apt] adding integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - DD_AGENT_BRANCH=master
   matrix:
     - TRAVIS_FLAVOR=default
+    - TRAVIS_FLAVOR=apt FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/apt/README.md
+++ b/apt/README.md
@@ -1,0 +1,32 @@
+# Apt Integration
+
+## Overview
+
+Get metrics from apt service in real time to:
+
+* Visualize and monitor apt states
+* Be notified about apt failovers and events.
+
+## Installation
+
+Install the `dd-check-apt` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `apt.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        apt
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The apt check is compatible with all major platforms

--- a/apt/check.py
+++ b/apt/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'apt'
+
+
+class AptCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/apt/check.py
+++ b/apt/check.py
@@ -40,11 +40,12 @@ class AptCheck(AgentCheck):
 
     def updates(self, instance):
         updates = {}
-        content = open(instance['updates_file'], 'r').read()
+        with open(instance['updates_file'], 'r') as fd:
+            content = fd.read()
 
-        for m in PACKAGES_REGEX.finditer(content):
-            updates['packages'] = int(m.groups()[0])
-        for m in SECURITY_REGEX.finditer(content):
-            updates['security'] = int(m.groups()[0])
+            for m in PACKAGES_REGEX.finditer(content):
+                updates['packages'] = int(m.groups()[0])
+            for m in SECURITY_REGEX.finditer(content):
+                updates['security'] = int(m.groups()[0])
 
         return updates

--- a/apt/check.py
+++ b/apt/check.py
@@ -39,7 +39,7 @@ class AptCheck(AgentCheck):
             self.service_check(SECURITY_CHECK, AgentCheck.OK)
 
     def updates(self, instance):
-        updates = { 'packages': 0, 'security': 0 }
+        updates = {'packages': 0, 'security': 0}
 
         with open(instance['updates_file'], 'r') as fd:
             content = fd.read()

--- a/apt/check.py
+++ b/apt/check.py
@@ -15,8 +15,8 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'apt'
 SECURITY_CHECK = 'apt.updates'
 
 # Regular expressions to match the /var/lib/update-notifier/updates-available format.
-PACKAGES_REGEX = re.compile(r"^(\d+) packages can be updated.*", re.MULTILINE)
-SECURITY_REGEX = re.compile(r"^(\d+) updates are security updates.*$", re.MULTILINE)
+PACKAGES_REGEX = re.compile(r"^(\d+) packages? can be updated.*", re.MULTILINE)
+SECURITY_REGEX = re.compile(r"^(\d+) updates? (is a|are) security updates?.*$", re.MULTILINE)
 
 class AptCheck(AgentCheck):
     """Generates metrics and service alerts when package updates are available
@@ -39,7 +39,8 @@ class AptCheck(AgentCheck):
             self.service_check(SECURITY_CHECK, AgentCheck.OK)
 
     def updates(self, instance):
-        updates = {}
+        updates = { 'packages': 0, 'security': 0 }
+
         with open(instance['updates_file'], 'r') as fd:
             content = fd.read()
 

--- a/apt/ci/apt.rake
+++ b/apt/ci/apt.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def apt_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def apt_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/apt_#{apt_version}"
+end
+
+namespace :ci do
+  namespace :apt do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('apt/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name apt source/apt:apt_version)
+      # sh %(docker start apt)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'apt'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop apt)
+    #   sh %(docker rm apt)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/apt/ci/fixtures/updates-available.no-updates
+++ b/apt/ci/fixtures/updates-available.no-updates
@@ -1,0 +1,4 @@
+
+0 packages can be updated.
+0 updates are security updates.
+

--- a/apt/ci/fixtures/updates-available.package-updates
+++ b/apt/ci/fixtures/updates-available.package-updates
@@ -1,0 +1,4 @@
+
+15 packages can be updated.
+0 updates are security updates.
+

--- a/apt/ci/fixtures/updates-available.security-updates
+++ b/apt/ci/fixtures/updates-available.security-updates
@@ -1,0 +1,4 @@
+
+10 packages can be updated.
+2 updates are security updates.
+

--- a/apt/ci/fixtures/updates-available.single
+++ b/apt/ci/fixtures/updates-available.single
@@ -1,0 +1,4 @@
+
+1 package can be updated.
+1 update is a security update.
+

--- a/apt/conf.yaml.example
+++ b/apt/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/apt/conf.yaml.example
+++ b/apt/conf.yaml.example
@@ -2,10 +2,8 @@ init_config:
   # Any global configurable parameters should be added here
 
 instances:
-  #   A typical instance configuration might include a hostname and port
-  #   a set of customizable tags and other parameters we might need to
-  #   configure the behavior of our check.
-  #
-  # - host: localhost
-  #   port: 26379
-  #   tags: ['custom:tag']
+  -
+    # The file where apt stores available updates.
+    #
+    # See also http://askubuntu.com/questions/49958/how-to-find-the-number-of-packages-needing-update-from-the-command-line
+    updates_file: /var/lib/update-notifier/updates-available

--- a/apt/manifest.json
+++ b/apt/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "apt",
+  "short_description": "apt description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/apt/metadata.csv
+++ b/apt/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/apt/requirements.txt
+++ b/apt/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/apt/test_apt.py
+++ b/apt/test_apt.py
@@ -37,3 +37,9 @@ class TestCheckAPT(AgentCheckTest):
         self.assertServiceCheckCritical('apt.updates')
         self.assertMetric('apt.updates.packages', value=10)
         self.assertMetric('apt.updates.security', value=2)
+
+    def test_single_update(self):
+        self.run_check(mock_config('updates-available.single'))
+        self.assertServiceCheckCritical('apt.updates')
+        self.assertMetric('apt.updates.packages', value=1)
+        self.assertMetric('apt.updates.security', value=1)

--- a/apt/test_apt.py
+++ b/apt/test_apt.py
@@ -1,21 +1,9 @@
-# stdlib
-from nose.plugins.attrib import attr
-
-# 3p
-import mock
-import json
-
 # project
-from tests.checks.common import AgentCheckTest, load_check, Fixtures
+from tests.checks.common import AgentCheckTest, Fixtures
 
 
 def mock_config(fixture):
-    return {
-            'init_config': {},
-            'instances' : [{
-                'updates_file': Fixtures.file(fixture)
-                }]
-            }
+    return {'init_config': {}, 'instances' : [{'updates_file': Fixtures.file(fixture)}]}
 
 class TestCheckAPT(AgentCheckTest):
     CHECK_NAME = 'apt'

--- a/apt/test_apt.py
+++ b/apt/test_apt.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='apt')
+class TestApt(AgentCheckTest):
+    """Basic Test for apt integration."""
+    CHECK_NAME = 'apt'
+
+    def test_check(self):
+        """
+        Testing Apt check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[apt]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi


### PR DESCRIPTION
### What does this PR do?

Adds an apt integration.

Originally written by @ejholmes (https://github.com/DataDog/dd-agent/pull/2275).

### Motivation

This is a custom agent check that will generate metrics and service alerts for apt package updates. It uses the /var/lib/update-notifier/updates-available file to determine what package updates are available (see http://askubuntu.com/questions/49958/how-to-find-the-number-of-packages-needing-update-from-the-command-line).

If there are security related updates available, the apt.updates service check goes critical. If there are non-security related package updates, the apt.updates check warns.