### PR TITLE
[hbase_master, hbase_regionserver] fix connection error to HBase JMX server in ci test

### DIFF
--- a/hbase_master/ci/hbase_master.rake
+++ b/hbase_master/ci/hbase_master.rake
@@ -14,11 +14,27 @@ namespace :ci do
 
     task :install do
       Rake::Task['ci:common:install'].invoke('hbase_master')
+      # run zookeeper and wait until it is up
       sh %(docker-compose -f \
-           #{ENV['TRAVIS_BUILD_DIR']}/hbase_master/ci/resources/docker-compose-hbase.yaml up -d)
+           #{ENV['TRAVIS_BUILD_DIR']}/hbase_master/ci/resources/docker-compose-hbase.yaml up -d zookeeper)
+      wait_on_docker_logs('resources_zookeeper_1', '30', 'Zookeeper Admin Concole:', 'http://localhost:8080/commands')
+      Wait.for 2181
+      # run hadoop and wait until it is up.
+      sh %(docker-compose -f \
+           #{ENV['TRAVIS_BUILD_DIR']}/hbase_master/ci/resources/docker-compose-hbase.yaml up -d hadoop)
+      wait_on_docker_logs('resources_hadoop_1', '30', 'NameNode:', 'http://localhost:50070')
+      Wait.for 8020
+      Wait.for 50_070
+      Wait.for 8042
+      Wait.for 50_075
+      # run zookeeper and wait until it is up
+      sh %(docker-compose -f \
+           #{ENV['TRAVIS_BUILD_DIR']}/hbase_master/ci/resources/docker-compose-hbase.yaml up -d hbase)
+      wait_on_docker_logs('resources_hbase_1', '30', 'HBase Master', 'http://localhost:60010', 'HBase Region Server', 'http://localhost:60030')
       Wait.for 10_101
       Wait.for 10_102
-      wait_on_docker_logs('resources_hbase_1', '30', 'HBase Master', 'http://localhost:60010', 'HBase Region Server', 'http://localhost:60030')
+      Wait.for 60_010
+      Wait.for 60_030
     end
 
     task before_script: ['ci:common:before_script']


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

- This fixes [#71: `hbase_master` and `hbase_regionserver` tests broken.](https://github.com/DataDog/integrations-extras/issues/71)
- Changes in this PR: improved start up sequence of hbase pseudo cluster used in ci test. (see below for details)

### Motivation

- To prevent blocking dev/release cycle of integration-extras repo

<!-- ### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines. -->

### Versioning
_the change affects only to ci tests_

- NONE: Bumped the version check in `manifest.json`
- NONE: Updated `CHANGELOG.md`



### Additional Notes

Root cause of the issue (#71) was that `docker-compose up` using in test sometime fails to start up hbase pseudo dist cluster because `docker-compose up` doesn't guarantees service dependencies(hbase depends on hadoop and zookeeper, hadoop depends on zookeeper).  Unfortunately this failure cannot be seen from test script.

So, I introduced controlled startup sequence which means test script spawns zookeeper, hadoop, hbase step by step and each step asserts required ports become ready.