### PR TITLE
[Uptime] Changing integration type to crawler

### DIFF
--- a/uptime/manifest.json
+++ b/uptime/manifest.json
@@ -9,7 +9,7 @@
   "creates_events": true,
   "public_title": "Datadog-Uptime Integration",
   "categories":["os & system"],
-  "type":"check",
+  "type":"crawler",
   "doc_link": "https://docs.datadoghq.com/integrations/uptime/",
   "is_public": true,
   "has_logo": false


### PR DESCRIPTION
### What does this PR do?

Change the type of uptime integrations from `check` to `crawler` to change the logo displayed on the DD-doc