### PR TITLE
Remove bundler installation from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,6 @@ services:
 install:
   # Use the 64-bit ruby so that all the Powershell classes are accessible when running shell commands from ruby
   - set PATH=C:\Ruby22-x64\bin;%PATH%
-  - gem install bundler --quiet --no-ri --no-rdoc
   - bundle install
   - bundle package
   - git clone -b %DD_AGENT_BRANCH% https://github.com/DataDog/dd-agent.git c:\projects\dd-agent


### PR DESCRIPTION
### What does this PR do?

Remove `bundler` during the AppVeyor build.

A brief description of the change being made with this pull request.

### Motivation

It's already present on the image and builds are failing.

