### PR TITLE
[snmpwalk] adding integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ install:
 script:
   - bundle exec rake prep_travis_ci
   - rake ci:run
+  - rake ci:run[snmpwalk]
   - bundle exec rake requirements
 
 # we should clean generated files before we save the cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
     # END OF TRAVIS MATRIX
 
 before_install:
-  - sudo apt-get update ; sudo apt-get install -y curl apt-transport-https git
+  - sudo apt-get update ; sudo apt-get install -y curl apt-transport-https git snmp snmp-mibs-downloader
 
 install:
   - bundle install

--- a/circle.yml
+++ b/circle.yml
@@ -10,15 +10,17 @@ machine:
         VOLATILE_DIR: '/tmp/integration-sdk-testing'
         SKIP_CLEANUP: 'true'
         INTEGRATIONS_DIR: "$HOME/embedded"
+        CI_BUILD_DIR: "$HOME/$CIRCLE_PROJECT_REPONAME"
         PIP_CACHE: "$HOME/.cache/pip"
         SDK_TESTING: "true"
         DD_AGENT_BRANCH: "master"
 
 dependencies:
     pre:
-        - sudo apt-get update ; sudo apt-get install -y curl apt-transport-https git
+        - sudo apt-get update ; sudo apt-get install -y curl apt-transport-https git snmp snmp-mibs-downloader
         - git clone -b $DD_AGENT_BRANCH --depth 1 https://github.com/DataDog/dd-agent.git $HOME/dd-agent
         - echo "$HOME/dd-agent/" > $(dirname $(pyenv which python))/../lib/python2.7/site-packages/datadog-agent.pth
+        - echo "$HOME/dd-agent/" > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/datadog-agent.pth
         - pip install pip --upgrade
         - pip install docker-compose
         - pip install pylint

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ test:
     override:
         - bundle exec rake prep_travis_ci
         - rake ci:run[default]
