### PR TITLE
Add log collection instruction to Logstash documentation

### DIFF
--- a/logstash/README.md
+++ b/logstash/README.md
@@ -14,7 +14,29 @@ Install the `dd-check-logstash` package manually or with your favorite configura
 
 ### Configuration
 
-Edit the `logstash.yaml` file to point to your server and port, set the masters to monitor.
+Create a file `logstash.yaml` in the Agent's `conf.d` directory.
+
+#### Metric Collection
+
+* Add this configuration setup to your `logstash.yaml` file to start gathering your [Logstash metrics](#metrics):
+
+```
+init_config:
+
+instances:
+  #   The URL where Logstash provides its monitoring API. This will be used to fetch various runtime metrics about Logstash.
+  #
+  - url: http://localhost:9600
+```
+
+Configure it to point to your server and port.
+
+See the [sample logstash.yaml](https://github.com/DataDog/integrations-extras/blob/master/logstash/conf.yaml.example) for all available configuration options.
+* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to begin sending Logstash metrics to Datadog.
+
+#### Log Collection
+
+Follow those [instructions](https://docs.datadoghq.com/logs/faq/how-to-send-logs-to-datadog-via-external-log-shippers/#logstash) to start forwarding logs to Datadog with Logstash.
 
 ### Validation
 

--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -10,7 +10,7 @@
   "supported_os": ["linux","mac_os","windows"],
   "version": "1.0.0",
   "public_title": "Datadog-Logstash Integration",
-  "categories":["logging"],
+  "categories":["logging", "log collection"],
   "type":"check",
   "doc_link": "https://docs.datadoghq.com/integrations/logstash/",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?

Add Log collection instruction with Logstash to the current documentation

### Motivation

A Logstash plugin can be used to forward logs to Datadog.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repository](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
