### PR TITLE
[powerdns_authoritative] adding integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - DD_AGENT_BRANCH=master
   matrix:
     - TRAVIS_FLAVOR=default
+    - TRAVIS_FLAVOR=powerdns_authoritative FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[powerdns_authoritative]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/powerdns_authoritative/README.md
+++ b/powerdns_authoritative/README.md
@@ -1,0 +1,32 @@
+# Powerdns_authoritative Integration
+
+## Overview
+
+Get metrics from powerdns_authoritative service in real time to:
+
+* Visualize and monitor powerdns_authoritative states
+* Be notified about powerdns_authoritative failovers and events.
+
+## Installation
+
+Install the `dd-check-powerdns_authoritative` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `powerdns_authoritative.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        powerdns_authoritative
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The powerdns_authoritative check is compatible with all major platforms

--- a/powerdns_authoritative/check.py
+++ b/powerdns_authoritative/check.py
@@ -11,7 +11,7 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'powerdns_authoritative'
 
 
 class PowerDNSAuthoritativeCheck(AgentCheck):
-    # See https://doc.powerdns.com/md/authoritative/stats/ for metrics explanation
+    # See https://doc.powerdns.com/md/authoritative/performance/#performance-monitoring for metrics explanation
 
     SERVICE_CHECK_NAME = 'powerdns.authoritative.can_connect'
 
@@ -23,7 +23,18 @@ class PowerDNSAuthoritativeCheck(AgentCheck):
         stats = self._get_pdns_stats(config)
         for stat in stats:
             self.log.debug('powerdns.authoritative.{}:{}'.format(stat['name'], stat['value']))
-            if 'status' or 'usage' or 'size' in stat['name']:
+
+            if 'status' in stat['name']:
+                self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+            elif 'size' in stat['name']:
+                self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+            elif 'usage' in stat['name']:
+                self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+            elif 'msec' in stat['name']:
+                self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+            elif 'time' in stat['name']:
+                self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+            elif 'latency' in stat['name']:
                 self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
             else:
                 self.rate('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)

--- a/powerdns_authoritative/check.py
+++ b/powerdns_authoritative/check.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'powerdns_authoritative'
+
+
+class Powerdns_authoritativeCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/powerdns_authoritative/check.py
+++ b/powerdns_authoritative/check.py
@@ -12,62 +12,6 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'powerdns_authoritative'
 
 class PowerDNSAuthoritativeCheck(AgentCheck):
     # See https://doc.powerdns.com/md/authoritative/stats/ for metrics explanation
-    GAUGE_METRICS = [
-        'corrupt-packets',
-        'deferred-cache-inserts',
-        'deferred-cache-lookup',
-        'dnsupdate-answers',
-        'dnsupdate-changes',
-        'dnsupdate-queries',
-        'dnsupdate-refused',
-        'incoming-notifications',
-        'packetcache-hit',
-        'packetcache-miss',
-        'packetcache-size',
-        'query-cache-hit',
-        'query-cache-miss',
-        'rd-queries',
-        'recursing-answers',
-        'recursing-questions',
-        'recursion-unanswered',
-        'security-status',
-        'servfail-packets',
-        'signatures',
-        'tcp-answers',
-        'tcp-answers-bytes',
-        'tcp-queries',
-        'tcp4-answers',
-        'tcp4-answers-bytes',
-        'tcp4-queries',
-        'tcp6-answers',
-        'tcp6-answers-bytes',
-        'tcp6-queries',
-        'timedout-packets',
-        'udp-answers',
-        'udp-answers-bytes',
-        'udp-do-queries',
-        'udp-queries',
-        'udp4-answers',
-        'udp4-answers-bytes',
-        'udp4-queries',
-        'udp6-answers',
-        'udp6-answers-bytes',
-        'udp6-queries',
-        'fd-usage',
-        'key-cache-size',
-        'latency',
-        'meta-cache-size',
-        'qsize-q',
-        'real-memory-usage',
-        'signature-cache-size',
-        'sys-msec',
-        'udp-in-errors',
-        'udp-noport-errors',
-        'udp-recvbuf-errors',
-        'udp-sndbuf-errors',
-        'uptime',
-        'user-msec'
-    ]
 
     SERVICE_CHECK_NAME = 'powerdns.authoritative.can_connect'
 
@@ -79,11 +23,7 @@ class PowerDNSAuthoritativeCheck(AgentCheck):
         stats = self._get_pdns_stats(config)
         for stat in stats:
             self.log.debug('powerdns.authoritative.{}:{}'.format(stat['name'], stat['value']))
-
-            if stat['name'] in PowerDNSAuthoritativeCheck.GAUGE_METRICS:
-                self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
-            elif stat['name'] in PowerDNSAuthoritativeCheck.RATE_METRICS:
-                self.rate('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+            self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
 
     def _get_config(self, instance):
         required = ['host', 'port', 'api_key']

--- a/powerdns_authoritative/check.py
+++ b/powerdns_authoritative/check.py
@@ -117,5 +117,5 @@ class PowerDNSAuthoritativeCheck(AgentCheck):
             raise
         self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
                            tags=service_check_tags)
-	    self.log.debug(request.json())
+        self.log.debug(request.json())
         return request.json()

--- a/powerdns_authoritative/check.py
+++ b/powerdns_authoritative/check.py
@@ -23,7 +23,10 @@ class PowerDNSAuthoritativeCheck(AgentCheck):
         stats = self._get_pdns_stats(config)
         for stat in stats:
             self.log.debug('powerdns.authoritative.{}:{}'.format(stat['name'], stat['value']))
-            self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+            if 'status' or 'usage' or 'size' in stat['name']:
+                self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+            else:
+                self.rate('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
 
     def _get_config(self, instance):
         required = ['host', 'port', 'api_key']

--- a/powerdns_authoritative/check.py
+++ b/powerdns_authoritative/check.py
@@ -103,7 +103,7 @@ class PowerDNSAuthoritativeCheck(AgentCheck):
         return Config(host, port, api_key), tags
 
     def _get_pdns_stats(self, config):
-        url = "http://{}:{}/servers/localhost/statistics".format(config.host, config.port)
+        url = "http://{}:{}/api/v1/servers/localhost/statistics".format(config.host, config.port)
         service_check_tags = ['authoritative_host:{}'.format(config.host), 'authoritative_port:{}'.format(config.port)]
         headers = {"X-API-Key": config.api_key}
         try:

--- a/powerdns_authoritative/check.py
+++ b/powerdns_authoritative/check.py
@@ -78,6 +78,8 @@ class PowerDNSAuthoritativeCheck(AgentCheck):
         config, tags = self._get_config(instance)
         stats = self._get_pdns_stats(config)
         for stat in stats:
+            self.log.debug('powerdns.authoritative.{}:{}'.format(stat['name'], stat['value']))
+
             if stat['name'] in PowerDNSAuthoritativeCheck.GAUGE_METRICS:
                 self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
             elif stat['name'] in PowerDNSAuthoritativeCheck.RATE_METRICS:
@@ -115,4 +117,5 @@ class PowerDNSAuthoritativeCheck(AgentCheck):
             raise
         self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
                            tags=service_check_tags)
+	    self.log.debug(request.json())
         return request.json()

--- a/powerdns_authoritative/check.py
+++ b/powerdns_authoritative/check.py
@@ -1,10 +1,8 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
-
 # stdlib
+from collections import namedtuple
 
 # 3rd party
+import requests
 
 # project
 from checks import AgentCheck
@@ -12,10 +10,109 @@ from checks import AgentCheck
 EVENT_TYPE = SOURCE_TYPE_NAME = 'powerdns_authoritative'
 
 
-class Powerdns_authoritativeCheck(AgentCheck):
+class PowerDNSAuthoritativeCheck(AgentCheck):
+    # See https://doc.powerdns.com/md/authoritative/stats/ for metrics explanation
+    GAUGE_METRICS = [
+        'corrupt-packets',
+        'deferred-cache-inserts',
+        'deferred-cache-lookup',
+        'dnsupdate-answers',
+        'dnsupdate-changes',
+        'dnsupdate-queries',
+        'dnsupdate-refused',
+        'incoming-notifications',
+        'packetcache-hit',
+        'packetcache-miss',
+        'packetcache-size',
+        'query-cache-hit',
+        'query-cache-miss',
+        'rd-queries',
+        'recursing-answers',
+        'recursing-questions',
+        'recursion-unanswered',
+        'security-status',
+        'servfail-packets',
+        'signatures',
+        'tcp-answers',
+        'tcp-answers-bytes',
+        'tcp-queries',
+        'tcp4-answers',
+        'tcp4-answers-bytes',
+        'tcp4-queries',
+        'tcp6-answers',
+        'tcp6-answers-bytes',
+        'tcp6-queries',
+        'timedout-packets',
+        'udp-answers',
+        'udp-answers-bytes',
+        'udp-do-queries',
+        'udp-queries',
+        'udp4-answers',
+        'udp4-answers-bytes',
+        'udp4-queries',
+        'udp6-answers',
+        'udp6-answers-bytes',
+        'udp6-queries',
+        'fd-usage',
+        'key-cache-size',
+        'latency',
+        'meta-cache-size',
+        'qsize-q',
+        'real-memory-usage',
+        'signature-cache-size',
+        'sys-msec',
+        'udp-in-errors',
+        'udp-noport-errors',
+        'udp-recvbuf-errors',
+        'udp-sndbuf-errors',
+        'uptime',
+        'user-msec'
+    ]
+
+    SERVICE_CHECK_NAME = 'powerdns.authoritative.can_connect'
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
     def check(self, instance):
-        pass
+        config, tags = self._get_config(instance)
+        stats = self._get_pdns_stats(config)
+        for stat in stats:
+            if stat['name'] in PowerDNSAuthoritativeCheck.GAUGE_METRICS:
+                self.gauge('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+            elif stat['name'] in PowerDNSAuthoritativeCheck.RATE_METRICS:
+                self.rate('powerdns.authoritative.{}'.format(stat['name']), float(stat['value']), tags=tags)
+
+    def _get_config(self, instance):
+        required = ['host', 'port', 'api_key']
+        for param in required:
+            if not instance.get(param):
+                raise Exception("powerdns_authoritative instance missing %s. Skipping." % (param))
+
+        host = instance.get('host')
+        port = int(instance.get('port'))
+        api_key = instance.get('api_key')
+        tags = instance.get('tags', [])
+
+        Config = namedtuple('Config', [
+            'host',
+            'port',
+            'api_key']
+        )
+
+        return Config(host, port, api_key), tags
+
+    def _get_pdns_stats(self, config):
+        url = "http://{}:{}/servers/localhost/statistics".format(config.host, config.port)
+        service_check_tags = ['authoritative_host:{}'.format(config.host), 'authoritative_port:{}'.format(config.port)]
+        headers = {"X-API-Key": config.api_key}
+        try:
+            request = requests.get(url, headers=headers)
+            request.raise_for_status()
+        except Exception:
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                               tags=service_check_tags)
+            raise
+        self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
+                           tags=service_check_tags)
+        return request.json()

--- a/powerdns_authoritative/ci/powerdns_authoritative.rake
+++ b/powerdns_authoritative/ci/powerdns_authoritative.rake
@@ -1,0 +1,64 @@
+require 'ci/common'
+
+def powerdns_authoritative_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def powerdns_authoritative_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/powerdns_authoritative_#{powerdns_authoritative_version}"
+end
+
+namespace :ci do
+  namespace :powerdns_authoritative do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('powerdns_authoritative/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name powerdns_authoritative source/powerdns_authoritative:powerdns_authoritative_version)
+      # sh %(docker start powerdns_authoritative)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'powerdns_authoritative'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop powerdns_authoritative)
+    #   sh %(docker rm powerdns_authoritative)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/powerdns_authoritative/conf.yaml.example
+++ b/powerdns_authoritative/conf.yaml.example
@@ -1,0 +1,11 @@
+init_config:
+  # Any global configurable parameters should be added here
+
+instances:
+  #   A typical instance configuration might include a hostname and port
+  #   a set of customizable tags and other parameters we might need to
+  #   configure the behavior of our check.
+  #
+  # - host: localhost
+  #   port: 26379
+  #   tags: ['custom:tag']

--- a/powerdns_authoritative/conf.yaml.example
+++ b/powerdns_authoritative/conf.yaml.example
@@ -1,11 +1,22 @@
 init_config:
-  # Any global configurable parameters should be added here
 
 instances:
-  #   A typical instance configuration might include a hostname and port
-  #   a set of customizable tags and other parameters we might need to
-  #   configure the behavior of our check.
+  # The PowerDNS Authoritative check retrieves metrics from the web server.
+  # See https://doc.powerdns.com/md/httpapi/README/
+  #     https://doc.powerdns.com/md/authoritative/performance/
   #
-  # - host: localhost
-  #   port: 26379
-  #   tags: ['custom:tag']
+  # This check works with PowerDNS authoritative 4.x.
+
+
+
+  # Host running the name server.
+  - host: 127.0.0.1
+  # name server web server port.
+    port: 8082
+  # name server web server api key.
+    api_key: pdns_api_key
+
+  # Optional tags to be applied to every emitted metric.
+    # tags:
+    #   - key:value
+    #   - instance:production

--- a/powerdns_authoritative/manifest.json
+++ b/powerdns_authoritative/manifest.json
@@ -1,0 +1,11 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "powerdns_authoritative",
+  "short_description": "powerdns_authoritative description.",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/powerdns_authoritative/metadata.csv
+++ b/powerdns_authoritative/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/powerdns_authoritative/requirements.txt
+++ b/powerdns_authoritative/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/powerdns_authoritative/test_powerdns_authoritative.py
+++ b/powerdns_authoritative/test_powerdns_authoritative.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='powerdns_authoritative')
+class TestPowerdns_authoritative(AgentCheckTest):
+    """Basic Test for powerdns_authoritative integration."""
+    CHECK_NAME = 'powerdns_authoritative'
+
+    def test_check(self):
+        """
+        Testing Powerdns_authoritative check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()


### PR DESCRIPTION
### What does this PR do?

This PR adds support for PowerDNS Authoritative server metrics.

Originally written by @joewilliams (https://github.com/DataDog/dd-agent/pull/2850)

### Motivation

We need the metrics.