### PR TITLE
[storm] update binary links, and update versions

### DIFF
--- a/storm/CHANGELOG.md
+++ b/storm/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG - Storm
 
-1.0.0/ Unreleased
+1.0.1/ Released
+=================
+
+### Changes
+
+* [UPDATE] Updated storm bin to 1.2, and forked storm binary blob to prevent future CI breakage
+
+1.0.0/ Released
 =================
 
 ### Changes

--- a/storm/ci/Dockerfile
+++ b/storm/ci/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.5.0-jdk-7
 
-RUN curl -fsSL http://apache.mirror.colo-serv.net/storm/apache-storm-1.1.1/apache-storm-1.1.1.tar.gz -o storm.tar.gz \
+RUN curl -fsSL https://github.com/platinummonkey/static_ci_files/raw/master/datadog/integrations-extras/apache-storm-1.2.1.tar.gz -o storm.tar.gz \
     && tar -xf storm.tar.gz \
     && mv ./apache* storm \
     && cd storm/examples/storm-starter \

--- a/storm/ci/storm.rake
+++ b/storm/ci/storm.rake
@@ -8,6 +8,7 @@ def storm_rootdir
   "#{ENV['INTEGRATIONS_DIR']}/storm_#{storm_version}"
 end
 
+# rubocop:disable Metrics/BlockLength
 namespace :ci do
   namespace :storm do |flavor|
     task before_install: ['ci:common:before_install']
@@ -22,14 +23,17 @@ namespace :ci do
       # Start the storm cluster
       sh %(docker run -d --restart always --name storm-zookeeper zookeeper:3.4)
       sh %(docker run -d --restart always -p 6627:6627 --name storm-nimbus --link storm-zookeeper:zookeeper \
-        storm:1.1 storm nimbus)
+        storm@sha256:203e7c327e491c2d36ad208e5272d7cf953ba20915ce41c6b44a12ab17343a30 storm nimbus)
       sh %(docker run -d --restart always --name storm-supervisor --link storm-zookeeper:zookeeper \
-        --link storm-nimbus:nimbus storm:1.1 storm supervisor)
-      sh %(docker run -d -p 9005:8080 --restart always --name storm-ui --link storm-nimbus:nimbus storm:1.1 storm ui)
+        --link storm-nimbus:nimbus storm@sha256:203e7c327e491c2d36ad208e5272d7cf953ba20915ce41c6b44a12ab17343a30 \
+        storm supervisor)
+      sh %(docker run -d -p 9005:8080 --restart always --name storm-ui --link storm-nimbus:nimbus \
+        storm@sha256:203e7c327e491c2d36ad208e5272d7cf953ba20915ce41c6b44a12ab17343a30 storm ui)
       # Wait for storm to start...
       sh %(sleep 60)
       # Deploy the basic WordCountTopology we created earlier.
-      sh %(docker run --link storm-nimbus:nimbus -it --rm -v $(pwd)/topology.jar:/topology.jar storm:1.1 storm jar \
+      sh %(docker run --link storm-nimbus:nimbus -it --rm -v $(pwd)/topology.jar:/topology.jar \
+        storm@sha256:203e7c327e491c2d36ad208e5272d7cf953ba20915ce41c6b44a12ab17343a30 storm jar \
         /topology.jar org.apache.storm.starter.WordCountTopology topology)
       # Wait again for slow topology starts.
       sh %(sleep 60)

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -8,7 +8,7 @@
   "guid": "5a9ec2c3-8ea0-4337-8c45-a6b8a36b8721",
   "support": "contrib",
   "supported_os": ["linux","mac_os","windows"],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "public_title": "Datadog-Storm Integration",
   "categories":["processing"],
   "type":"check",


### PR DESCRIPTION
### What does this PR do?

Updates Storm binary link to a forked binary blob, previously the mirror had removed the file link and CI was failing.

This updates storm testing to 1.2 version of apache storm.

### Motivation

Broken CI for `storm` integration

### Testing Guidelines

### Versioning

- [x] Bumped the version check in `manifest.json`
- [x] Updated `CHANGELOG.md`
- [x] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repository](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

