### PR TITLE
[dropwizard] adding integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - DD_AGENT_BRANCH=master
   matrix:
     - TRAVIS_FLAVOR=default
+    - TRAVIS_FLAVOR=dropwizard FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[dropwizard]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/dropwizard/README.md
+++ b/dropwizard/README.md
@@ -1,0 +1,32 @@
+# Dropwizard Integration
+
+## Overview
+
+Get metrics from dropwizard service in real time to:
+
+* Visualize and monitor dropwizard states
+* Be notified about dropwizard failovers and events.
+
+## Installation
+
+Install the `dd-check-dropwizard` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `dropwizard.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        dropwizard
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The dropwizard check is compatible with all major platforms

--- a/dropwizard/check.py
+++ b/dropwizard/check.py
@@ -33,7 +33,7 @@ This is because of how CodaHale handles counters. And for ease of use in Datadog
 See /dropwizard/conf.yaml.example for documentation on all accepted input options.
 Further implementation details can be found below...
 
-Questions or Comments? chriswberry at gmail.com
+Questions or Comments? chrisberry.dw at gmail.com
 
 About Metric Naming
 -----------------------

--- a/dropwizard/check.py
+++ b/dropwizard/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'dropwizard'
+
+
+class DropwizardCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/dropwizard/check.py
+++ b/dropwizard/check.py
@@ -22,7 +22,7 @@ DropwizardCheck
 DropwizardCheck is a DataDog Check for Java Dropwizard metrics (a.k.a CodaHale metrics, after it's originator).
 (For further details, see http://metrics.dropwizard.io/3.1.0/)
 
-DropwizardCheck calls the standard Dropwizard stats URL: http://localhost:8080/metrics
+DropwizardCheck calls the standard Dropwizard stats URL: http://localhost:8081/metrics
 (Of course, all those fields are configurable per instance (host, port, stats_url))
 The Dropwizard URL yields up a JSON response consisting of the all metrics in it's MetricRegistry at that time.
 DropwizardCheck reads this response, parses it, and creates the corresponding DataDog metrics.
@@ -183,10 +183,10 @@ class DropwizardCheck(AgentCheck):
     # All metrics will be prefixed with this field. Unless an "appname" is found in the instance config
     DEFAULT_METRIC_PREFIX = 'dropwizard'
 
-    # Defaults to "http://localhost:8080/metrics"
+    # Defaults to "http://localhost:8081/metrics"
     #  May be overriden in the instance config
     DEFAULT_HOST = 'localhost'
-    DEFAULT_PORT = 8080
+    DEFAULT_PORT = 8081
     DEFAULT_STATS_URL = "/metrics"
 
     # Metrics with these suffixes will be ignored

--- a/dropwizard/check.py
+++ b/dropwizard/check.py
@@ -1,21 +1,598 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # stdlib
+import logging
+import time
+import copy
+import re
 
 # 3rd party
+import requests
+import json
 
 # project
 from checks import AgentCheck
+from config import _is_affirmative
+
+
+'''
+DropwizardCheck
+
+DropwizardCheck is a DataDog Check for Java Dropwizard metrics (a.k.a CodaHale metrics, after it's originator).
+(For further details, see http://metrics.dropwizard.io/3.1.0/)
+
+DropwizardCheck calls the standard Dropwizard stats URL: http://localhost:8080/metrics
+(Of course, all those fields are configurable per instance (host, port, stats_url))
+The Dropwizard URL yields up a JSON response consisting of the all metrics in it's MetricRegistry at that time.
+DropwizardCheck reads this response, parses it, and creates the corresponding DataDog metrics.
+
+NOTE: In DropwizardCheck, all metrics are converted into a gauges, including Counters.
+This is because of how CodaHale handles counters. And for ease of use in Datadog dashboards. (See below)
+
+See /dropwizard/conf.yaml.example for documentation on all accepted input options.
+Further implementation details can be found below...
+
+Questions or Comments? chriswberry at gmail.com
+
+About Metric Naming
+-----------------------
+DropwizardCheck does a bit of manipulation on the metric names (although you can turn these off);
+
+* Java package names are collapsed out of the metric name.
+  I.e. `a.b.c.Class.method.mtype` becomes `Class.method.mtype` (where `mtype` is `max`,`min`, `mean`, etc)
+* The "appname" is prepended to the metric name. (more on this below)
+  I.e. `Class.method.mtype` becomes `appname.Class.method.mtype`
+* If the metric name contains a field like this; .(x=y,a=b). , then that field is extracted and tags are created (`a:b` and `x:y`).
+  See "About Metric Tagging" for further details
+
+Because Dropwizard is really a framework for building webapps, most shops are likely run many different Dropwizard apps.
+Often even many on the same host.
+
+And because, in DataDog, the first field of the metric is assumed to be the "application name".
+Where most off-the-shelf DataDog checks will simply set that first field to be the "application type" (e.g. "cassandra" or "mongo")
+And while this scheme works fine for centralized apps like DBs.
+It doesn't work well for micro-services frameworks like Dropwizard, where, in general,
+most users want to see only their webapp's metrics alone, and there is no upside to lumping them together.
+This is especially true for DataDog's Infrastructure View,
+where all webapps on the host would show up grouped into a single "dropwizard application".
+
+Thus, rather than roll all those metrics into a single "dropwizard" grouping -- it is a
+better idea to supply an "appname" per instance. This will prefix the "appname" as the first field of the metric,
+instead of "dropwizard". Which makes things in the DataDog UI much easier.
+
+About Metric Tagging
+---------------------------
+DropwizardCheck allows you to supply metric tags at all three levels of the configuration; agent_config, init_config, and instance.
+
+In addition, as alluded to above, DropwizardCheck can also do a bit of magic metric tagging for you.
+Which is quite useful because Tags are essential to the user experience in the DataDog UI.
+
+A metric name consists of dot-delimited fields. And if the metric name contains a field like this; ".(x=y,a=b).",
+then that field is extracted and corresponding "key:value" tags are created (i.e. "a:b" and "x:y").
+
+Let's look at a real example. Assume that you've created the following metric inside your application;
+"com.x.y.ServletHandler.(type=berrys,method=find).requests.count"
+DropwizardCheck will look for any matching fields with; ".(key=value).", and, if found, will extract that field,
+and use it to create DataDog tags. Thus, for our example, your metric will become; "appname.ServletHandler.requests.count"
+with the following tags applied; ["type:berrys", "method:find"]
+
+About "Zero values"
+---------------------------
+Dropwizard will report all metrics in the underlying MetricRegistry.
+Even if they are zero or they appeared only once or twice a long time ago.
+This can lead to a great deal of confusion.
+
+Dropwizard Timers that measure very rare events may contain samples that are so far back in time that they cause more
+confusion than anything else. The classic example is an Error metric that occurred once at startup, due to, say, an
+out-of-SLA elapsed time because nothing was warm . In Dropwizard, the Counter for this metric
+would report that one measurement forever (until next restart) suggesting that the app is unhealthy or slow,
+even though it's really not.
+
+To work around this, DropwizardCheck omits histogram-based Timer measurements from the metrics output
+when a particular timer hasn't received any recent events.
+
+NOTE: a Timer that receives a single event takes 15 minutes for the "one minute rate" to drop < 1e-7.  When
+more than one event is received it'll take a little longer than 15 minutes, but not too much longer.
+
+Similarly, DropwizardCheck does not report zero metrics.
+Zero means that metric has never occurred during the run, and there is little sense in reporting something
+that didn't happen, over and over. Not to mention, we pay for every custom metric in DataDog,
+regardless if they are always zero.
+
+About DropWizard Counts
+----------------------------
+The default form of Counters from DropWizard are monotonically increasing numbers.
+
+But, DropwizardCheck can NOT use the "monotonic_count" in DataDog -- because a monotonic_count in DataDog must,
+in general, ALWAYS increase. If DropwizardCheck were to submit a monotonic_count value that is less than the current total,
+then DataDog would store this as Zero! (Actually, per DataDog support; The monotonic_count is only Zero
+when *consecutive* values are not increasing.)
+
+So, for example: given the following monotonic_count value pattern: [0 ; 1000 ; 1200 ; 400; (restart); 600; 800​; 1200]
+Will result in the graph: [nothing yet; 1000 ; 200 ; 0 ; 200; 400]
+Which produces erroneous results -- since the 400 is missed -- and the overall total will be wrong
+
+Thus, DropwizardCheck would miss initial numbers for every service restart, because at restart the Dropwizard Counters
+start over at Zero. For this reason we use a gauge for Dropwizard Counters
+'''
+
+#################################################################
+'''
+EncodedTagsProcessor : Processes any fields in the metric name, such that,
+if the metric name contains a field like this;  .(x=y,a=b).
+then that field is extracted, and the corresponding key:value tags are created (i.e. a:b and x:y).
+'''
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'dropwizard'
 
 
+class EncodedTagsProcessor(object):
+    # There must be at least one = sign within the ()
+    BETWEEN_PARANS_REGEX = '\.\((\S*=\S*)\)\.'
+    PATTERN = re.compile(BETWEEN_PARANS_REGEX)
+
+    def process_tags_from_metric(self, full_metric, log, tag_prefix=None):
+        self.trace(log, "full_metric: %s", full_metric)
+
+        metric = full_metric
+        tags = []
+        if (self._metric_is_not_empty(metric)):
+            match = self.PATTERN.search(full_metric)
+            if match:
+                self.trace(log, "EncodedTagsProcessor: MATCH: match %s", match.groups())
+                field = match.group(1)
+
+                tags = self._process_tags_field(field, log, tag_prefix)
+
+                # delete from the metric
+                metric = metric[0:match.start()] + "." + metric[match.end():]
+            else:
+                self.trace(log, "SKIPPING: (%s) no fields match pattern", full_metric)
+        else:
+            self.trace(log, "SKIPPING %s", full_metric)
+
+        self.trace(log, "metric %s, tags %s", metric, tags)
+        return metric, tags
+
+    def _metric_is_not_empty(self, metric):
+        return ((metric is not None) and (metric.strip()))
+
+    def _process_tags_field(self, field, log, tag_prefix):
+        tags = []
+        kvs = field.strip().split(',')
+        self.trace(log, "kvs: %s", kvs)
+
+        for kv in kvs:
+            kvsplit = kv.strip().split('=')
+            key = (tag_prefix + '_' + kvsplit[0]) if (tag_prefix is not None) else kvsplit[0]
+            tags.append(key + ":" + kvsplit[1])
+        self.trace(log, "tags: %s", tags)
+
+        return tags
+
+    def trace(self, log, fmt, *arg):
+        if log:
+            log.debug(fmt % arg)
+
+#################################################################
+class DropwizardError(Exception):
+    pass
+
 class DropwizardCheck(AgentCheck):
+    # All metrics will be prefixed with this field. Unless an "appname" is found in the instance config
+    DEFAULT_METRIC_PREFIX = 'dropwizard'
+
+    # Defaults to "http://localhost:8080/metrics"
+    #  May be overriden in the instance config
+    DEFAULT_HOST = 'localhost'
+    DEFAULT_PORT = 8080
+    DEFAULT_STATS_URL = "/metrics"
+
+    # Metrics with these suffixes will be ignored
+    DEFAULT_METRIC_TYPE_BLACKLIST = ['.p75', '.p98']
+    # To specify no metric blacklist
+    NO_METRIC_BLACKLIST = 'none'
+
+    # Timeout to call http (in seconds)
+    DEFAULT_TIMEOUT = 0.25
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self.log.debug("DropwizardCheck::agentConfig: %s\ninit_config: %s" % (agentConfig, init_config))
+
+        # Debug options
+        self.log_each_metric = self.init_config.get('log_each_metric', False)
+        self.log_at_trace = self.init_config.get('log_at_trace', False)
+        debug = self.init_config.get('debug', False)
+        if debug:
+            self.log.setLevel(logging.DEBUG)
+
+        # Pattern to remove Java package names
+        self.starts_with_cap_pattern = re.compile("\.([A-Z][\w]*)\.")
+
+        # Specify, if you do not want package names removed
+        self.leave_package_names = _is_affirmative(init_config.get('leave_package_names', False))
+
+        self.http_timeout = self.init_config.get('http_timeout', self.DEFAULT_TIMEOUT)
+
+        # List of metric suffixes to skip
+        self.metric_type_blacklist = init_config.get('metrictype_blacklist', self.DEFAULT_METRIC_TYPE_BLACKLIST)
+        if self.metric_type_blacklist is self.NO_METRIC_BLACKLIST:
+            self.metric_type_blacklist = []
+
+        # Global tags
+        self.service_tags = self._clean_tags(init_config.get('service_tags', None))
+        self.agent_tags = self._clean_tags(agentConfig.get('tags'))
+        self.log.debug("agent_tags: %s service_tags %s" % (self.agent_tags, self.service_tags))
+
+        self.encoded_tags_processor = EncodedTagsProcessor()
 
     def check(self, instance):
-        pass
+        dropwizard_json = self._fetch_dropwizard_json(instance)
+        if dropwizard_json:
+            self._process_dropwizard_json(dropwizard_json, instance)
+
+    def get_encoded_tags_processor(self):
+        return self.encoded_tags_processor
+
+    def _fetch_dropwizard_json(self, instance):
+        url = 'undefined'
+        try:
+            host = instance.get('host', self.DEFAULT_HOST)
+            port = instance.get('port', self.DEFAULT_PORT)
+            stats_url = instance.get('stats_url', self.DEFAULT_STATS_URL)
+
+            url = "http://" + host + ":" + str(port) + stats_url
+
+            self.log.debug("Fetching dropwizard data from: %s" % url)
+            resp = requests.get(url, timeout=self.http_timeout)  # timeout after 100ms
+            resp.raise_for_status()
+
+            return resp.json()
+
+        except Exception as e:  # Log and move on....
+            raise DropwizardError("%s Could not fetch: for %s (%s)" % (repr(e), url, instance))
+
+    def process_counters(self, section_data, tags, appname):
+        ''' Format:
+          "counters": {
+            "io.dropwizard.jetty.MutableServletContextHandler.active-dispatches": {
+              "count": 0
+            },
+            "io.dropwizard.jetty.MutableServletContextHandler.active-requests": {
+              "count": 0
+            }
+          },
+        '''
+        self.trace("COUNTERS: %s", section_data)
+        for base_metric_name, metric_data in section_data.iteritems():
+            if metric_data['count'] is 0:
+                self.log.debug("SKIPPING ZERO METRIC: %s" % base_metric_name)
+                continue
+
+            metric = base_metric_name + '.count'
+            mtags = copy.deepcopy(tags)
+            self._process_metric(appname, metric, metric_data['count'], mtags)
+
+    def process_gauges(self, section_data, tags, appname):
+        ''' Format:
+          "gauges": {
+            "io.dropwizard.jetty.MutableServletContextHandler.percent-4xx-15m": {
+              "value": 0.019564512218014994
+            },
+            "io.dropwizard.jetty.MutableServletContextHandler.percent-4xx-1m": {
+              "value": 0.003530850874892612
+            }
+          },
+        '''
+        self.trace("GAUGES: %s", section_data)
+        for base_metric_name, metric_data in section_data.iteritems():
+            # the value may be; -1, 0, int, float, string
+            # we need to skip -1 & 0 metrics
+            value = metric_data['value']
+            self.trace("NAME: %s VALUE: %s", base_metric_name, value)
+
+            if not self._is_primitive(value):
+                self.log.debug("SKIPPING STRING METRIC: %s" % base_metric_name)
+                continue
+
+            if value in [-1, 0]:
+                self.log.debug("SKIPPING 0 or -1 METRIC: %s" % base_metric_name)
+                continue
+
+            metric = base_metric_name
+            mtags = copy.deepcopy(tags)
+
+            self._process_metric(appname, metric, value, mtags)
+
+    def process_histograms(self, section_data, tags, appname):
+        ''' Format:
+          "histograms": {},
+        }
+        '''
+        # Note -- are there any no 'units' in histogram JSON
+        self._process_reservoir_metric(section_data, tags, 'HISTOGRAMS', [], appname)
+
+    def process_meters(self, section_data, tags, appname):
+        ''' Format:
+          "meters": {
+            "ch.qos.logback.core.Appender.all": {
+              "count": 130,
+              "m15_rate": 0.33050995296474994,
+              "m1_rate": 0.008913390064755949,
+              "m5_rate": 0.10601442238857867,
+              "mean_rate": 0.1705098859093358,
+              "units": "events/second"
+            }
+          },
+        }
+        '''
+        self._process_reservoir_metric(section_data, tags, 'METERS', ['units'], appname)
+
+    def process_timers(self, section_data, tags, appname):
+        '''  Format:
+          "timers": {
+            "com.foo.web.InquiriesResource.findByEmail": {
+              "count": 8,
+              "max": 0.12919699,
+              "mean": 0.006554913354028336,
+              "min": 0.0008676440000000001,
+              "p50": 0.008963556000000001,
+              "p75": 0.009144276,
+              "p95": 0.009144276,
+              "p98": 0.009144276,
+              "p99": 0.009144276,
+              "p999": 0.12919699,
+              "stddev": 0.005611150805755341,
+              "m15_rate": 0.005474707899477395,
+              "m1_rate": 0.0012658831602204207,
+              "m5_rate": 0.007079839429920503,
+              "mean_rate": 0.010663674994514599,
+              "duration_units": "seconds",
+              "rate_units": "calls/second"
+            }
+        '''
+        self._process_reservoir_metric(section_data, tags, 'TIMERS', ['duration_units', 'rate_units'], appname)
+
+    def _process_reservoir_metric(self, section_data, tags, section_name, types_to_skip, appname):
+        '''
+        histograms, meters, and timers are all reservoir-based metrics
+        '''
+        self.trace("SECTION: %s: %s", section_name, section_data)
+        for base_metric_name, metric_data in section_data.iteritems():
+            # skip metrics
+            if self._skips_reservoir(metric_data, base_metric_name):
+                continue
+
+            for metric_type, value in metric_data.iteritems():
+                self.trace("NAME: %s TYPE %s VALUE: %s", base_metric_name, metric_type, value)
+                if metric_type in types_to_skip:
+                    self.trace("SKIPPING TYPE: %s %s", base_metric_name, metric_type)
+                    continue
+
+                metric = base_metric_name + '.' + metric_type
+                mtags = copy.deepcopy(tags)
+                self._process_metric(appname, metric, value, mtags)
+
+    def _skips_reservoir(self, metric_data, base_metric_name):
+        '''
+         Timers that measure very rare events may contain samples that are so far back in time that they cause more
+         confusion than anything else.  The classic example is an event that occurred once at startup and had a long
+         out-of-SLA elapsed time because nothing was warm: the jvm would report that one measurement forever (until
+         restart) suggesting that the app is unhealthy and slow, even though it's really not.  To work around this,
+         omit histogram-based timer measurements from the metrics output when a particular timer hasn't received any
+         recent events.
+
+         A timer that receives a single event takes 15 minutes for the "one minute rate" to drop < 1e-7.  When
+         more than one event is received it'll take a little longer than 15 minutes, but not too much longer.
+        '''
+        if metric_data['count'] is 0:
+            self.log.debug("SKIPPING 0 METRIC: %s" % base_metric_name)
+            return True
+        m1rate = metric_data.get('m1_rate', None)
+
+        self.trace("###### m1rate %s", m1rate)
+        if (m1rate is not None) and (m1rate < 1.0e-7):
+            self.log.debug("SKIPPING (m1rate < 1e-7) METRIC: %s %s" % (base_metric_name, m1rate))
+            return True
+        return False
+
+    # Note: see https://github.com/dropwizard/metrics/blob/dff1a69b3a0824ff445492777052ea0417b9c5cf/metrics-json/src/main/java/com/dropwizard/metrics/json/MetricsModule.java
+    #       for details on JSON formats
+    METHOD_MAP = {u'counters' : process_counters,
+                  u'gauges' : process_gauges,
+                  u'histograms' : process_histograms,
+                  u'meters' : process_meters,
+                  u'timers' : process_timers}
+
+    def _process_dropwizard_json(self, dropwizard_json, instance):
+        ''' Main data-processing loop.
+        Overall Dropwizard JSON looks like this
+        {
+          "version": "3.0.0",
+          "gauges": {},
+          "counters": {},
+          "histograms": {},
+          "meters": {},
+          "timers": {}
+        }
+        '''
+        appname = instance.get('appname', self.DEFAULT_METRIC_PREFIX)
+
+        tags = self._clean_tags(instance.get('instance_tags', None))
+        tags = self._extend_with_addtl_tags(tags, self.service_tags)
+        tags = self._extend_with_addtl_tags(tags, self.agent_tags)
+
+        for key, section in dropwizard_json.iteritems():
+            try:
+                if key in self.METHOD_MAP:
+                    self.METHOD_MAP[key](self, section, tags, appname)
+            except:
+                # Log and move on....
+                self.log.exception("Could not process line. For instance: %s" % (instance))
+
+    def _process_metric(self, appname, metric, value, tags):
+        if self._skips_metric(metric):
+            self.log.debug("SKIPPING Metric (blacklisted type) : %s" % metric)
+            return
+
+        metric = self._process_metricname(metric)
+        if metric is None:
+            return
+
+        metric, addtl_tags = self._process_tags(metric, appname)
+        if metric is None:
+            return
+        if addtl_tags:
+            tags = self._extend_with_addtl_tags(tags, addtl_tags)
+
+        # Because of how the DataDog UI (Infrastructure View) is setup -- the first "field" is always assumed to be the app's name
+        #  So we accommodate that, by doing it explicitly
+        #  If you don't provide an appname, "dropwizard" will be used
+        metric = appname + "." + metric
+
+        self._process_gauge(metric, value, tags)
+
+    def _skips_metric(self, metric):
+        return self._is_blacklisted_metric_type(metric)
+
+    def _is_blacklisted_metric_type(self, metric):
+        if self.metric_type_blacklist is not None:
+            for type in self.metric_type_blacklist:
+                if metric.endswith(type):
+                    return True
+        return False
+
+    def _process_metricname(self, metric):
+        if metric is None:
+            return None
+
+        # We pass thru all JVM metrics as is (except change the name to match our convention)
+        # NOTE: changing the name first (here) has the desired side-effect
+        #       of keeping the pseudo package name supplied by Dropwizard for JVM metrics
+        if metric.startswith('jvm'):
+            metric = metric.replace('jvm', 'Jvm')
+            return metric
+
+        # Remove the java package name up front
+        if not self.leave_package_names:
+            match = self.starts_with_cap_pattern.search(metric)
+            if match:
+                self.trace("MATCH: match %s", match.groups())
+                # Skip the first matched "."
+                metric = metric[(match.start() + 1):]
+
+        return self._cleanup_metric(metric)
+
+    def _cleanup_metric(self, metric):
+        metric = metric.replace('..', '.')
+        if metric.startswith('.'):
+            metric = metric[1:]
+        return metric
+
+    def _process_tags(self, metric, appname):
+        log = self.log if self.log_at_trace else None
+        addtl_tags = []
+
+        metric, addtl_tags1 = self.encoded_tags_processor.process_tags_from_metric(metric, log)
+        if metric is None:
+            return None, []
+        addtl_tags.extend(addtl_tags1)
+
+        self.trace(">> appname %s metric %s, addtl_tags: %s", appname, metric, addtl_tags)
+        return metric, addtl_tags
+
+    def _get_tag_prefix(self, appname):
+        return appname.split('-')[0]
+
+    # Python reads in the agent_tags as a list of chars. Take evasive action...
+    def _clean_tags(self, tags_in):
+        tags_out = []
+        if tags_in:
+            sss = ''.join(tags_in)
+            tags_out = sss.strip().split(', ')
+        return tags_out
+
+    def _process_gauge(self, metric, value, tags):
+        if self.log_each_metric or self.log_at_trace:
+            self.log.info("%%%%%% ADDING gauge **[[ %s ]]** %s %s" % (metric, value, tags))
+        self.gauge(metric, value, tags=tags)
+
+    def _process_counter(self, metric, value, tags):
+        ival = int(float(value)) if self._isfloat(value) else int(value)
+        if self.log_each_metric or self.log_at_trace:
+            self.log.info("%%%%%% ADDING counter **[[ %s ]]** %s %s" % (metric, ival, tags))
+        self.count(metric, ival, tags=tags)
+
+    def _extend_with_addtl_tags(self, tags, addtl_tags):
+        if addtl_tags:
+            for tag in addtl_tags:
+                tags.append(tag)
+        self.trace("global_tags: %s", tags)
+        return tags
+
+    def _isfloat(self, value):
+        # NOTE: value here is a string, so we have to test if it can be cast to a float....
+        try:
+            float(value)
+            return True
+        except:
+            return False
+
+    def _is_primitive(self, value_element):
+        return (type(value_element) in [int, float, long])
+
+    def trace(self, fmt, *arg):
+        if self.log_at_trace:
+            self.log.debug(fmt % arg)
+
+
+# ---------------------------
+# Code for the MAIN below
+# ---------------------------
+# PYTHONPATH=. python dropwizard/check.py
+#
+# NOTE: running standalone is currently broken.
+#       See https://github.com/DataDog/dd-agent/issues/3057
+#
+def process_check(check):
+    time_start = time.clock()
+    check.check(instance)
+    metrics = check.get_metrics()
+    print 'Metrics: %s' % (json.dumps(metrics, indent=4, sort_keys=True))
+    print 'NUM Metrics: %s' % (len(metrics))
+    time_elasped = time.clock() - time_start
+    log.debug("Processing dropwizard took: %s" % time_elasped)
+
+def setup_logger(name):
+    log = logging.getLogger(name)
+    log.setLevel(logging.INFO)
+    ch = logging.StreamHandler()
+    log.addHandler(ch)
+    return log
+
+if __name__ == '__main__':
+    import traceback
+
+    from config import initialize_logging
+    initialize_logging('collector')
+
+    log = setup_logger('checks.dropwizard')
+    setup_logger('aggregator')
+
+    agentConfig = {
+        'version': '0.1',
+        'api_key': 'toto',
+        'tags': 'foo:bar, blah:blah'
+    }
+    check, instances = DropwizardCheck.from_yaml('./dropwizard/ci/fixtures/dropwizard.1.yaml', agentConfig)
+
+    try:
+        for instance in instances:
+            process_check(check)
+
+    except Exception as e:
+        print "Whoops something happened {0}".format(traceback.format_exc())
+    finally:
+        check.stop()

--- a/dropwizard/check.py
+++ b/dropwizard/check.py
@@ -100,6 +100,8 @@ Zero means that metric has never occurred during the run, and there is little se
 that didn't happen, over and over. Not to mention, we pay for every custom metric in DataDog,
 regardless if they are always zero.
 
+NOTE: it is possible to override this behavior with the "leave_zero_metrics" switch
+
 About DropWizard Counts
 ----------------------------
 The default form of Counters from DropWizard are monotonically increasing numbers.
@@ -213,6 +215,8 @@ class DropwizardCheck(AgentCheck):
 
         # Specify, if you do not want package names removed
         self.leave_package_names = _is_affirmative(init_config.get('leave_package_names', False))
+        # If you do not want zero metrics removed
+        self.leave_zero_metrics = _is_affirmative(init_config.get('leave_zero_metrics', False))
 
         self.http_timeout = self.init_config.get('http_timeout', self.DEFAULT_TIMEOUT)
 
@@ -297,8 +301,12 @@ class DropwizardCheck(AgentCheck):
                 self.log.debug("SKIPPING STRING METRIC: %s" % base_metric_name)
                 continue
 
-            if value in [-1, 0]:
-                self.log.debug("SKIPPING 0 or -1 METRIC: %s" % base_metric_name)
+            if value is -1:
+                self.log.debug("SKIPPING -1 METRIC: %s" % base_metric_name)
+                continue
+
+            if (not self.leave_zero_metrics) and (value is 0):
+                self.log.debug("SKIPPING 0 METRIC: %s" % base_metric_name)
                 continue
 
             metric = base_metric_name
@@ -312,7 +320,7 @@ class DropwizardCheck(AgentCheck):
         }
         '''
         # Note -- are there any no 'units' in histogram JSON
-        self._process_reservoir_metric(section_data, tags, 'HISTOGRAMS', [], appname)
+        self._process_reservoir_metric(section_data, tags, 'HISTOGRAMS', ['values'], appname)
 
     def process_meters(self, section_data, tags, appname):
         ''' Format:
@@ -328,7 +336,7 @@ class DropwizardCheck(AgentCheck):
           },
         }
         '''
-        self._process_reservoir_metric(section_data, tags, 'METERS', ['units'], appname)
+        self._process_reservoir_metric(section_data, tags, 'METERS', ['units', 'values'], appname)
 
     def process_timers(self, section_data, tags, appname):
         '''  Format:
@@ -353,7 +361,7 @@ class DropwizardCheck(AgentCheck):
               "rate_units": "calls/second"
             }
         '''
-        self._process_reservoir_metric(section_data, tags, 'TIMERS', ['duration_units', 'rate_units'], appname)
+        self._process_reservoir_metric(section_data, tags, 'TIMERS', ['duration_units', 'rate_units', 'values'], appname)
 
     def _process_reservoir_metric(self, section_data, tags, section_name, types_to_skip, appname):
         '''
@@ -387,13 +395,14 @@ class DropwizardCheck(AgentCheck):
          A timer that receives a single event takes 15 minutes for the "one minute rate" to drop < 1e-7.  When
          more than one event is received it'll take a little longer than 15 minutes, but not too much longer.
         '''
-        if metric_data['count'] is 0:
+        count = metric_data.get('count', None)
+        if (not self.leave_zero_metrics) and (count is not None) and (count is 0):
             self.log.debug("SKIPPING 0 METRIC: %s" % base_metric_name)
             return True
-        m1rate = metric_data.get('m1_rate', None)
 
+        m1rate = metric_data.get('m1_rate', None)
         self.trace("###### m1rate %s", m1rate)
-        if (m1rate is not None) and (m1rate < 1.0e-7):
+        if (not self.leave_zero_metrics) and (m1rate is not None) and (m1rate < 1.0e-7):
             self.log.debug("SKIPPING (m1rate < 1e-7) METRIC: %s %s" % (base_metric_name, m1rate))
             return True
         return False

--- a/dropwizard/ci/dropwizard.rake
+++ b/dropwizard/ci/dropwizard.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def dropwizard_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def dropwizard_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/dropwizard_#{dropwizard_version}"
+end
+
+namespace :ci do
+  namespace :dropwizard do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('dropwizard/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name dropwizard source/dropwizard:dropwizard_version)
+      # sh %(docker start dropwizard)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'dropwizard'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop dropwizard)
+    #   sh %(docker rm dropwizard)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/dropwizard/ci/fixtures/codahale.metrics.json
+++ b/dropwizard/ci/fixtures/codahale.metrics.json
@@ -1,0 +1,859 @@
+{
+  "version": "3.0.0",
+  "gauges": {
+    "io.dropwizard.jetty.MutableServletContextHandler.percent-4xx-15m": {
+      "value": 3.732483458517298e-9
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.percent-4xx-1m": {
+      "value": 8.343207915504691e-83
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.percent-4xx-5m": {
+      "value": 1.9291113730213532e-19
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.percent-5xx-15m": {
+      "value": 0.012878268909549634
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.percent-5xx-1m": {
+      "value": 0.00447829280250964
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.percent-5xx-5m": {
+      "value": 0.01104170625619058
+    },
+    "jvm.attribute.name": {
+      "value": "6@ip-172-25-15-87"
+    },
+    "jvm.attribute.uptime": {
+      "value": 491557806
+    },
+    "jvm.attribute.vendor": {
+      "value": "Oracle Corporation Java HotSpot(TM) 64-Bit Server VM 25.72-b15 (1.8)"
+    },
+    "jvm.buffers.direct.capacity": {
+      "value": 1660550
+    },
+    "jvm.buffers.direct.count": {
+      "value": 49
+    },
+    "jvm.buffers.direct.used": {
+      "value": 1660550
+    },
+    "jvm.buffers.mapped.capacity": {
+      "value": 0
+    },
+    "jvm.buffers.mapped.count": {
+      "value": 0
+    },
+    "jvm.buffers.mapped.used": {
+      "value": 0
+    },
+    "jvm.classloader.loaded": {
+      "value": 5547
+    },
+    "jvm.classloader.unloaded": {
+      "value": 114
+    },
+    "jvm.filedescriptor": {
+      "value": 0.00008678436279296875
+    },
+    "jvm.gc.PS-MarkSweep.count": {
+      "value": 417
+    },
+    "jvm.gc.PS-MarkSweep.time": {
+      "value": 38327
+    },
+    "jvm.gc.PS-Scavenge.count": {
+      "value": 167169
+    },
+    "jvm.gc.PS-Scavenge.time": {
+      "value": 454354
+    },
+    "jvm.memory.heap.committed": {
+      "value": 37224448
+    },
+    "jvm.memory.heap.init": {
+      "value": 132120576
+    },
+    "jvm.memory.heap.max": {
+      "value": 954728448
+    },
+    "jvm.memory.heap.usage": {
+      "value": 0.03381732268231312
+    },
+    "jvm.memory.heap.used": {
+      "value": 32286360
+    },
+    "jvm.memory.non-heap.committed": {
+      "value": 60620800
+    },
+    "jvm.memory.non-heap.init": {
+      "value": 2555904
+    },
+    "jvm.memory.non-heap.max": {
+      "value": -1
+    },
+    "jvm.memory.non-heap.usage": {
+      "value": -58931096
+    },
+    "jvm.memory.non-heap.used": {
+      "value": 58931096
+    },
+    "jvm.memory.pools.Code-Cache.committed": {
+      "value": 22872064
+    },
+    "jvm.memory.pools.Code-Cache.init": {
+      "value": 2555904
+    },
+    "jvm.memory.pools.Code-Cache.max": {
+      "value": 251658240
+    },
+    "jvm.memory.pools.Code-Cache.usage": {
+      "value": 0.08939030965169271
+    },
+    "jvm.memory.pools.Code-Cache.used": {
+      "value": 22495808
+    },
+    "jvm.memory.pools.Compressed-Class-Space.committed": {
+      "value": 4063232
+    },
+    "jvm.memory.pools.Compressed-Class-Space.init": {
+      "value": 0
+    },
+    "jvm.memory.pools.Compressed-Class-Space.max": {
+      "value": 1073741824
+    },
+    "jvm.memory.pools.Compressed-Class-Space.usage": {
+      "value": 0.0035058781504631042
+    },
+    "jvm.memory.pools.Compressed-Class-Space.used": {
+      "value": 3764408
+    },
+    "jvm.memory.pools.Metaspace.committed": {
+      "value": 33685504
+    },
+    "jvm.memory.pools.Metaspace.init": {
+      "value": 0
+    },
+    "jvm.memory.pools.Metaspace.max": {
+      "value": -1
+    },
+    "jvm.memory.pools.Metaspace.usage": {
+      "value": 0.9698795066269456
+    },
+    "jvm.memory.pools.Metaspace.used": {
+      "value": 32670880
+    },
+    "jvm.memory.pools.PS-Eden-Space.committed": {
+      "value": 6291456
+    },
+    "jvm.memory.pools.PS-Eden-Space.init": {
+      "value": 33554432
+    },
+    "jvm.memory.pools.PS-Eden-Space.max": {
+      "value": 356515840
+    },
+    "jvm.memory.pools.PS-Eden-Space.usage": {
+      "value": 0.006606270285213695
+    },
+    "jvm.memory.pools.PS-Eden-Space.used": {
+      "value": 2357320
+    },
+    "jvm.memory.pools.PS-Old-Gen.committed": {
+      "value": 30408704
+    },
+    "jvm.memory.pools.PS-Old-Gen.init": {
+      "value": 88080384
+    },
+    "jvm.memory.pools.PS-Old-Gen.max": {
+      "value": 716177408
+    },
+    "jvm.memory.pools.PS-Old-Gen.usage": {
+      "value": 0.04129851580015213
+    },
+    "jvm.memory.pools.PS-Old-Gen.used": {
+      "value": 29577064
+    },
+    "jvm.memory.pools.PS-Survivor-Space.committed": {
+      "value": 524288
+    },
+    "jvm.memory.pools.PS-Survivor-Space.init": {
+      "value": 5242880
+    },
+    "jvm.memory.pools.PS-Survivor-Space.max": {
+      "value": 524288
+    },
+    "jvm.memory.pools.PS-Survivor-Space.usage": {
+      "value": 0.687530517578125
+    },
+    "jvm.memory.pools.PS-Survivor-Space.used": {
+      "value": 360464
+    },
+    "jvm.memory.total.committed": {
+      "value": 97845248
+    },
+    "jvm.memory.total.init": {
+      "value": 134676480
+    },
+    "jvm.memory.total.max": {
+      "value": 954728447
+    },
+    "jvm.memory.total.used": {
+      "value": 91230208
+    },
+    "jvm.threads.blocked.count": {
+      "value": 0
+    },
+    "jvm.threads.count": {
+      "value": 134
+    },
+    "jvm.threads.daemon.count": {
+      "value": 11
+    },
+    "jvm.threads.deadlock.count": {
+      "value": 0
+    },
+    "jvm.threads.deadlocks": {
+      "value": []
+    },
+    "jvm.threads.new.count": {
+      "value": 0
+    },
+    "jvm.threads.runnable.count": {
+      "value": 10
+    },
+    "jvm.threads.terminated.count": {
+      "value": 0
+    },
+    "jvm.threads.timed_waiting.count": {
+      "value": 117
+    },
+    "jvm.threads.waiting.count": {
+      "value": 7
+    },
+    "org.eclipse.jetty.util.thread.QueuedThreadPool.dw.jobs": {
+      "value": 0
+    },
+    "org.eclipse.jetty.util.thread.QueuedThreadPool.dw.size": {
+      "value": 8
+    },
+    "org.eclipse.jetty.util.thread.QueuedThreadPool.dw.utilization": {
+      "value": 0.375
+    },
+    "org.eclipse.jetty.util.thread.QueuedThreadPool.dw.utilization-max": {
+      "value": 0.0029296875
+    }
+  },
+  "counters": {
+    "io.dropwizard.jetty.MutableServletContextHandler.active-dispatches": {
+      "count": 0
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.active-requests": {
+      "count": 0
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.active-suspended": {
+      "count": 0
+    }
+  },
+  "histograms": {},
+  "meters": {
+    "ch.qos.logback.core.Appender.all": {
+      "count": 14006,
+      "m15_rate": 0.02198605754737047,
+      "m1_rate": 0.007563441089672757,
+      "m5_rate": 0.018703742857508542,
+      "mean_rate": 0.02849319914419003,
+      "units": "events/second"
+    },
+    "ch.qos.logback.core.Appender.debug": {
+      "count": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "units": "events/second"
+    },
+    "ch.qos.logback.core.Appender.error": {
+      "count": 3,
+      "m15_rate": 7.616299186408016e-25,
+      "m1_rate": 2.964393875e-314,
+      "m5_rate": 1.19288644239618e-67,
+      "mean_rate": 0.000006103069937131077,
+      "units": "events/second"
+    },
+    "ch.qos.logback.core.Appender.info": {
+      "count": 648,
+      "m15_rate": 1.5275193477728016e-9,
+      "m1_rate": 2.4708785988079914e-108,
+      "m5_rate": 2.3991756937509575e-23,
+      "mean_rate": 0.0013182631058792104,
+      "units": "events/second"
+    },
+    "ch.qos.logback.core.Appender.trace": {
+      "count": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "units": "events/second"
+    },
+    "ch.qos.logback.core.Appender.warn": {
+      "count": 13355,
+      "m15_rate": 0.021986056019851114,
+      "m1_rate": 0.007563441089672757,
+      "m5_rate": 0.018703742857508542,
+      "mean_rate": 0.02716883299603446,
+      "units": "events/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.1xx-responses": {
+      "count": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "units": "events/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.2xx-responses": {
+      "count": 709604,
+      "m15_rate": 1.6097636989711934,
+      "m1_rate": 1.642932883191428,
+      "m5_rate": 1.6221675783011074,
+      "mean_rate": 1.4435888878932235,
+      "units": "events/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.3xx-responses": {
+      "count": 27717,
+      "m15_rate": 0.057392293544678084,
+      "m1_rate": 0.03833532101498379,
+      "m5_rate": 0.05180634511145261,
+      "mean_rate": 0.05638631294555375,
+      "units": "events/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.4xx-responses": {
+      "count": 39,
+      "m15_rate": 6.3038727517848735e-9,
+      "m1_rate": 1.4090594129652655e-82,
+      "m5_rate": 3.265406394587177e-19,
+      "mean_rate": 0.00007933997928668814,
+      "units": "events/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.5xx-responses": {
+      "count": 12518,
+      "m15_rate": 0.021750389351040175,
+      "m1_rate": 0.007563254675296074,
+      "m5_rate": 0.018690293738535157,
+      "mean_rate": 0.02546609899723427,
+      "units": "events/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.async-dispatches": {
+      "count": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "units": "events/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.async-timeouts": {
+      "count": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "units": "events/second"
+    }
+  },
+  "timers": {
+    "routeTo.(svc=someapp,svcenv=production,svcver=0.56,svciid=1cbc0ad7)": {
+      "count": 17774,
+      "max": 0.010358384,
+      "mean": 0.0014999181153016765,
+      "min": 0.0007182940000000001,
+      "p50": 0.001365829,
+      "p75": 0.0016777580000000001,
+      "p95": 0.002016796,
+      "p98": 0.0021518080000000003,
+      "p99": 0.0024935260000000002,
+      "p999": 0.009554748,
+      "stddev": 0.0006783301080701184,
+      "m15_rate": 0.39754241459823986,
+      "m1_rate": 0.3999923123511042,
+      "m5_rate": 0.39859467746027977,
+      "mean_rate": 0.39733212869896933,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "routeTo.(svc=someapp,svcenv=production,svcver=0.56,svciid=7820d473)": {
+      "count": 17774,
+      "max": 0.007585057,
+      "mean": 0.0019655542147909736,
+      "min": 0.001101144,
+      "p50": 0.0020630930000000002,
+      "p75": 0.002261055,
+      "p95": 0.002407443,
+      "p98": 0.002503182,
+      "p99": 0.002503182,
+      "p999": 0.0032180280000000004,
+      "stddev": 0.0003596886041711067,
+      "m15_rate": 0.3975429537661493,
+      "m1_rate": 0.3999923123511042,
+      "m5_rate": 0.3985946906582311,
+      "mean_rate": 0.3973321331429019,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "routeTo.(svc=someapp,svcenv=production,svcver=0.56,svciid=7dc9f55b)": {
+      "count": 17774,
+      "max": 0.9730245810000001,
+      "mean": 0.0020665120467721052,
+      "min": 0.0009195140000000001,
+      "p50": 0.001666469,
+      "p75": 0.00212612,
+      "p95": 0.0036801530000000002,
+      "p98": 0.00953211,
+      "p99": 0.00953211,
+      "p999": 0.009747873,
+      "stddev": 0.0013386668067995324,
+      "m15_rate": 0.39754444973599523,
+      "m1_rate": 0.3999923123551018,
+      "m5_rate": 0.3985957772522905,
+      "mean_rate": 0.39733212385129496,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "routeTo.(svc=someapp2,svcenv=production,svcver=0.1.34,svciid=0549fe47)": {
+      "count": 41213,
+      "max": 0.195998094,
+      "mean": 0.016340854524834837,
+      "min": 0.0010212860000000002,
+      "p50": 0.016947323,
+      "p75": 0.020185942000000002,
+      "p95": 0.05616977,
+      "p98": 0.09580753700000001,
+      "p99": 0.11884096000000001,
+      "p999": 0.15903119400000001,
+      "stddev": 0.02083465843340231,
+      "m15_rate": 0.9637929871975118,
+      "m1_rate": 1.0234866680233812,
+      "m5_rate": 0.991541920079955,
+      "mean_rate": 0.9212810229484966,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "routeTo.(svc=someapp2,svcenv=production,svcver=0.1.34,svciid=95b63290)": {
+      "count": 40892,
+      "max": 0.146281406,
+      "mean": 0.012334533711879413,
+      "min": 0.000425595,
+      "p50": 0.015424253,
+      "p75": 0.018303075000000002,
+      "p95": 0.025545095,
+      "p98": 0.028027993,
+      "p99": 0.088344536,
+      "p999": 0.127972527,
+      "stddev": 0.014667142058123682,
+      "m15_rate": 0.9558502483299042,
+      "m1_rate": 0.9512289995471678,
+      "m5_rate": 0.9610828705252846,
+      "mean_rate": 0.9141276113910587,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "routeTo.(svc=someapp2,svcenv=production,svcver=0.1.34,svciid=f30a742f)": {
+      "count": 41050,
+      "max": 0.212499715,
+      "mean": 0.016764559568186628,
+      "min": 0.0008459860000000001,
+      "p50": 0.015546941000000002,
+      "p75": 0.019718835,
+      "p95": 0.08823157000000001,
+      "p98": 0.12304039300000001,
+      "p99": 0.12304039300000001,
+      "p999": 0.14006447400000002,
+      "stddev": 0.0258317566089193,
+      "m15_rate": 0.9358344289019194,
+      "m1_rate": 0.8534297184110874,
+      "m5_rate": 0.9037698579605359,
+      "mean_rate": 0.9176061634297451,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "routeTo.(svc=someapp3,svcenv=production,svcver=0.0.33-snapshot,svciid=73797771)": {
+      "count": 32934,
+      "max": 0.8517567800000001,
+      "mean": 0.0018924995818171075,
+      "min": 0.000446545,
+      "p50": 0.0015101140000000001,
+      "p75": 0.002117865,
+      "p95": 0.00486402,
+      "p98": 0.008498083,
+      "p99": 0.008498083,
+      "p999": 0.008498083,
+      "stddev": 0.001610634502385742,
+      "m15_rate": 0.39702623025588574,
+      "m1_rate": 0.39983216932646093,
+      "m5_rate": 0.3973903113072123,
+      "mean_rate": 0.397526709070122,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "routeTo.(svc=someapp3,svcenv=production,svcver=0.0.33-snapshot,svciid=c352ae63)": {
+      "count": 32932,
+      "max": 0.343752579,
+      "mean": 0.002474404036701262,
+      "min": 0.000611048,
+      "p50": 0.0019273180000000001,
+      "p75": 0.002665616,
+      "p95": 0.0059699570000000006,
+      "p98": 0.017372523,
+      "p99": 0.017372523,
+      "p999": 0.017372523,
+      "stddev": 0.002731620702901135,
+      "m15_rate": 0.39613640844204606,
+      "m1_rate": 0.38549650589768575,
+      "m5_rate": 0.39375885992534826,
+      "mean_rate": 0.397557154973202,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "com.stooges.app.Router.route": {
+      "count": 749874,
+      "max": 0.213093304,
+      "mean": 0.025375680943448595,
+      "min": 0.000205416,
+      "p50": 0.019197093000000002,
+      "p75": 0.021828421,
+      "p95": 0.08775313400000001,
+      "p98": 0.12260894600000001,
+      "p99": 0.123315162,
+      "p999": 0.159399686,
+      "stddev": 0.022366590184054062,
+      "m15_rate": 1.6889731498373752,
+      "m1_rate": 1.6898528904132906,
+      "m5_rate": 1.6928663157161468,
+      "mean_rate": 1.5255123806031103,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "com.stooges.app.pckg.CloudNodeProducer.produce": {
+      "count": 749874,
+      "max": 0.0007733070000000001,
+      "mean": 0.000007532638590098486,
+      "min": 0.000001223,
+      "p50": 0.00000748,
+      "p75": 0.000008173000000000001,
+      "p95": 0.0000104,
+      "p98": 0.000010458,
+      "p99": 0.00001081,
+      "p999": 0.000034156,
+      "stddev": 0.000009245296351794245,
+      "m15_rate": 1.6882224983665046,
+      "m1_rate": 1.6788136049857902,
+      "m5_rate": 1.690610394104613,
+      "mean_rate": 1.5255099182607572,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "com.stooges.app.pckg.CloudNodeProducer.update": {
+      "count": 100,
+      "max": 10.6233533,
+      "mean": 0.00883356872103367,
+      "min": 0.002951098,
+      "p50": 0.013226164,
+      "p75": 0.013226164,
+      "p95": 0.013226164,
+      "p98": 0.013226164,
+      "p99": 0.013226164,
+      "p999": 0.013226164,
+      "stddev": 0.004458980855248051,
+      "m15_rate": 1.1308448658424797e-16,
+      "m1_rate": 1.2341251172015067e-201,
+      "m5_rate": 8.661333697062853e-43,
+      "mean_rate": 0.00020343549963539964,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "com.stooges.app.pckg.ImmutableTopologyManager.events": {
+      "count": 0,
+      "max": 0,
+      "mean": 0,
+      "min": 0,
+      "p50": 0,
+      "p75": 0,
+      "p95": 0,
+      "p98": 0,
+      "p99": 0,
+      "p999": 0,
+      "stddev": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.connect-requests": {
+      "count": 0,
+      "max": 0,
+      "mean": 0,
+      "min": 0,
+      "p50": 0,
+      "p75": 0,
+      "p95": 0,
+      "p98": 0,
+      "p99": 0,
+      "p999": 0,
+      "stddev": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.delete-requests": {
+      "count": 0,
+      "max": 0,
+      "mean": 0,
+      "min": 0,
+      "p50": 0,
+      "p75": 0,
+      "p95": 0,
+      "p98": 0,
+      "p99": 0,
+      "p999": 0,
+      "stddev": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.dispatches": {
+      "count": 749878,
+      "max": 0.21400000000000002,
+      "mean": 0.02733858136294065,
+      "min": 0.001,
+      "p50": 0.021,
+      "p75": 0.025,
+      "p95": 0.08900000000000001,
+      "p98": 0.12400000000000001,
+      "p99": 0.125,
+      "p999": 0.161,
+      "stddev": 0.022370516849662295,
+      "m15_rate": 1.6889129760310153,
+      "m1_rate": 1.688870068625824,
+      "m5_rate": 1.6926916473085334,
+      "mean_rate": 1.525520621865629,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.get-requests": {
+      "count": 91623,
+      "max": 0.399,
+      "mean": 0.05646780177282181,
+      "min": 0.001,
+      "p50": 0.038,
+      "p75": 0.08900000000000001,
+      "p95": 0.126,
+      "p98": 0.132,
+      "p99": 0.136,
+      "p999": 0.161,
+      "stddev": 0.03815282549915831,
+      "m15_rate": 0.31516999450212385,
+      "m1_rate": 0.31465599529133453,
+      "m5_rate": 0.31552507138327657,
+      "mean_rate": 0.18639402203678587,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.head-requests": {
+      "count": 658209,
+      "max": 0.202,
+      "mean": 0.020738012137019212,
+      "min": 0.003,
+      "p50": 0.02,
+      "p75": 0.022000000000000002,
+      "p95": 0.026000000000000002,
+      "p98": 0.032,
+      "p99": 0.032,
+      "p999": 0.11800000000000001,
+      "stddev": 0.0068366503040795685,
+      "m15_rate": 1.3737363791565589,
+      "m1_rate": 1.3741754635903736,
+      "m5_rate": 1.3771391457677793,
+      "mean_rate": 1.3390330249503684,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.move-requests": {
+      "count": 0,
+      "max": 0,
+      "mean": 0,
+      "min": 0,
+      "p50": 0,
+      "p75": 0,
+      "p95": 0,
+      "p98": 0,
+      "p99": 0,
+      "p999": 0,
+      "stddev": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.options-requests": {
+      "count": 34,
+      "max": 0.076,
+      "mean": 0.053999999841703984,
+      "min": 0.006,
+      "p50": 0.054000000000000006,
+      "p75": 0.054000000000000006,
+      "p95": 0.054000000000000006,
+      "p98": 0.054000000000000006,
+      "p99": 0.054000000000000006,
+      "p999": 0.054000000000000006,
+      "stddev": 0.000002756484915217949,
+      "m15_rate": 6.3038727517848735e-9,
+      "m1_rate": 1.4090594129652655e-82,
+      "m5_rate": 3.265406394587177e-19,
+      "mean_rate": 0.0000691681865082632,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.other-requests": {
+      "count": 4,
+      "max": 0,
+      "mean": 0,
+      "min": 0,
+      "p50": 0,
+      "p75": 0,
+      "p95": 0,
+      "p98": 0,
+      "p99": 0,
+      "p999": 0,
+      "stddev": 0,
+      "m15_rate": 1.063268615790778e-168,
+      "m1_rate": 2.964393875e-314,
+      "m5_rate": 1.4821969375e-313,
+      "mean_rate": 0.000008137433714429134,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.post-requests": {
+      "count": 8,
+      "max": 0.18300000000000002,
+      "mean": 0.001,
+      "min": 0.001,
+      "p50": 0.001,
+      "p75": 0.001,
+      "p95": 0.001,
+      "p98": 0.001,
+      "p99": 0.001,
+      "p999": 0.001,
+      "stddev": 7.937084216445845e-25,
+      "m15_rate": 3.893832147639638e-24,
+      "m1_rate": 2.37043309627359e-309,
+      "m5_rate": 1.4238176183232405e-64,
+      "mean_rate": 0.000016274867399648097,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.put-requests": {
+      "count": 0,
+      "max": 0,
+      "mean": 0,
+      "min": 0,
+      "p50": 0,
+      "p75": 0,
+      "p95": 0,
+      "p98": 0,
+      "p99": 0,
+      "p999": 0,
+      "stddev": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.requests": {
+      "count": 749878,
+      "max": 0.21400000000000002,
+      "mean": 0.027353818494922025,
+      "min": 0.001,
+      "p50": 0.021,
+      "p75": 0.025,
+      "p95": 0.08900000000000001,
+      "p98": 0.12400000000000001,
+      "p99": 0.125,
+      "p999": 0.161,
+      "stddev": 0.022365515323481442,
+      "m15_rate": 1.6889218189031283,
+      "m1_rate": 1.6888700692053047,
+      "m5_rate": 1.692699778900237,
+      "mean_rate": 1.5255205916541583,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "io.dropwizard.jetty.MutableServletContextHandler.trace-requests": {
+      "count": 0,
+      "max": 0,
+      "mean": 0,
+      "min": 0,
+      "p50": 0,
+      "p75": 0,
+      "p95": 0,
+      "p98": 0,
+      "p99": 0,
+      "p999": 0,
+      "stddev": 0,
+      "m15_rate": 0,
+      "m1_rate": 0,
+      "m5_rate": 0,
+      "mean_rate": 0,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "org.eclipse.jetty.server.HttpConnectionFactory.8080.connections": {
+      "count": 510242,
+      "max": 962.9591915780001,
+      "mean": 31.112789725282916,
+      "min": 29.999893682000003,
+      "p50": 30.000924268000002,
+      "p75": 30.001045362000003,
+      "p95": 41.604980975000004,
+      "p98": 46.881016846,
+      "p99": 47.224152058,
+      "p999": 58.662197746000004,
+      "stddev": 7.439157130916863,
+      "m15_rate": 1.0461139524734688,
+      "m1_rate": 1.0659605346879562,
+      "m5_rate": 1.0472300023395853,
+      "mean_rate": 1.0380147587647137,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    },
+    "org.eclipse.jetty.server.HttpConnectionFactory.8081.connections": {
+      "count": 64825,
+      "max": 1349.999414742,
+      "mean": 5.659154262031276,
+      "min": 0.000455459,
+      "p50": 0.0008983550000000001,
+      "p75": 0.013538859,
+      "p95": 0.084557965,
+      "p98": 59.999403336,
+      "p99": 359.99936780400003,
+      "p999": 599.9999192930001,
+      "stddev": 47.21529571913196,
+      "m15_rate": 0.133673802428621,
+      "m1_rate": 0.1386223769828673,
+      "m5_rate": 0.13684616991997442,
+      "mean_rate": 0.13187724565138048,
+      "duration_units": "seconds",
+      "rate_units": "calls/second"
+    }
+  }
+}

--- a/dropwizard/ci/fixtures/codahale.metrics.json
+++ b/dropwizard/ci/fixtures/codahale.metrics.json
@@ -380,6 +380,34 @@
       "duration_units": "seconds",
       "rate_units": "calls/second"
     },
+    "com.stooges.app.pckg.feeditem.add": {
+      "count": 7,
+      "max": 539.843628,
+      "mean": 497.2943332787729,
+      "min": 454.400686,
+      "p50": 497.294333,
+      "p75": 497.294333,
+      "p95": 497.294333,
+      "p98": 497.294333,
+      "p99": 497.294333,
+      "p999": 497.294333,
+      "values": [
+        454.400686,
+        497.294333,
+        498.25892799999997,
+        503.44122699999997,
+        515.369783,
+        517.882508,
+        539.843628
+      ],
+      "stddev": 0.0022467132506182896,
+      "m15_rate": 0.39754241459823986,
+      "m1_rate": 0.3999923123511042,
+      "m5_rate": 0.39859467746027977,
+      "mean_rate": 0.39733212869896933,
+      "duration_units": "milliseconds",
+      "rate_units": "calls/millisecond"
+    },
     "routeTo.(svc=someapp,svcenv=production,svcver=0.56,svciid=7820d473)": {
       "count": 17774,
       "max": 0.007585057,

--- a/dropwizard/ci/fixtures/dropwizard.1.yaml
+++ b/dropwizard/ci/fixtures/dropwizard.1.yaml
@@ -14,8 +14,8 @@ init_config:
 instances:
   - appname: chris
     host: myhost.stooges.com
-    port: 8080
-    stats_url: /private/metrics
+    port: 8081
+    stats_url: /metrics
 
     instance_tags: appgrp:mady
 

--- a/dropwizard/ci/fixtures/dropwizard.1.yaml
+++ b/dropwizard/ci/fixtures/dropwizard.1.yaml
@@ -1,0 +1,21 @@
+init_config:
+  debug: True
+  log_at_trace: True
+  log_each_metric: False
+
+  http_timeout: 0.25
+
+  metrictype_blacklist: min, .p75, .p98
+
+  service_tags: grp:celia, xx:yy
+
+  leave_package_names: True
+
+instances:
+  - appname: chris
+    host: myhost.stooges.com
+    port: 8080
+    stats_url: /private/metrics
+
+    instance_tags: appgrp:mady
+

--- a/dropwizard/conf.yaml.example
+++ b/dropwizard/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/dropwizard/conf.yaml.example
+++ b/dropwizard/conf.yaml.example
@@ -26,9 +26,9 @@ init_config:
   #leave_package_names: False
 
 instances:
-  # Overrides for the default Dropwizard stats URL; http://localhost:8080/metrics
+  # Overrides for the default Dropwizard stats URL; http://localhost:8081/metrics
   - host: localhost
-    port: 8080
+    port: 8081
     stats_url: /metrics
 
     # The name of this Dropwizard application

--- a/dropwizard/conf.yaml.example
+++ b/dropwizard/conf.yaml.example
@@ -1,11 +1,42 @@
+###
+###   DropwizardCheck configuration
+###
+
 init_config:
-  # Any global configurable parameters should be added here
+  # Turn on debug logging
+  #debug: False
+
+  # Debug logging on steriods
+  #log_at_trace: False
+
+  # Sometimes you want to see teh metrics you'll send
+  #log_each_metric: False
+
+  # Timeout for the call to /metrics
+  #http_timeout: 0.25
+
+  # By default, we do not process the following suffixes: ".p75, .p98"
+  # You can modify that list, or you can disable the behavior altogether by specifying; "none"
+  #metrictype_blacklist: min, .p75, .p98
+
+  # Tags applied to all of these Dropwizard services
+  #service_tags: grp:webtier, xx:yy
+
+  # Default behavior is to remove Java package names from the front of the metric
+  #leave_package_names: False
 
 instances:
-  #   A typical instance configuration might include a hostname and port
-  #   a set of customizable tags and other parameters we might need to
-  #   configure the behavior of our check.
-  #
-  # - host: localhost
-  #   port: 26379
-  #   tags: ['custom:tag']
+  # Overrides for the default Dropwizard stats URL; http://localhost:8080/metrics
+  - host: localhost
+    port: 8080
+    stats_url: /metrics
+
+    # The name of this Dropwizard application
+    # NOTE: if defined, "appname" is prefixed as the first field of the metrics,
+    #       so that all of the dropwizard metrics don't end up in the single, default "dropwizard" first field
+    #appname: myapp
+
+    # Tags applied to this specific instance
+    # NOTE: it is strongly recommended that you supply and "app:xxx" tag,
+    #       if you do not plan to use "appname" above
+    #instance_tags: appgrp:homepage, app:myapp

--- a/dropwizard/conf.yaml.example
+++ b/dropwizard/conf.yaml.example
@@ -25,6 +25,10 @@ init_config:
   # Default behavior is to remove Java package names from the front of the metric
   #leave_package_names: False
 
+  # Default behavior is to remove zero metrics.
+  # Be forewarned, leaving zero metrics will cause confusion in DataDog
+  #leave_zero_metrics: False
+
 instances:
   # Overrides for the default Dropwizard stats URL; http://localhost:8081/metrics
   - host: localhost

--- a/dropwizard/manifest.json
+++ b/dropwizard/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "dropwizard",
+  "short_description": "dropwizard description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/dropwizard/metadata.csv
+++ b/dropwizard/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/dropwizard/requirements.txt
+++ b/dropwizard/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/dropwizard/test_dropwizard.py
+++ b/dropwizard/test_dropwizard.py
@@ -21,9 +21,9 @@ MOCK_CONFIG = {
         'leave_package_names': False
     },
     'instances': [{'host': 'stooges.com',
-                'appname': 'my-app',
-                'port': 8181,
-                'instance_tags' : 'appgrp:mady, aa:bb'
+                   'appname': 'my-app',
+                   'port': 8181,
+                   'instance_tags': 'appgrp:mady, aa:bb'
                    }]
 }
 
@@ -115,14 +115,18 @@ class TestDropwizard(AgentCheckTest):
         self.assertMetric('my-app.MutableServletContextHandler.3xx-responses.m1_rate', value=0.03833532101498379, tags=tags)
         self.assertMetric('my-app.MutableServletContextHandler.head-requests.max', value=0.202, tags=tags)
 
-        # assert that 0 metrics are missing
+        # No CamelCase
+        self.assertMetric('my-app.com.stooges.app.pckg.feeditem.add.mean_rate', value=0.39733212869896933, tags=tags)
+        assertNoMetric(self, 'my-app.com.stooges.app.pckg.feeditem.add.values')
+
+        # assert that -1, 0 metrics are missing
         assertNoMetric(self, 'my-app.Appender.debug.count')
         assertNoMetric(self, 'my-app.Jvm.memory.pools.Metaspace.max')
         assertNoMetric(self, 'my-app.Jvm.memory.pools.Metaspace.init')
         assertNoMetric(self, 'my-app.ImmutableTopologyManager.events.max')
         assertNoMetric(self, 'my-app.MutableServletContextHandler.move-requests.max')
 
-        # assert that m1_rate < 1e-9 are missing
+        # assert that m1_rate < 1e-7 are missing
         assertNoMetric(self, 'my-app.MutableServletContextHandler.4xx-responses.m1_rate')
         assertNoMetric(self, 'my-app.CloudNodeProducer.update.count')
         assertNoMetric(self, 'my-app.MutableServletContextHandler.options-requests.max')
@@ -170,6 +174,25 @@ class TestDropwizard(AgentCheckTest):
         self.assertMetric('my-app.io.dropwizard.jetty.MutableServletContextHandler.3xx-responses.m1_rate', value=0.03833532101498379, tags=tags)
         self.assertMetric('my-app.io.dropwizard.jetty.MutableServletContextHandler.head-requests.max', value=0.202, tags=tags)
 
+    def test_leave_zero_metrics(self):
+        self.data_type = 1
+        my_config = copy.deepcopy(MOCK_CONFIG)
+        my_config['init_config']['leave_zero_metrics'] = True
+
+        self.run_check(my_config, agent_config=self.agentConfig, mocks=self._get_mocks(), force_reload=True)
+        #self.print_current_state()
+
+        tags = ['appgrp:mady', 'aa:bb', 'grp:celia', 'xx:yy', 'foo:bar']
+
+        # assert that 0 metrics are present
+        self.assertMetric('my-app.Appender.debug.count', value=0, tags=tags)
+        self.assertMetric('my-app.Jvm.threads.blocked.count', value=0, tags=tags)
+        self.assertMetric('my-app.MutableServletContextHandler.async-timeouts.mean_rate', value=0, tags=tags)
+
+        # assert that m1_rate < 1e-7 are present
+        self.assertMetric('my-app.CloudNodeProducer.update.count', value=100, tags=tags)
+        self.assertMetric('my-app.MutableServletContextHandler.options-requests.max', value=0.076, tags=tags)
+
     def test_encodedtags_basics(self):
         self.load_check(MOCK_CONFIG, self.agentConfig)
         ff = self.check.get_encoded_tags_processor()
@@ -181,7 +204,6 @@ class TestDropwizard(AgentCheckTest):
         assertTag('myapp_svcenv:production', tags)
         assertTag('myapp_svcver:0.1.32', tags)
         assertTag('myapp_svciid:0f60fee0', tags)
-
 
     def test_encodedtags_no_tag_prefix(self):
         self.load_check(MOCK_CONFIG, self.agentConfig)

--- a/dropwizard/test_dropwizard.py
+++ b/dropwizard/test_dropwizard.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='dropwizard')
+class TestDropwizard(AgentCheckTest):
+    """Basic Test for dropwizard integration."""
+    CHECK_NAME = 'dropwizard'
+
+    def test_check(self):
+        """
+        Testing Dropwizard check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()

--- a/dropwizard/test_dropwizard.py
+++ b/dropwizard/test_dropwizard.py
@@ -1,38 +1,196 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # stdlib
-from nose.plugins.attrib import attr
+import logging
+import copy
+import os
 
 # 3p
+import json
 
 # project
 from tests.checks.common import AgentCheckTest
 
-
-instance = {
-    'host': 'localhost',
-    'port': 26379,
-    'password': 'datadog-is-devops-best-friend'
+MOCK_CONFIG = {
+    'init_config': {
+        'min_collection_interval': 30,
+        'debug': False,
+        'log_at_trace': False,
+        'service_tags': 'grp:celia, xx:yy',
+        'leave_package_names': False
+    },
+    'instances': [{'host': 'stooges.com',
+                'appname': 'my-app',
+                'port': 8181,
+                'instance_tags' : 'appgrp:mady, aa:bb'
+                   }]
 }
 
+LEVEL = logging.INFO
+
+def setup_logging(logger, level=LEVEL):
+    logger.setLevel(level)
+    ch = logging.StreamHandler()
+    logger.addHandler(ch)
+
+tests_log = logging.getLogger('tests')
+setup_logging(tests_log, level=LEVEL)
+setup_logging(logging.getLogger('checks.dropwizard'), level=LEVEL)
+
+def assertNoMetric(test, metric_name, value=None, tags=None, count=None, at_least=1, hostname=None, device_name=None, metric_type=None):
+    try:
+        tests_log.info("calling assertMetric for %s" % metric_name)
+        test.assertMetric(metric_name, value=value, tags=tags, count=count, at_least=at_least, hostname=hostname, device_name=device_name, metric_type=metric_type)
+        raise Exception("The metric (%s) should NOT be present" % metric_name)
+    except AssertionError as ee:
+        tests_log.debug("Expected Exception occured %s" % ee)
+        pass
+
+def assertTag(tag, tags):
+    if tag not in tags:
+        raise Exception("tag: %s is not in (%s)" % (tag, tags))
+
+# -------------------------------------------------------------
+# PYTHONPATH=. nosetests ./dropwizard/test_dropwizard.py
+# -------------------------------------------------------------
 
 # NOTE: Feel free to declare multiple test classes if needed
 
-@attr(requires='dropwizard')
 class TestDropwizard(AgentCheckTest):
     """Basic Test for dropwizard integration."""
     CHECK_NAME = 'dropwizard'
 
-    def test_check(self):
-        """
-        Testing Dropwizard check.
-        """
-        self.load_check({}, {})
+    def __init__(self, *args, **kwargs):
+        AgentCheckTest.__init__(self, *args, **kwargs)
 
-        # run your actual tests...
+        self.agentConfig = {
+            'version': '0.1',
+            'api_key': 'toto',
+            'tags': ['foo:bar'],
+            'hostname': 'dogstar.stooges.com'
+        }
 
-        self.assertTrue(True)
-        # Raises when COVERAGE=true and coverage < 100%
-        self.coverage_report()
+    def setUp(self):
+        self.log = tests_log
+
+    def mock_fetch_dropwizard_json(self, instance):
+        tests_log.debug("Fetching data from: %s" % instance)
+        return self.fetch_json('./dropwizard/ci/fixtures/codahale.metrics.json')
+
+    def _get_mocks(self):
+        return {
+            '_fetch_dropwizard_json': self.mock_fetch_dropwizard_json
+        }
+
+    def fetch_json(self, file):
+        tests_log.debug("Fetching data from: %s" % file)
+        if not file:
+            raise Exception("Attempt to fetch an Empty file")
+        data = {}
+        if file:
+            if not os.path.isfile(file) or not os.access(file, os.R_OK):
+                # Don't run the check if the file is unavailable
+                raise Exception("Unable to read file at %s" % file)
+            else:
+                with open(file, 'r') as stream:
+                    data = json.load(stream)
+                    stream.close()
+        ## log.debug("json: %s" % data)
+        return data
+
+    def test_check_basics(self):
+        tests_log.debug("RUNNING test_check_no_comments")
+        self.run_check(MOCK_CONFIG, agent_config=self.agentConfig, mocks=self._get_mocks(), force_reload=True)
+        self.print_current_state()
+
+        tags = ['appgrp:mady', 'aa:bb', 'grp:celia', 'xx:yy', 'foo:bar']
+
+        my_tags = copy.deepcopy(tags).extend([u'svc:someapp3', u'svcenv:production', u'svcver:0.0.33-snapshot', u'svciid:c352ae63'])
+        self.assertMetric('my-app.routeTo.count', value=32932, tags=my_tags)
+
+        self.assertMetric('my-app.Jvm.memory.pools.Metaspace.committed', value=33685504, tags=tags)
+        self.assertMetric('my-app.Appender.all.count', value=14006, tags=tags)
+        self.assertMetric('my-app.Jvm.memory.pools.PS-Survivor-Space.committed', value=524288, tags=tags)
+        self.assertMetric('my-app.MutableServletContextHandler.3xx-responses.m1_rate', value=0.03833532101498379, tags=tags)
+        self.assertMetric('my-app.MutableServletContextHandler.head-requests.max', value=0.202, tags=tags)
+
+        # assert that 0 metrics are missing
+        assertNoMetric(self, 'my-app.Appender.debug.count')
+        assertNoMetric(self, 'my-app.Jvm.memory.pools.Metaspace.max')
+        assertNoMetric(self, 'my-app.Jvm.memory.pools.Metaspace.init')
+        assertNoMetric(self, 'my-app.ImmutableTopologyManager.events.max')
+        assertNoMetric(self, 'my-app.MutableServletContextHandler.move-requests.max')
+
+        # assert that m1_rate < 1e-9 are missing
+        assertNoMetric(self, 'my-app.MutableServletContextHandler.4xx-responses.m1_rate')
+        assertNoMetric(self, 'my-app.CloudNodeProducer.update.count')
+        assertNoMetric(self, 'my-app.MutableServletContextHandler.options-requests.max')
+
+        # assert the metric blacklist are missing
+        assertNoMetric(self, 'my-app.routeTo.p98')
+        assertNoMetric(self, 'my-app.routeTo.p75')
+
+    def test_empty_lists(self):
+        my_config = copy.deepcopy(MOCK_CONFIG)
+        my_config['init_config']['service_tags'] = None
+        my_config['init_config']['metrictype_blacklist'] = 'none'
+        my_config['instances'][0]['instance_tags'] = None
+
+        self.run_check(my_config, agent_config=self.agentConfig, mocks=self._get_mocks(), force_reload=True)
+        self.print_current_state()
+
+        tags = ['foo:bar']
+
+        self.assertMetric('my-app.Jvm.memory.pools.Metaspace.committed', value=33685504, tags=tags)
+        self.assertMetric('my-app.Appender.all.count', value=14006, tags=tags)
+        self.assertMetric('my-app.Jvm.memory.pools.PS-Survivor-Space.committed', value=524288, tags=tags)
+        self.assertMetric('my-app.MutableServletContextHandler.3xx-responses.m1_rate', value=0.03833532101498379, tags=tags)
+        self.assertMetric('my-app.MutableServletContextHandler.head-requests.max', value=0.202, tags=tags)
+
+        my_tags = copy.deepcopy(tags).extend([u'svc:someapp3', u'svcenv:production', u'svcver:0.0.33-snapshot', u'svciid:c352ae63'])
+        self.assertMetric('my-app.routeTo.count', value=32932, tags=my_tags)
+
+        my_tags = copy.deepcopy(tags).extend([u'svc:someapp', u'svcenv:production', u'svcver:0.56', u'svciid:7820d473'])
+        self.assertMetric('my-app.routeTo.p98', value=0.002503182, tags=my_tags)
+        self.assertMetric('my-app.routeTo.p75', value=0.020185942000000002, tags=my_tags)
+
+    def test_check_leave_package_names(self):
+        my_config = copy.deepcopy(MOCK_CONFIG)
+        my_config['init_config']['leave_package_names'] = True
+
+        self.run_check(my_config, agent_config=self.agentConfig, mocks=self._get_mocks(), force_reload=True)
+        #self.print_current_state()
+
+        tags = ['appgrp:mady', 'aa:bb', 'grp:celia', 'xx:yy', 'foo:bar']
+
+        self.assertMetric('my-app.Jvm.memory.pools.Metaspace.committed', value=33685504, tags=tags)
+        self.assertMetric('my-app.ch.qos.logback.core.Appender.all.count', value=14006, tags=tags)
+        self.assertMetric('my-app.Jvm.memory.pools.PS-Survivor-Space.committed', value=524288, tags=tags)
+        self.assertMetric('my-app.io.dropwizard.jetty.MutableServletContextHandler.3xx-responses.m1_rate', value=0.03833532101498379, tags=tags)
+        self.assertMetric('my-app.io.dropwizard.jetty.MutableServletContextHandler.head-requests.max', value=0.202, tags=tags)
+
+    def test_encodedtags_basics(self):
+        self.load_check(MOCK_CONFIG, self.agentConfig)
+        ff = self.check.get_encoded_tags_processor()
+
+        full_metric = 'myapp.routeTo.(svc=otherapp,svcenv=production,svcver=0.1.32,svciid=0f60fee0).count'
+        metric, tags = ff.process_tags_from_metric(full_metric, self.log, tag_prefix='myapp')
+        self.assertEquals('myapp.routeTo.count', metric)
+        assertTag('myapp_svc:otherapp', tags)
+        assertTag('myapp_svcenv:production', tags)
+        assertTag('myapp_svcver:0.1.32', tags)
+        assertTag('myapp_svciid:0f60fee0', tags)
+
+
+    def test_encodedtags_no_tag_prefix(self):
+        self.load_check(MOCK_CONFIG, self.agentConfig)
+        ff = self.check.get_encoded_tags_processor()
+
+        full_metric = 'myapp.routeTo.(svc=otherapp,svcenv=production,svcver=0.1.32,svciid=0f60fee0).count'
+        metric, tags = ff.process_tags_from_metric(full_metric, self.log)
+        self.assertEquals('myapp.routeTo.count', metric)
+        assertTag('svc:otherapp', tags)
+        assertTag('svcenv:production', tags)
+        assertTag('svcver:0.1.32', tags)
+        assertTag('svciid:0f60fee0', tags)


### PR DESCRIPTION
### What does this PR do?

Adds a new DropwizardCheck.
A DataDog check for the popular Java Dropwizard framework.

Originally written by @cberry777 (https://github.com/DataDog/dd-agent/pull/3058)

### Motivation

Dropwizard is a widely popular Java framework for creating microservices.
(For further details, see http://metrics.dropwizard.io/3.1.0/)
The Java world really needs a first class check in DataDog for Dropwizard services.

DropwizardCheck calls the standard Dropwizard stats URL: http://localhost:8081/metrics -- which yields up a JSON response consisting of the all metrics in it's MetricRegistry at that time. DropwizardCheck reads this response, parses it, and creates the corresponding DataDog metrics.

### Testing Guidelines

A Testcase is provided here: tests/checks/mock/test_dropwizard.py
It contains 5 tests.

### Additional Notes

Please see the DropwizardCheck (checks.d/dropwizard.py) for quite a bit of documentation.

NOTE: A form of this code has been running in Production for many months at my employer.
And we've decided to make it available to all...

