### PR TITLE
add nsd agent check

### DIFF
--- a/nsd/check.py
+++ b/nsd/check.py
@@ -1,0 +1,40 @@
+# stdlib
+import os
+import re
+
+# project
+from checks import AgentCheck
+from config import _is_affirmative
+from util import Platform
+from utils.subprocess_output import get_subprocess_output
+
+class NsdCheck(AgentCheck):
+    # Stats info https://www.nlnetlabs.nl/projects/nsd/nsd-control.8.html
+
+    NSD_CTL = ['nsd-control', 'stats']
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances=instances)
+        if instances is not None and len(instances) > 1:
+            raise Exception("NSD check only supports one configured instance.")
+
+    def check(self, instance):
+        if instance is None:
+            instance = {}
+
+        host = instance.get('host')
+        tags = instance.get('tags', [])
+
+        nsd_out, _, _ = get_subprocess_output(self.NSD_CTL + ['-s', host], self.log)
+        self.log.debug(self.NSD_CTL + ['-s', host])
+        self.log.debug(nsd_out)
+
+        data = re.findall(r'(\S+)=(.*\d)', nsd_out)
+
+        for stat in data:
+            self.log.debug('nsd.{}:{}'.format(stat[0], stat[1]))
+
+            if 'num.' in stat[0]:
+                self.rate('nsd.{}'.format(stat[0]), float(stat[1]), tags=tags)
+            else:
+                self.gauge('nsd.{}'.format(stat[0]), float(stat[1]), tags=tags)

--- a/nsd/conf.yaml.example
+++ b/nsd/conf.yaml.example
@@ -1,0 +1,9 @@
+# dd-agent needs permissions to read:
+# /etc/nsd/nsd_control.pem
+# /etc/nsd/nsd_control.key
+# /etc/nsd/nsd_server.pem
+
+init_config:
+
+instances:
+  - host: 127.0.0.1


### PR DESCRIPTION


### What does this PR do?

Adds a check for the nsd authoritative dns server daemon.

### Motivation

We use nsd.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
