### PR TITLE
UPS Battery Integration via upsc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ env:
     - TRAVIS_FLAVOR=logstash FLAVOR_VERSION=latest
     - TRAVIS_FLAVOR=stardog FLAVOR_VERSION=latest
     - TRAVIS_FLAVOR=reboot_required FLAVOR_VERSION=latest
+    - TRAVIS_FLAVOR=upsc FLAVOR_VERSION=latest
     # END OF TRAVIS MATRIX
 
 before_install:

--- a/circle.yml
+++ b/circle.yml
@@ -47,6 +47,7 @@ test:
         - TRAVIS_FLAVOR="storm" bundle exec rake ci:run
         - TRAVIS_FLAVOR="logstash" bundle exec rake ci:run
         - TRAVIS_FLAVOR="stardog" bundle exec rake ci:run
+        - TRAVIS_FLAVOR="upsc" bundle exec rake ci:run
         - bundle exec rake requirements
     post:
         - if [[ $(docker ps -a -q) ]]; then docker stop $(docker ps -a -q); fi

--- a/upsc/CHANGELOG.md
+++ b/upsc/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG - UPSC
+
+0.1.0/ Unreleased
+==================
+
+### Changes
+
+* [FEATURE] adds upsc stats collector integration.

--- a/upsc/README.md
+++ b/upsc/README.md
@@ -1,0 +1,32 @@
+# UPSC Stats Collector Integration
+
+## Overview
+
+Get metrics from UPSD service via upsc in real time to:
+
+* Visualize and monitor UPS battery health and states
+* Be notified about UPS failovers and events.
+
+## Installation
+
+Install the `dd-check-upsc` package manually or with your favorite configuration manager
+
+## Configuration
+
+Edit the `upsc.yaml` file to point to your server and port, set the masters to monitor
+
+## Validation
+
+When you run `datadog-agent info` you should see something like the following:
+
+    Checks
+    ======
+
+        upsc
+        -----------
+          - instance #0 [OK]
+          - Collected 39 metrics, 0 events & 7 service checks
+
+## Compatibility
+
+The UPSC check is compatible with linux-based platforms.

