### PR TITLE
adding doc team notification check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@ is available in our contribution guidelines.
 
 - [ ] Bumped the version check in `manifest.json`
 - [ ] Updated `CHANGELOG.md`
+- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repository](https://github.com/DataDog/documentation/issues/new)
 
 ### Additional Notes
 


### PR DESCRIPTION
### What does this PR do?

Add a check to remember peoples doing PR to notify the doc.

### Motivation

Since https://github.com/DataDog/documentation/pull/1956 integrations-extras integrations are automatically pulled to DD documentation. 

Adding this check will allow for a more up-to-date documentation.