### PR TITLE
Giladsh/filebeat check fix

### DIFF
--- a/filebeat/CHANGELOG.md
+++ b/filebeat/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.1.1
+[giladsh]
+- fixed registrty file parsing error - the file contains a list of dictionaries, not a dictionary
+- added and explicit file permission issue - since filebeat creates the file as root
+
+# 0.1.0
+initial version

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -7,5 +7,5 @@
   "short_description": "filebeat description.",
   "support": "contrib",
   "supported_os": ["linux","mac_os","windows"],
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
…e permissions issue

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

- fixed registry file parsing error - the file contains a list of dictionaries, not a dictionary
- added and explicit file permission issue - since filebeat creates the file as root

### Motivation

the fails to run with filebeat 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