--- a/upsc/check.py
+++ b/upsc/check.py
@@ -29,7 +29,7 @@ class UpscCheck(AgentCheck):
         """
         try:
             results = subprocess.check_output(['upsc', '-l'], stderr=self.DEV_NULL)
-            return [r.lstrip().rstrip() for r in results.split('\n')]
+            return [r.strip() for r in results.split('\n')]
         except subprocess.CalledProcessError as e:
             self.log.error("Unable to query devices: %s", e)
             return []
@@ -47,7 +47,7 @@ class UpscCheck(AgentCheck):
             stats = {}
             for line in results.splitlines(False):
                 key, val = line.split(':', 1)
-                stats[key] = val.lstrip().rstrip()
+                stats[key] = val.strip()
             return stats
         except subprocess.CalledProcessError as e:
             self.log.error("Unable to query device %s" % name, e)
@@ -76,10 +76,10 @@ class UpscCheck(AgentCheck):
             if found_re:
                 continue
 
-            try:
-                value = float(v.lstrip().rstrip())
+            try:  # try a number conversion
+                value = float(v.strip())
                 results[k] = value
-            except Exception:
+            except Exception:  # this is a string value instead
                 if k == 'ups.status':
                     if v.lower().startswith('ol') or v.lower().startswith('on'):
                         results[k] = 1.0
@@ -121,8 +121,7 @@ class UpscCheck(AgentCheck):
         self.string_tags = list(self.DEFAULT_STRING_TAGS)
         self.string_tags.extend(instance.get('string_tags', []))
 
-        self.additional_tags = []
-        self.additional_tags.extend(instance.get('tags', []))
+        self.additional_tags = instance.get('tags', [])
 
         self.excluded = list(self.DEFAULT_EXCLUDED_TAGS)
         self.excluded.extend(instance.get('excluded', []))
@@ -130,8 +129,7 @@ class UpscCheck(AgentCheck):
         for excluded_regex in instance.get('excluded_re', []):
             self.excluded_re.append(re.compile(excluded_regex))
 
-        self.excluded_devices = []
-        self.excluded_devices.extend(instance.get('excluded_devices', []))
+        self.excluded_devices = instance.get('excluded_devices', [])
         self.excluded_devices_re = []
         for excluded_regex in instance.get('excluded_devices_re', []):
             self.excluded_devices_re.append(re.compile(excluded_regex))

--- a/upsc/check.py
+++ b/upsc/check.py
@@ -1,0 +1,134 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import os
+import re
+import subprocess
+
+# 3rd party
+
+# project
+from checks import AgentCheck
+
+EVENT_TYPE = SOURCE_TYPE_NAME = 'upsc'
+
+
+class UpscCheck(AgentCheck):
+
+    DEV_NULL = open(os.devnull, 'w')
+
+    def list_ups_devices(self):
+        """ Generate and return the list of configured devices.
+
+        :return: list of devices by name
+        :rtype: list[str]
+        """
+        try:
+            results = subprocess.check_output(['upsc', '-l'], stderr=self.DEV_NULL)
+            return results.splitlines(False)
+        except subprocess.CalledProcessError as e:
+            self.log.error("Unable to query devices", e)
+            return []
+
+    def query_ups_device(self, name):
+        """ Query ups device and return results
+
+        :param name: UPS device name from `list_ups_devices`
+        :type name: str
+        :return: raw results in simple form
+        :rtype: dict(str, str)
+        """
+        try:
+            results = subprocess.check_output(['upsc', name], stderr=self.DEV_NULL)
+            stats = {}
+            for line in results.splitlines(False):
+                key, val = line.split(':', 1)
+                stats[key] = val
+            return stats
+        except subprocess.CalledProcessError as e:
+            self.log.error("Unable to query device %s" % name, e)
+            return {}
+
+    def convert_and_filter_stats(self, stats):
+        """ Converts raw query stats to native python types
+
+        Drops string results as well.
+
+        :param stats: raw query stats
+        :type stats: dict(str, str)
+        :return: converted results and tags
+        :rtype: tuple[dict(str, float), list[str]]
+        """
+        results = {}
+        tags = set(self.additional_tags)
+        for k, v in stats.items():
+            if k in self.excluded:
+                continue
+            found_re = False
+            for r in self.excluded_re:
+                "type: re.compile"
+                if r.match(k):
+                    found_re = True
+                    break
+            if found_re:
+                continue
+
+            v = v.lstrip().rstrip()
+            try:
+                value = float(v.lstrip().rstrip())
+                results[k] = value
+            except Exception:
+                if k == 'ups.status':
+                    if v.lower().startswith('ol') or v.lower().startswith('on'):
+                        results[k] = 1
+                    else:
+                        results[k] = 0
+                if k in self.string_tags:
+                    tags.add('{}:{}'.format(k, self.convert_to_underscore_separated(v)))
+        return results
+
+    def check(self, instance):
+        self.update_from_config(instance)
+
+        for device in self.list_ups_devices():
+            if device not in self.excluded_devices:
+                excluded = False
+                for r in self.excluded_devices_re:
+                    if r.match(device):
+                        excluded = True
+                        break
+                if excluded:
+                    continue
+
+                # query stats
+                stats, tags = self.query_ups_device(device)
+
+                # report stats
+                for k, v in stats:
+                    self.gauge('upsc.{}'.format(k), v, tags=tags)
+
+    def update_from_config(self, instance):
+        """ Update Configuration tunables from instance configuration.
+
+        :param instance: Agent config instance.
+        :return: None
+        """
+        self.string_tags = ['device.mfr', 'device.model']
+        self.string_tags.extend(instance.get('string_tags', []))
+
+        self.additional_tags = []
+        self.additional_tags.extend(instance.get('tags', []))
+
+        self.excluded = ['ups.vendorid', 'ups.productid', 'driver.version.internal', 'driver.version']
+        self.excluded.extend(instance.get('excluded', []))
+        self.excluded_re = []
+        for excluded_regex in instance.get('excluded_re', []):
+            self.excluded_re.append(re.compile(excluded_regex))
+
+        self.excluded_devices = []
+        self.excluded_devices.extend(instance.get('excluded_devices', []))
+        self.excluded_devices_re = []
+        for excluded_regex in instance.get('excluded_devices_re', []):
+            self.excluded_devices_re.append(re.compile(excluded_regex))

--- a/upsc/check.py
+++ b/upsc/check.py
@@ -31,7 +31,7 @@ class UpscCheck(AgentCheck):
             results = subprocess.check_output(['upsc', '-l'], stderr=self.DEV_NULL)
             return [r.lstrip().rstrip() for r in results.split('\n')]
         except subprocess.CalledProcessError as e:
-            self.log.error("Unable to query devices", e)
+            self.log.error("Unable to query devices: %s", e)
             return []
 
     def query_ups_device(self, name):
@@ -135,4 +135,3 @@ class UpscCheck(AgentCheck):
         self.excluded_devices_re = []
         for excluded_regex in instance.get('excluded_devices_re', []):
             self.excluded_devices_re.append(re.compile(excluded_regex))
-

--- a/upsc/check.py
+++ b/upsc/check.py
@@ -135,3 +135,4 @@ class UpscCheck(AgentCheck):
         self.excluded_devices_re = []
         for excluded_regex in instance.get('excluded_devices_re', []):
             self.excluded_devices_re.append(re.compile(excluded_regex))
+

--- a/upsc/ci/upsc.rake
+++ b/upsc/ci/upsc.rake
@@ -1,0 +1,65 @@
+require 'ci/common'
+
+def upsc_version
+  ENV['FLAVOR_VERSION'] || 'latest'
+end
+
+def upsc_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/upsc_#{upsc_version}"
+end
+
+namespace :ci do
+  namespace :upsc do |flavor|
+    task before_install: ['ci:common:before_install']
+
+    task :install do
+      Rake::Task['ci:common:install'].invoke('upsc')
+      # sample docker usage
+      # sh %(docker create -p XXX:YYY --name upsc source/upsc:upsc_version)
+      # sh %(docker start upsc)
+    end
+
+    task before_script: ['ci:common:before_script']
+
+    task script: ['ci:common:script'] do
+      this_provides = [
+        'upsc'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task before_cache: ['ci:common:before_cache']
+
+    task cleanup: ['ci:common:cleanup']
+    # sample cleanup task
+    # task cleanup: ['ci:common:cleanup'] do
+    #   sh %(docker stop upsc)
+    #   sh %(docker rm upsc)
+    # end
+
+    task :execute do
+      exception = nil
+      begin
+        %w[before_install install before_script].each do |u|
+          Rake::Task["#{flavor.scope.path}:#{u}"].invoke
+        end
+        if !ENV['SKIP_TEST']
+          Rake::Task["#{flavor.scope.path}:script"].invoke
+        else
+          puts 'Skipping tests'.yellow
+        end
+        Rake::Task["#{flavor.scope.path}:before_cache"].invoke
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      raise exception if exception
+    end
+  end
+end

--- a/upsc/conf.yaml.example
+++ b/upsc/conf.yaml.example
@@ -1,7 +1,7 @@
 init_config:
 
 instances:
-  # -
+  # - ups: all
   #   # your own custom tags
   #   tags: ['custom:tag']
   #   # string-based stats results that should be converted to tags on the metrics

--- a/upsc/conf.yaml.example
+++ b/upsc/conf.yaml.example
@@ -1,0 +1,17 @@
+init_config:
+
+instances:
+  # -
+  #   # your own custom tags
+  #   tags: ['custom:tag']
+  #   # string-based stats results that should be converted to tags on the metrics
+  #   string_tags: ['ups.beeper.status']
+  #   # specific list of stats to ignore
+  #   excluded: ['ups.load']
+  #   # regex list of stats to ignore
+  #   excluded_re: ['ups.*']
+  #   # list of specific excluded devices
+  #   excluded_devices: ['badups1']
+  #   # regex list of excluded devices
+  #   excluded_devices_regex: ['ext.*']
+  #

--- a/upsc/manifest.json
+++ b/upsc/manifest.json
@@ -1,0 +1,12 @@
+{
+  "maintainer": "cody.lee@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "upsc",
+  "short_description": "UPSC stats collector for UPS batteries",
+  "guid": "f14607ca-0e30-4c7f-9564-fbdb46ca3030",
+  "support": "contrib",
+  "supported_os": ["linux"],
+  "version": "0.1.0"
+}

--- a/upsc/metadata.csv
+++ b/upsc/metadata.csv
@@ -1,0 +1,13 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+upsc.status,gauge,,sample,status,UPS Status,1,upsc,status
+upsc.battery.charge,gauge,,sample,percent,UPS Charge,1,upsc,charge %
+upsc.battery.charge.low,gauge,,sample,percent,UPS Charge Low Threshold,1,upsc,low charge %
+upsc.battery.charge.warning,gauge,,sample,percent,UPS Charge Warn Threshold,1,upsc,warn charge %
+upsc.battery.runtime,gauge,,minutes,minutes,UPS Runtime Remaining,1,upsc,runtime min
+upsc.battery.runtime.low,gauge,,minutes,minutes,UPS Runtime Low Threshold,1,upsc,runtime low min threshold
+upsc.battery.voltage,gauge,,sample,voltage,UPS Battery Voltage,1,upsc,V
+upsc.battery.voltage.nominal,gauge,,sample,voltage,UPS Battery Nominal Voltage,1,upsc,V
+upsc.input.voltage,gauge,,sample,voltage,UPS Input Voltage,1,upsc,V
+upsc.input.voltage.nominal,gauge,,sample,voltage,UPS Input Nominal Voltage,1,upsc,V
+upsc.output.voltage,gauge,,sample,voltage,UPS Output Voltage,1,upsc,V
+upsc.load,gauge,,sample,load,UPS Load,-1,upsc,load

--- a/upsc/requirements.txt
+++ b/upsc/requirements.txt
@@ -1,0 +1,1 @@
+# integration pip requirements

--- a/upsc/test_upsc.py
+++ b/upsc/test_upsc.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from nose.plugins.attrib import attr
+
+# 3p
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+instance = {
+    'host': 'localhost',
+    'port': 26379,
+    'password': 'datadog-is-devops-best-friend'
+}
+
+
+# NOTE: Feel free to declare multiple test classes if needed
+
+@attr(requires='upsc')
+class TestUpsc(AgentCheckTest):
+    """Basic Test for upsc integration."""
+    CHECK_NAME = 'upsc'
+
+    def test_check(self):
+        """
+        Testing Upsc check.
+        """
+        self.load_check({}, {})
+
+        # run your actual tests...
+
+        self.assertTrue(True)
+        # Raises when COVERAGE=true and coverage < 100%
+        self.coverage_report()

--- a/upsc/test_upsc.py
+++ b/upsc/test_upsc.py
@@ -3,13 +3,15 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
+import mock
 from nose.plugins.attrib import attr
+import re
 
 # 3p
 
 # project
 from tests.checks.common import AgentCheckTest
-
+import check
 
 instance = {
     'host': 'localhost',
@@ -18,21 +20,117 @@ instance = {
 }
 
 
-# NOTE: Feel free to declare multiple test classes if needed
-
 @attr(requires='upsc')
 class TestUpsc(AgentCheckTest):
-    """Basic Test for upsc integration."""
+    """Test for UPSC integration."""
     CHECK_NAME = 'upsc'
+    TEST_CHECK_CONFIG = {'instances': [
+        {
+            'tags': ['foo:bar'],
+            'string_tags': ['ups.testStringTag'],
+            'excluded': ['ups.ignoreme'],
+            'excluded_re': ['ups\.ignore\..*'],
+            'excluded_devices': ['ignoreme'],
+            'excluded_devices_re': ['ignore\..*']
+        }
+    ]}
 
-    def test_check(self):
+    class MockUpscCheck(check.UpscCheck):
+        """ Some overrides to work in CI"""
+
+        def list_ups_devices(self):
+            return ['ignoreme', 'ignore.me.too', 'testUps']
+
+        @mock.patch('subprocess.check_output')
+        def query_ups_device(self, name):
+            return {
+                'ups.status': 'OL',
+
+            }
+
+
+    @attr('config')
+    def test_load_from_config(self):
+        self.load_check(self.TEST_CHECK_CONFIG, {})
+        self.check.update_from_config(self.TEST_CHECK_CONFIG['instances'][0])
+
+        self.assertListEqual(['foo:bar'], self.check.additional_tags)
+        self.assertListEqual(sorted(['ups.testStringTag'] + self.check.DEFAULT_STRING_TAGS),
+                             sorted(self.check.string_tags))
+        self.assertListEqual(sorted(['ups.ignoreme'] + self.check.DEFAULT_EXCLUDED_TAGS),
+                             sorted(self.check.excluded))
+        self.assertListEqual([re.compile('ups\.ignore\..*')], self.check.excluded_re)
+        self.assertListEqual(['ignoreme'], self.check.excluded_devices)
+        self.assertListEqual([re.compile('ignore\..*')], self.check.excluded_devices_re)
+
+    @mock.patch('subprocess.check_output')
+    def test_list_ups_devices(self, mock_iocall):
+        self.load_check(self.TEST_CHECK_CONFIG, {})
+        self.check.update_from_config(self.TEST_CHECK_CONFIG['instances'][0])
+
+        mock_iocall.return_value = '\n'.join(['ignoreme', 'ignore.me.too', 'testUps'])
+        self.assertListEqual(sorted(['ignoreme', 'ignore.me.too', 'testUps']),
+                             sorted(self.check.list_ups_devices()))
+
+    @mock.patch('subprocess.check_output')
+    def test_query_ups_device(self, mock_iocall):
+        self.load_check(self.TEST_CHECK_CONFIG, {})
+        self.check.update_from_config(self.TEST_CHECK_CONFIG['instances'][0])
+
+        mock_iocall.return_value = '\n'.join(['ups.status: OL', 'battery.charge: 100'])
+        self.assertDictEqual({'ups.status': 'OL', 'battery.charge': '100'}, self.check.query_ups_device('testUps'))
+
+    def test_convert_and_filter_stats(self):
+        self.load_check(self.TEST_CHECK_CONFIG, {})
+        self.check.update_from_config(self.TEST_CHECK_CONFIG['instances'][0])
+
+        test_stats = {'ups.status': 'OL', 'battery.charge': '100', 'ups.testStringTag': 'foo Bar-*/baz',
+                      'device.mfr': 'CPS', 'device.model': 'OR700VAU1'}
+        result_stats, tags = self.check.convert_and_filter_stats(test_stats)
+        self.assertDictEqual({'ups.status': 1.0, 'battery.charge': 100.0}, result_stats)
+        self.assertListEqual(
+            sorted(['ups.testStringTag:foo__bar_baz', 'foo:bar', 'device.mfr:cps', 'device.model:or700_vau1']),
+            sorted(tags)
+        )
+
+    @mock.patch('subprocess.check_output')
+    def test_check(self, mock_iocall):
         """
         Testing Upsc check.
         """
-        self.load_check({}, {})
+        self.load_check(self.TEST_CHECK_CONFIG, {})
 
         # run your actual tests...
+        mock_list_results = '\n'.join(['ignoreme', 'ignore.me.too', 'testUps'])
+        mock_query_results = '\n'.join(['ups.status: OL', 'battery.charge: 100', 'ups.testStringTag: foo Bar-*/baz',
+                                        'ups.ignoreme: 1', 'ups.ignore.me.too: 3', 'device.mfr: CPS',
+                                        'device.model: OR700VAU1'])
 
-        self.assertTrue(True)
+        results = [
+            mock_list_results, mock_query_results, mock_query_results, mock_query_results, mock_query_results
+        ]
+
+        def sequence_calls(*args, **kwargs):
+            return results.pop(0)
+
+        mock_iocall.side_effect = sequence_calls
+
+        self.run_check(self.TEST_CHECK_CONFIG['instances'][0])
+
+        test_tags = ['foo:bar', 'ups.testStringTag:foo__bar_baz', 'device.mfr:cps', 'device.model:or700_vau1']
+
+        test_cases = (
+            ('battery.charge', 1, 100.0),
+            ('ups.status', 1, 1.0),
+        )
+
+        for name, count, value in test_cases:
+            self.assertMetric(
+                'upsc.{}'.format(name),
+                count=count,
+                value=value,
+                tags=test_tags
+            )
+
         # Raises when COVERAGE=true and coverage < 100%
         self.coverage_report()


### PR DESCRIPTION
### What does this PR do?

Adds UPS Device stats reporting via `upsc` client.

This assumes `nut`/`upsd` is configured correctly and running and only tested on linux systems.

### Motivation

Having UPS health and charge data is really helpful in a rack and in home.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`

### Additional Notes

Anything else we should know when reviewing?