+        - rake ci:run[snmpwalk]
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/snmpwalk/README.md
+++ b/snmpwalk/README.md
@@ -1,0 +1,32 @@
+# Snmpwalk Integration
+
+## Overview
+
+Get metrics from snmpwalk service in real time to:
+
+* Visualize and monitor snmpwalk states
+* Be notified about snmpwalk failovers and events.
+
+## Installation
+
+Install the `dd-check-snmpwalk` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `snmpwalk.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        snmpwalk
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The snmpwalk check is compatible with all major platforms

--- a/snmpwalk/check.py
+++ b/snmpwalk/check.py
@@ -1,0 +1,196 @@
+# stdlib
+from collections import defaultdict
+from subprocess import check_output, CalledProcessError
+import re
+
+# 3rd party
+
+# project
+from checks.network_checks import NetworkCheck, Status
+
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'snmpwrap'
+
+class SnmpwalkCheck(NetworkCheck):
+    '''
+    This is a work-alike for checks.d/snmp.py that makes use of snmpwalk for
+    performance reasons. It's much faster than making the calls directly with
+    pysnmp in our use-cases. It is not a 100% reimplementation. It only supports
+    the functionality that we currently use. Other differences include:
+        * regex matching for dynamic tagging w/additional_tags
+        * tags using "enum" values emit the human-readable form instead of the
+          integer.
+    '''
+
+    DEFAULT_RETRIES = 2
+    DEFAULT_TIMEOUT = 1
+    COUNTER_TYPES = frozenset(('Counter32', 'Counter64', 'ZeroBasedCounter64'))
+    GAUGE_TYPES = frozenset(('Gauge32', 'Unsigned32', 'CounterBasedGauge64',
+                             'INTEGER', 'Integer32'))
+    SC_STATUS = 'snmp.can_check'
+
+    # regex for parsing the output of snmp walk
+    output_re = re.compile(r'([\w\-]+)::(?P<symbol>\w+)\.(?P<index>\d+) = '
+                        r'(?P<type>\w+): (?P<value>.*)$')
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        for instance in instances:
+            # if we don't have a name add one, but mark skip_event so that we
+            # don't emit the event
+            if 'name' not in instance:
+                instance['name'] = self._get_instance_name(instance)
+            instance['skip_event'] = True
+
+        NetworkCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def _get_instance_name(self, instance):
+        host = instance.get('host', None)
+        ip = instance.get('ip_address', None)
+        port = instance.get('port', None)
+        if host and port:
+            key = "{host}:{port}".format(host=host, port=port)
+        elif ip and port:
+            key = "{host}:{port}".format(host=ip, port=port)
+        elif host:
+            key = host
+        elif ip:
+            key = ip
+
+        return key
+
+    def _check(self, instance):
+        ip_address = instance["ip_address"]
+        metrics = instance.get('metrics', [])
+        community_string = instance.get('community_string', 'public')
+        timeout = int(instance.get('timeout', self.DEFAULT_TIMEOUT))
+        retries = int(instance.get('retries', self.DEFAULT_RETRIES))
+
+        hostname = instance.get('metric_host', None)
+
+        # Build up our dataset
+        data = defaultdict(dict)
+        types = {}
+        for metric in metrics:
+            mib = metric['MIB']
+            table = metric['table']
+            cmd = ['/usr/bin/snmpwalk', '-c{}'.format(community_string),
+                   '-v2c', '-t', str(timeout), '-r', str(retries), ip_address,
+                   '{}:{}'.format(mib, table)]
+
+            try:
+                output = check_output(cmd)
+            except CalledProcessError as e:
+                error = "Fail to collect metrics for {0} - {1}" \
+                    .format(instance['name'], e)
+                self.log.warning(error)
+                return [(self.SC_STATUS, Status.CRITICAL, error)]
+
+            for line in output.split('\n'):
+                if line == '':
+                    continue
+                match = self.output_re.match(line)
+                if match is not None:
+                    symbol = match.group('symbol')
+                    index = int(match.group('index'))
+                    value = match.group('value')
+                    typ = match.group('type')
+                    types[symbol] = typ
+                    if typ == 'INTEGER':
+                        try:
+                            value = int(value)
+                        except ValueError:
+                            pass
+                    elif value == '':
+                        value = None
+                    data[symbol][index] = value
+                else:
+                    # TODO: remove this
+                    self.log.warning('Problem parsing output of snmp walk: %s',
+                                     line)
+
+        # Get any base configured tags and add our primary tag
+        tags = instance.get('tags', []) + [
+            'snmp_device:{}'.format(ip_address),
+        ]
+
+        # It seems kind of weird, but from what I can tell the snmp check allows
+        # you to add symbols to a metric that were retrieved by another metric,
+        # both for values and tags. So you can add a symbol in the 1st metric
+        # that pulls data from the 2nd. Same applies to tag lookups. Seems like
+        # symbols should have been at the instance level rather than
+        # per-metric... That way the bahavior would match up with schema, but oh
+        # well.
+
+        # Time to emit metrics
+        for metric in metrics:
+
+            # Build a list of dynamic tags per-index
+            dynamic_tags = defaultdict(list)
+            for metric_tag in metric.get('metric_tags', []):
+                if 'column' in metric_tag:
+                    tag = metric_tag['tag']
+                    column = metric_tag['column']
+                    regex = metric_tag.get('regex', None)
+                    if regex is not None:
+                        # pre-compile our regex
+                        regex = re.compile(regex)
+                    for i, v in data[column].items():
+                        if v is None:
+                            # No value for the column, ignore
+                            continue
+                        elif types[column] == 'INTEGER':
+                            # enum/bool etc, use the human readable name
+                            v = v.split('(')[0]
+
+                        if regex is not None:
+                            # There's a regex for this tag
+                            match = regex.match(v)
+                            if match is not None:
+                                # It matches so we'll apply it, group(1) becomes
+                                # the value
+                                v = match.group(1)
+                                dynamic_tags[i].append('{}:{}' .format(tag, v))
+                                additional_tags = \
+                                    metric_tag.get('additional_tags', [])
+                                # and we add any additional tags
+                                dynamic_tags[i].extend(additional_tags)
+                        else:
+                            # This is a standard tag, just use the value
+                            dynamic_tags[i].append('{}:{}'.format(tag, v))
+                else:
+                    raise Exception('unsupported metric_tag: {}'
+                                    .format(metric_tag))
+
+            symbols = metric.get('symbols', [])
+            # For each of the symbols we'll be recording as a metric
+            for symbol in symbols:
+                # For each value for that symbol
+                for i, value in data[symbol].items():
+                    if value is None:
+                        # skip empty
+                        continue
+                    # metric key
+                    key = 'snmp.{}'.format(symbol)
+                    value = int(value)
+
+                    typ = types[symbol]
+                    if typ in self.COUNTER_TYPES:
+                        self.rate(key, value, tags + dynamic_tags[i],
+                                  hostname=hostname)
+                    elif typ in self.GAUGE_TYPES:
+                        self.gauge(key, value, tags + dynamic_tags[i],
+                                   hostname=hostname)
+                    else:
+                        raise Exception('unsupported metric symbol type: {}'
+                                        .format(typ))
+
+        return [(self.SC_STATUS, Status.UP, None)]
+
+    def report_as_service_check(self, sc_name, status, instance, msg=None):
+        sc_tags = ['snmp_device:{0}'.format(instance["ip_address"])]
+        custom_tags = instance.get('tags', [])
+        tags = sc_tags + custom_tags
+
+        self.service_check(sc_name,
+                           NetworkCheck.STATUS_TO_SERVICE_CHECK[status],
+                           tags=tags, message=msg)

--- a/snmpwalk/ci/resources/snmpd.conf
+++ b/snmpwalk/ci/resources/snmpd.conf
@@ -1,0 +1,1 @@
+rocommunity    public

--- a/snmpwalk/ci/snmpwalk.rake
+++ b/snmpwalk/ci/snmpwalk.rake
@@ -1,0 +1,61 @@
+require 'ci/common'
+
+def snmpwalk_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def snmpwalk_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/snmpwalk_#{snmpwalk_version}"
+end
+
+namespace :ci do
+  namespace :snmpwalk do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task install: ['ci:common:install'] do
+      use_venv = in_venv
+      install_requirements('snmpwalk/requirements.txt',
+                           "--cache-dir #{ENV['PIP_CACHE']}",
+                           "#{ENV['VOLATILE_DIR']}/ci.log", use_venv)
+      sh %( docker run -d --name snmpwalk -p 11111:161/udp polinux/snmpd -c /etc/snmp/snmpd.conf)
+      Wait.for 11111
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'snmpwalk'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup'] do
+      sh %(docker stop snmpwalk)
+      sh %(docker rm snmpwalk)
+    end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script).each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        Rake::Task["#{flavor.scope.path}:script"].invoke
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/snmpwalk/conf.yaml.example
+++ b/snmpwalk/conf.yaml.example
@@ -1,0 +1,81 @@
+init_config:
+#    #You can specify an additional folder for your custom mib files (python format)
+#    mibs_folder: /path/to/your/mibs/folder
+#    ignore_nonincreasing_oid: False
+
+instances:
+
+  # SNMP v1-v2 configuration
+  #
+  # - ip_address: localhost
+  #   port: 161
+  #   community_string: public
+  #   snmp_version: 2 # Only required for snmp v1, will default to 2
+  #   timeout: 1 # second, by default
+  #   retries: 5
+  #   enforce_mib_constraints: true  # if set to false we will not check the values
+  #                                  # returned meet the MIB constraints. Defaults to True.
+  #   tags:
+  #     - optional_tag_1
+  #     - optional_tag_2
+  #
+  #   # Specify metrics you want to monitor
+  #   metrics:
+  #     # You can specify metrics using MIBS (Counter and Gauge)
+  #     - MIB: UDP-MIB
+  #       symbol: udpInDatagrams
+  #     - MIB: TCP-MIB
+  #       symbol: tcpActiveOpens
+  #     # If it's just a scalar, you can specify by OID and name it
+  #     - OID: 1.3.6.1.2.1.6.5
+  #       name: tcpPassiveOpens
+  #
+  #     # This monitor auto-detects OID data types from the remote agent's response.
+  #     # If you're dealing with a buggy agent that returns incorrect data types for OIDs,
+  #     # You can force the data type with the 'forced_type' parameter.  Valid options for
+  #     # this parameter are 'gauge' and 'counter'.
+  #     # Example: When a F5 Networks load balancer is queried for this OID, it will return
+  #     # it as a Counter64 when it should be a gauge.  So, we force the data type to gauge:
+  #     - OID: 1.3.6.1.4.1.3375.2.1.1.2.1.8.0
+  #       name: F5_TotalCurrentConnections
+  #       forced_type: gauge
+  #
+  #     # You can also query a table and specify
+  #     #   - which columns to report as value (symbols)
+  #     #   - which columns / indexes to use as tags (metric_tags)
+  #     - MIB: IF-MIB
+  #       table: ifTable
+  #       symbols:
+  #         - ifInOctets
+  #         - ifOutOctets
+  #       metric_tags:
+  #         - tag: interface
+  #           column: ifDescr  # specify which column to read the tag value from
+  #     - MIB: IP-MIB
+  #       table: ipSystemStatsTable
+  #       symbols:
+  #         - ipSystemStatsInReceives
+  #       metric_tags:
+  #         - tag: ipversion
+  #           index: 1        # specify which index you want to read the tag value from
+
+  # SNMP v3 configuration
+  # check http://pysnmp.sourceforge.net/docs/current/security-configuration.html
+  #
+  # - ip_address: 192.168.34.10
+  #   # port: 161 # default value
+  #   user: user
+  #   authKey: password
+  #   privKey: private_key
+  #   authProtocol: authProtocol
+  #   privProtocol: privProtocol
+  #   timeout: 1 # second, by default
+  #   retries: 5
+  #   tags:
+  #     - optional_tag_1
+  #     - optional_tag_2
+  #   metrics:
+  #     - MIB: UDP-MIB
+  #       symbol: udpInDatagrams
+  #     - MIB: TCP-MIB
+  #       symbol: tcpActiveOpens

--- a/snmpwalk/conf.yaml.example
+++ b/snmpwalk/conf.yaml.example
@@ -1,7 +1,9 @@
 init_config:
-#    #You can specify an additional folder for your custom mib files (python format)
-#    mibs_folder: /path/to/your/mibs/folder
-#    ignore_nonincreasing_oid: False
+#    #You can specify paths to your MIB files (default:
+#                     $HOME/.snmp/mibs:/usr/share/snmp/mibs:/usr/share/snmp/mibs/iana:
+#                     /usr/share/snmp/mibs/ietf:/usr/share/mibs/site:/usr/share/snmp/mibs:
+#                     /usr/share/mibs/iana:/usr/share/mibs/ietf:/usr/share/mibs/netsnmp)
+#    mibs_folders: /path/to/your/mibs/folders:/more/paths:/another/one
 
 instances:
 
@@ -13,36 +15,12 @@ instances:
   #   snmp_version: 2 # Only required for snmp v1, will default to 2
   #   timeout: 1 # second, by default
   #   retries: 5
-  #   enforce_mib_constraints: true  # if set to false we will not check the values
-  #                                  # returned meet the MIB constraints. Defaults to True.
   #   tags:
   #     - optional_tag_1
   #     - optional_tag_2
   #
   #   # Specify metrics you want to monitor
   #   metrics:
-  #     # You can specify metrics using MIBS (Counter and Gauge)
-  #     - MIB: UDP-MIB
-  #       symbol: udpInDatagrams
-  #     - MIB: TCP-MIB
-  #       symbol: tcpActiveOpens
-  #     # If it's just a scalar, you can specify by OID and name it
-  #     - OID: 1.3.6.1.2.1.6.5
-  #       name: tcpPassiveOpens
-  #
-  #     # This monitor auto-detects OID data types from the remote agent's response.
-  #     # If you're dealing with a buggy agent that returns incorrect data types for OIDs,
-  #     # You can force the data type with the 'forced_type' parameter.  Valid options for
-  #     # this parameter are 'gauge' and 'counter'.
-  #     # Example: When a F5 Networks load balancer is queried for this OID, it will return
-  #     # it as a Counter64 when it should be a gauge.  So, we force the data type to gauge:
-  #     - OID: 1.3.6.1.4.1.3375.2.1.1.2.1.8.0
-  #       name: F5_TotalCurrentConnections
-  #       forced_type: gauge
-  #
-  #     # You can also query a table and specify
-  #     #   - which columns to report as value (symbols)
-  #     #   - which columns / indexes to use as tags (metric_tags)
   #     - MIB: IF-MIB
   #       table: ifTable
   #       symbols:
@@ -75,7 +53,18 @@ instances:
   #     - optional_tag_1
   #     - optional_tag_2
   #   metrics:
-  #     - MIB: UDP-MIB
-  #       symbol: udpInDatagrams
-  #     - MIB: TCP-MIB
-  #       symbol: tcpActiveOpens
+  #     - MIB: IF-MIB
+  #       table: ifTable
+  #       symbols:
+  #         - ifInOctets
+  #         - ifOutOctets
+  #       metric_tags:
+  #         - tag: interface
+  #           column: ifDescr  # specify which column to read the tag value from
+  #     - MIB: IP-MIB
+  #       table: ipSystemStatsTable
+  #       symbols:
+  #         - ipSystemStatsInReceives
+  #       metric_tags:
+  #         - tag: ipversion
+  #           index: 1        # specify which index you want to read the tag value from

--- a/snmpwalk/manifest.json
+++ b/snmpwalk/manifest.json
@@ -1,0 +1,12 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "snmpwalk",
+  "short_description": "snmpwalk description.",
+  "guid": "a2864821-994c-4ebb-8532-b6879ea9a9ab",
+  "support": "contrib",
+  "supported_os": ["linux","mac_os","windows"],
+  "version": "0.1.0"
+}

--- a/snmpwalk/metadata.csv
+++ b/snmpwalk/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/snmpwalk/requirements.txt
+++ b/snmpwalk/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/snmpwalk/test_snmpwalk.py
+++ b/snmpwalk/test_snmpwalk.py
@@ -1,0 +1,104 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import os
+import copy
+import time
+
+# 3p
+from nose.plugins.attrib import attr
+
+# project
+from checks import AgentCheck
+from tests.checks.common import AgentCheckTest
+
+
+RESULTS_TIMEOUT = 10
+
+@attr(requires='snmpwalk')
+class TestSnmpwalk(AgentCheckTest):
+    """Basic Test for snmpwrap integration."""
+    CHECK_NAME = 'snmpwrap'
+    FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'ci')
+
+    INSTANCE_CONF = {
+        'ip_address': "localhost",
+        'port': 11111,
+        'community_string': "public",
+    }
+    CONFIG = {
+        'init_config': {},
+        'instances' : [INSTANCE_CONF]
+    }
+
+    TABULAR_OBJECTS = [{
+        'MIB': "IF-MIB",
+        'table': "ifTable",
+        'symbols': ["ifInOctets", "ifOutOctets"],
+        'metric_tags': [
+            {
+                'tag': "interface",
+                'column': "ifDescr"
+            }, {
+                'tag': "dumbindex",
+                'index': 1
+            }
+        ]
+    }]
+
+    def tearDown(self):
+        if self.check:
+            self.check.stop()
+
+    @classmethod
+    def generate_instance_config(cls, metrics):
+        instance_config = copy.copy(cls.SNMP_CONF)
+        instance_config['metrics'] = metrics
+        instance_config['name'] = "localhost"
+        return instance_config
+
+    def wait_for_async(self, method, attribute, count):
+        """
+        Loop on `self.check.method` until `self.check.attribute >= count`.
+
+        Raise after
+        """
+        i = 0
+        while i < RESULTS_TIMEOUT:
+            self.check._process_results()
+            if len(getattr(self.check, attribute)) >= count:
+                return getattr(self.check, method)()
+            time.sleep(1)
+            i += 1
+        raise Exception("Didn't get the right count for {attribute} in time, {total}/{expected} in {seconds}s: {attr}"
+                        .format(attribute=attribute, total=len(getattr(self.check, attribute)), expected=count, seconds=i,
+                                attr=getattr(self.check, attribute)))
+
+
+    def test_check(self):
+        """
+        Testing Snmpwrap check.
+        """
+        config = {
+            'instances': [self.generate_instance_config(self.TABULAR_OBJECTS)]
+        }
+        self.run_check_n(config, repeat=3, sleep=2)
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+
+        # Test metrics
+        for symbol in self.TABULAR_OBJECTS[0]['symbols']:
+            metric_name = "snmp." + symbol
+            self.assertMetric(metric_name, at_least=1)
+            self.assertMetricTag(metric_name, self.CHECK_TAGS[0], at_least=1)
+
+            for mtag in self.TABULAR_OBJECTS[0]['metric_tags']:
+                tag = mtag['tag']
+                self.assertMetricTagPrefix(metric_name, tag, at_least=1)
+
+        # Test service check
+        self.assertServiceCheck("snmp.can_check", status=AgentCheck.OK,
+                                tags=self.CHECK_TAGS, count=1)
+
+        self.coverage_report()


### PR DESCRIPTION
### What's this PR do?

Provides a wrapper to the snmpwalk binary.

This integration, originally written by @ross here https://gist.github.com/ross/0f6b7cc57bc3f42e93292fbafc6e1194 is a wrapper on snmpwalk and should behave similarly to the original SNMP integration (https://github.com/DataDog/integrations-core/pull/110).

### Motivation

This was written by @ross as a faster alternative to the original integration. It's merely a parser for the seriously quicker snmpwalk binary. So if you're collecting large volumes of metrics by walking, this provides a means to keep your CPU low with a much quicker check. It's not as feature rich, but may help in numerous use-cases.

This integration relies on the `snmpwalk` binary. This is a hard requirement.
