### PR TITLE
[file] new check to test for a file's existence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - DD_AGENT_BRANCH=master
   matrix:
     - TRAVIS_FLAVOR=default
+    - TRAVIS_FLAVOR=file FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[file]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/file/README.md
+++ b/file/README.md
@@ -1,0 +1,32 @@
+# File Integration
+
+## Overview
+
+Get metrics from file service in real time to:
+
+* Visualize and monitor file states
+* Be notified about file failovers and events.
+
+## Installation
+
+Install the `dd-check-file` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `file.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        file
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The file check is compatible with all major platforms

--- a/file/check.py
+++ b/file/check.py
@@ -1,8 +1,7 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
-
 # stdlib
+import errno
+import os
+import time
 
 # 3rd party
 
@@ -14,8 +13,79 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'file'
 
 class FileCheck(AgentCheck):
 
+    STATUS_ABSENT = 'absent'
+    STATUS_PRESENT = 'present'
+
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self._last_state_by_path = {}
+
+    def has_different_status(self, path, current):
+        last_state = self._last_state_by_path.get(path, None)
+        self._last_state_by_path[path] = current
+        return (last_state is not None and last_state != current)
+
+    def stat_file(self, path):
+        try:
+            statinfo = os.stat(path)
+            return self.STATUS_PRESENT, statinfo
+        except OSError, e:
+            if e.errno == errno.ENOENT:
+                return self.STATUS_ABSENT, []
+            else:
+                raise
+
 
     def check(self, instance):
-        pass
+        """
+        Stats a file and emits service_checks and metrics on file creation/age.
+        """
+        if 'path' not in instance:
+            raise Exception("Missing 'path' in file check config")
+        if 'expect' not in instance:
+            raise Exception("Missing 'expect' in file check config")
+
+        path = instance['path']
+        expect = instance['expect']
+
+        status, statinfo = self.stat_file(path)
+
+        tags = [
+            'expected_status:' + expect,
+            'path:' + path,
+            'actual_status:' + status,
+        ]
+
+        # Emit a service check:
+        msg = "File %s is %s" % (path, expect)
+        check_status = AgentCheck.OK
+        if status != expect:
+            check_status = AgentCheck.CRITICAL
+            msg = "File %s that was expected to be %s is %s instead" % (path, expect, status)
+        self.service_check('file.existence', check_status, message=msg, tags=tags)
+
+        # Emit an event if the previous state is known & it's different:
+        if self.has_different_status(path, status):
+            timestamp = time.time()
+            if status == self.STATUS_PRESENT:
+                timestamp = statinfo.st_ctime
+
+            alert_type = 'success'
+            if check_status != AgentCheck.OK:
+                alert_type = 'error'
+
+            title = 'File %s is now %s' % (path, status)
+            self.event({
+                'timestamp': timestamp,
+                'event_type': 'file.presence_change',
+                'msg_title': title,
+                'alert_type': alert_type,
+                'tags': tags,
+                'aggregation_key': path,
+            })
+
+        # Emit age metrics (of dubious utility):
+        file_age = -1
+        if status == self.STATUS_PRESENT:
+            file_age = time.time() - statinfo.st_ctime
+        self.gauge('file.age_seconds', file_age, tags=tags)

--- a/file/check.py
+++ b/file/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'file'
+
+
+class FileCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/file/ci/file.rake
+++ b/file/ci/file.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def file_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def file_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/file_#{file_version}"
+end
+
+namespace :ci do
+  namespace :file do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('file/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name file source/file:file_version)
+      # sh %(docker start file)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'file'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop file)
+    #   sh %(docker rm file)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/file/conf.yaml.example
+++ b/file/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/file/conf.yaml.example
+++ b/file/conf.yaml.example
@@ -1,11 +1,8 @@
 init_config:
-  # Any global configurable parameters should be added here
+# Not required for this check
 
 instances:
-  #   A typical instance configuration might include a hostname and port
-  #   a set of customizable tags and other parameters we might need to
-  #   configure the behavior of our check.
-  #
-  # - host: localhost
-  #   port: 26379
-  #   tags: ['custom:tag']
+ - path: '/var/run/reboot-required'
+   expected: absent
+ - path: '/etc/passwd'
+   expected: present

--- a/file/manifest.json
+++ b/file/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "file",
+  "short_description": "file description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/file/metadata.csv
+++ b/file/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/file/requirements.txt
+++ b/file/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/file/test_file.py
+++ b/file/test_file.py
@@ -1,38 +1,54 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
-
 # stdlib
-from nose.plugins.attrib import attr
 
 # 3p
 
 # project
-from tests.checks.common import AgentCheckTest
+from tests.checks.common import AgentCheckTest, load_check
+from checks import AgentCheck
 
 
-instance = {
-    'host': 'localhost',
-    'port': 26379,
-    'password': 'datadog-is-devops-best-friend'
-}
-
-
-# NOTE: Feel free to declare multiple test classes if needed
-
-@attr(requires='file')
 class TestFile(AgentCheckTest):
-    """Basic Test for file integration."""
     CHECK_NAME = 'file'
 
-    def test_check(self):
-        """
-        Testing File check.
-        """
-        self.load_check({}, {})
+    def assert_tags(self, expected_tags, present_tags):
+        for tag in expected_tags:
+            self.assertTrue(tag in present_tags)
 
-        # run your actual tests...
+    def test_present_success(self):
+        conf = {
+            'init_config': {},
+            'instances': [
+                {'path': __file__, 'expect': 'present'}
+            ]
+        }
+        self.check = load_check('file', conf, {})
+        self.check.check(conf['instances'][0])
+        metrics = self.check.get_metrics()
+        self.assertTrue(len(metrics) == 1)
+        metric = metrics[0]
+        self.assertTrue(metric[2] > 0)
+        self.assert_tags(['expected_status:present', 'actual_status:present'], metric[3]['tags'])
 
-        self.assertTrue(True)
-        # Raises when COVERAGE=true and coverage < 100%
-        self.coverage_report()
+        service_checks = self.check.get_service_checks()
+        self.assertTrue(service_checks[0]['status'] == AgentCheck.OK)
+        self.assert_tags(['expected_status:present', 'actual_status:present'], service_checks[0]['tags'])
+
+
+    def test_absent_failure(self):
+        conf = {
+            'init_config': {},
+            'instances': [
+                {'path': __file__, 'expect': 'absent'}
+            ]
+        }
+        self.check = load_check('file', conf, {})
+        self.check.check(conf['instances'][0])
+        metrics = self.check.get_metrics()
+        self.assertTrue(len(metrics) == 1)
+        metric = metrics[0]
+        self.assertTrue(metric[2] > 0)
+        self.assert_tags(['expected_status:absent', 'actual_status:present'], metric[3]['tags'])
+
+        service_checks = self.check.get_service_checks()
+        self.assertTrue(service_checks[0]['status'] == AgentCheck.CRITICAL)
+        self.assert_tags(['expected_status:absent', 'actual_status:present'], service_checks[0]['tags'])

--- a/file/test_file.py
+++ b/file/test_file.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='file')
+class TestFile(AgentCheckTest):
+    """Basic Test for file integration."""
+    CHECK_NAME = 'file'
+
+    def test_check(self):
+        """
+        Testing File check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()


### PR DESCRIPTION
### What does this PR do?

Adds a check for file existence

This PR was originally written by @antifuchs (https://github.com/DataDog/dd-agent/pull/2411)

The file.py check allows the agent to test for whether files exist in the local file system, and if they do, emit a metric for how long they have existed. This is particularly useful for files like Debian's "package upgrades require a reboot" marker in /var/run/, or local puppet facts meant to be kept around only for a short time.

I have added almost no documentation to this check (mostly out of ignorance what format / locations are desired!), but would be interested in learning how you all prefer the check docs to be written.

### Testing

I added an integration test for the metric and service_check behavior. We're also running this check on our infra to test for exactly the presence of /var/run/reboot-required, and it emits events and service checks as intended.