### PR TITLE
[docker_machine] adding integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - DD_AGENT_BRANCH=master
   matrix:
     - TRAVIS_FLAVOR=default
+    - TRAVIS_FLAVOR=docker_machine FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[docker_machine]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/docker_machine/README.md
+++ b/docker_machine/README.md
@@ -1,0 +1,32 @@
+# Docker_machine Integration
+
+## Overview
+
+Get metrics from docker_machine service in real time to:
+
+* Visualize and monitor docker_machine states
+* Be notified about docker_machine failovers and events.
+
+## Installation
+
+Install the `dd-check-docker_machine` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `docker_machine.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        docker_machine
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The docker_machine check is compatible with all major platforms

--- a/docker_machine/check.py
+++ b/docker_machine/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'docker_machine'
+
+
+class Docker_machineCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/docker_machine/check.py
+++ b/docker_machine/check.py
@@ -2,20 +2,143 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+"""docker-machine check
+Collects metrics from docker-machine
+"""
+
 # stdlib
+import os
+import re
+import time
 
 # 3rd party
+import json
 
 # project
 from checks import AgentCheck
+from utils.subprocess_output import get_subprocess_output
+from config import _is_affirmative
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'docker_machine'
 
 
 class Docker_machineCheck(AgentCheck):
+    """ Collect metrics and events from docker_machine """
+
+    DEFAULT_DM_CMD = '/usr/bin/docker-machine'
+    NAMESPACE = "docker-machine"
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
+    def _collect_raw(self, docker_machine_cmd, instance):
+        use_sudo = _is_affirmative(instance.get('use_sudo', False))
+        if use_sudo:
+            test_sudo = os.system('setsid sudo -l < /dev/null')
+            if test_sudo != 0:
+                raise Exception('The dd-agent user does not have sudo access')
+                docker_machine_cmd = 'sudo' + docker_machine_cmd
+        else:
+            docker_machine_cmd = docker_machine_cmd
+
+        format_args = instance.get('format_args', [])
+
+        #### Docker machine command example ####
+        # docker - machine
+        # ls - -format
+        # "machine-name: {{.Name}},
+        #   status: {{.State}},
+        #   is_active:{{.Active}},
+        #   error: {{.Error}},
+        #   driver_name: {{.DriverName}},
+        #   url: {{.URL}},
+        #   response_time: {{.ResponseTime}}"
+
+        format_args = ["\"%s\": \"{{.%s}}\"" % (self._convert_camel(k), k) for k in format_args]
+        args = docker_machine_cmd.split() + ["{" + ",".join(format_args) + "},"]
+
+        try:
+            output, _, _ = get_subprocess_output(args, self.log)
+            output = '[{}]'.format(output).replace(",\n]", "]")
+            res = json.loads(output)
+            return res
+        except Exception as e:
+            return None
+            self.log.warning('Unable to parse data from cmd=%s: %s' % (args, str(e)))
+
+    def _publish(self, raw, func, keyspec, tags):
+        try:
+            for k in keyspec:
+                raw = raw[k]
+            func(self.NAMESPACE + '.' + k, raw, tags)
+        except KeyError:
+            return
+
+    def _extract_metrics(self, raw, instance):
+        running_dms = 0
+        stopped_dms = 0
+        check_name = '{}.checks'.format(self.NAMESPACE)
+
+        for dm in raw:
+            tags = []
+            dm_state = str(dm['state']).lower()
+            tags.append('{}.name:{}'.format(self.NAMESPACE, dm['name']))
+            tags.append('{}.url:{}'.format(self.NAMESPACE, (dm['url'] or "None")))
+            tags.append('{}.state:{}'.format(self.NAMESPACE, dm['state']))
+            tags.append('{}.driver_name:{}'.format(self.NAMESPACE, dm['driver_name']))
+            if dm['error'] is not None:
+                tags.append('{}.error:{}'.format(self.NAMESPACE, dm['error']))
+            self.gauge(self.NAMESPACE, 1, tags=tags)
+
+            if dm_state == 'running':
+                running_dms += 1
+                self.service_check(check_name, AgentCheck.OK, tags=tags)
+                self.gauge('{}.response_time'.format(self.NAMESPACE), int(filter(str.isdigit, str(dm['response_time']))),
+                           tags=tags)
+            elif dm_state == 'stopped':
+                stopped_dms += 1
+                self.service_check(check_name, AgentCheck.CRITICAL, tags=tags)
+            else:
+                self.service_check(check_name, AgentCheck.UNKNOWN, tags=tags)
+
+        self.gauge(self.NAMESPACE, len(raw), tags=tags)
+        self.gauge("{}.running".format(self.NAMESPACE), running_dms, tags=self.NAMESPACE)
+        self.gauge("{}.stopped".format(self.NAMESPACE), stopped_dms, tags=self.NAMESPACE)
+        self.gauge("{}.unknown".format(self.NAMESPACE), (len(raw) - running_dms - stopped_dms), tags=self.NAMESPACE)
+
+        if running_dms == 0:
+            self.log.warn("sending no runner event as there is no running docker machine")
+            self._send_no_runner_event(instance)
+
+
+    def _convert_camel(self, camel_str):
+        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', camel_str)
+        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+    def _send_no_runner_event(self, instance):
+        event = {
+            "msg_title": "There's NO docker-machine running on host",
+            "msg_text": "Couldn't get any docker machine by running the command {}".format(instance.get('docker_machine_cmd') or self.DEFAULT_DM_CMD),
+            "alert_type": "error",
+            "event_type": "docker-machine runner error",
+            "timestamp": int(time.time()),
+            "api_key": "{}".format(instance.get("api_key")),
+            "tags": "{}".format(self.NAMESPACE)
+        }
+        self.event(event)
+
     def check(self, instance):
-        pass
+        docker_machine_cmd = instance.get('docker_machine_cmd') or self.DEFAULT_DM_CMD
+        raw = self._collect_raw(docker_machine_cmd, instance)
+
+        if raw is None or len(raw) == 0:
+            self._send_no_runner_event(instance)
+            self.log.warn("sending no runner event")
+        else:
+            self._extract_metrics(raw, instance)
+
+
+if __name__ == '__main__':
+    check, instances = Docker_machineCheck.from_yaml('/opt/datadog-agent/etc/conf.d/docker_machine.yaml')
+    for i in instances:
+        check.check(i)

--- a/docker_machine/ci/docker_machine.rake
+++ b/docker_machine/ci/docker_machine.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def docker_machine_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def docker_machine_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/docker_machine_#{docker_machine_version}"
+end
+
+namespace :ci do
+  namespace :docker_machine do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('docker_machine/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name docker_machine source/docker_machine:docker_machine_version)
+      # sh %(docker start docker_machine)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'docker_machine'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop docker_machine)
+    #   sh %(docker rm docker_machine)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/docker_machine/conf.yaml.example
+++ b/docker_machine/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/docker_machine/conf.yaml.example
+++ b/docker_machine/conf.yaml.example
@@ -1,11 +1,13 @@
 init_config:
-  # Any global configurable parameters should be added here
 
 instances:
-  #   A typical instance configuration might include a hostname and port
-  #   a set of customizable tags and other parameters we might need to
-  #   configure the behavior of our check.
-  #
-  # - host: localhost
-  #   port: 26379
-  #   tags: ['custom:tag']
+# refer to https://docs.docker.com/machine/reference/ls/ formatting
+  - format_args: [Name, State, Error, DriverName, URL, ResponseTime]
+    docker_machine_cmd: "docker-machine ls -f"
+    api_key: DATADOG_API_KEY 
+#
+# If your environment requires sudo, please add a line like:
+#          dd-agent ALL=(ALL) NOPASSWD:/usr/bin/ceph
+# to your sudoers file, and uncomment the below option.
+#
+#    use_sudo: True

--- a/docker_machine/manifest.json
+++ b/docker_machine/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "docker_machine",
+  "short_description": "docker_machine description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/docker_machine/metadata.csv
+++ b/docker_machine/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/docker_machine/requirements.txt
+++ b/docker_machine/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/docker_machine/test_docker_machine.py
+++ b/docker_machine/test_docker_machine.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='docker_machine')
+class TestDocker_machine(AgentCheckTest):
+    """Basic Test for docker_machine integration."""
+    CHECK_NAME = 'docker_machine'
+
+    def test_check(self):
+        """
+        Testing Docker_machine check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()


### PR DESCRIPTION
## What's this PR do?

Adds a docker_machine check.

Originally written by @minzhang28 (https://github.com/DataDog/dd-agent/pull/3047)

## Motivation

- Tracking the status of docker machine every 15 seconds by default, docker machine status includes
  - running
  - stopped
  - unknown

- Aggregate the metrics of docker-machine by calling `gauge` function from data dog agent libs. This shows the number of instance under each status on data dog dashboard.

- Send error event to datadog if there's no docker-machine running on the target machine


*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*
