### PR TITLE
Ian/storm

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Style/SingleLineBlockParams:
 Lint/RescueWithoutErrorClass:
   Enabled: false
 
-Style/EndOfLine:
+Layout/EndOfLine:
   Enabled: false
 
 Style/FrozenStringLiteralComment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
   - git -C $HOME/dd-agent pull || git clone -b $DD_AGENT_BRANCH --depth 1 https://github.com/DataDog/dd-agent.git $HOME/dd-agent
   - git -C $HOME/integrations-core pull || git clone -b $CORE_BRANCH --depth 1 https://github.com/DataDog/integrations-core.git $HOME/integrations-core
   - echo "$HOME/dd-agent/" > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/datadog-agent.pth
-  - pip install 'docker-compose==1.11.2'
+  - pip install 'docker-compose==1.18.0'
   - pip install pylint
   - if [ -e $TRAVIS_BUILD_DIR/requirements.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements.txt; fi
   - if [ -e $TRAVIS_BUILD_DIR/requirements-test.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements-test.txt; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,15 +60,14 @@ install:
   - git -C $HOME/dd-agent pull || git clone -b $DD_AGENT_BRANCH --depth 1 https://github.com/DataDog/dd-agent.git $HOME/dd-agent
   - git -C $HOME/integrations-core pull || git clone -b $CORE_BRANCH --depth 1 https://github.com/DataDog/integrations-core.git $HOME/integrations-core
   - echo "$HOME/dd-agent/" > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/datadog-agent.pth
-  - pip uninstall docker-py
-  - pip uninstall docker
-  - pip install docker
   - pip install 'docker-compose==1.21.1'
   - pip install pylint
   - if [ -e $TRAVIS_BUILD_DIR/requirements.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements.txt; fi
   - if [ -e $TRAVIS_BUILD_DIR/requirements-test.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements-test.txt; fi
   - if [ -e $TRAVIS_BUILD_DIR/requirements-opt.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements-opt.txt; fi
   - if [ -e ~/dd-agent/requirements.txt ]; then pip install -r ~/dd-agent/requirements.txt; fi
+  - pip uninstall docker-py
+  - pip install docker
   - bundle exec rake setup_agent_libs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,14 +60,12 @@ install:
   - git -C $HOME/dd-agent pull || git clone -b $DD_AGENT_BRANCH --depth 1 https://github.com/DataDog/dd-agent.git $HOME/dd-agent
   - git -C $HOME/integrations-core pull || git clone -b $CORE_BRANCH --depth 1 https://github.com/DataDog/integrations-core.git $HOME/integrations-core
   - echo "$HOME/dd-agent/" > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/datadog-agent.pth
-  - pip install 'docker-compose==1.21.1'
+  - pip install 'docker-compose==1.9.0'
   - pip install pylint
   - if [ -e $TRAVIS_BUILD_DIR/requirements.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements.txt; fi
   - if [ -e $TRAVIS_BUILD_DIR/requirements-test.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements-test.txt; fi
   - if [ -e $TRAVIS_BUILD_DIR/requirements-opt.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements-opt.txt; fi
   - if [ -e ~/dd-agent/requirements.txt ]; then pip install -r ~/dd-agent/requirements.txt; fi
-  - pip uninstall docker-py
-  - pip install docker
   - bundle exec rake setup_agent_libs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
   - git -C $HOME/dd-agent pull || git clone -b $DD_AGENT_BRANCH --depth 1 https://github.com/DataDog/dd-agent.git $HOME/dd-agent
   - git -C $HOME/integrations-core pull || git clone -b $CORE_BRANCH --depth 1 https://github.com/DataDog/integrations-core.git $HOME/integrations-core
   - echo "$HOME/dd-agent/" > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/datadog-agent.pth
-  - pip install 'docker-compose==1.18.0'
+  - pip install 'docker-compose==1.12.0'
   - pip install pylint
   - if [ -e $TRAVIS_BUILD_DIR/requirements.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements.txt; fi
   - if [ -e $TRAVIS_BUILD_DIR/requirements-test.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements-test.txt; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,10 @@ install:
   - git -C $HOME/dd-agent pull || git clone -b $DD_AGENT_BRANCH --depth 1 https://github.com/DataDog/dd-agent.git $HOME/dd-agent
   - git -C $HOME/integrations-core pull || git clone -b $CORE_BRANCH --depth 1 https://github.com/DataDog/integrations-core.git $HOME/integrations-core
   - echo "$HOME/dd-agent/" > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/datadog-agent.pth
-  - pip install 'docker-compose==1.12.0'
+  - pip uninstall docker-py
+  - pip uninstall docker
+  - pip install docker
+  - pip install 'docker-compose==1.21.1'
   - pip install pylint
   - if [ -e $TRAVIS_BUILD_DIR/requirements.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements.txt; fi
   - if [ -e $TRAVIS_BUILD_DIR/requirements-test.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements-test.txt; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
   - git -C $HOME/dd-agent pull || git clone -b $DD_AGENT_BRANCH --depth 1 https://github.com/DataDog/dd-agent.git $HOME/dd-agent
   - git -C $HOME/integrations-core pull || git clone -b $CORE_BRANCH --depth 1 https://github.com/DataDog/integrations-core.git $HOME/integrations-core
   - echo "$HOME/dd-agent/" > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/datadog-agent.pth
-  - pip install 'docker-compose==1.9.0'
+  - pip install 'docker-compose==1.11.2'
   - pip install pylint
   - if [ -e $TRAVIS_BUILD_DIR/requirements.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements.txt; fi
   - if [ -e $TRAVIS_BUILD_DIR/requirements-test.txt ]; then pip install -r $TRAVIS_BUILD_DIR/requirements-test.txt; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ services:
 install:
   # Use the 64-bit ruby so that all the Powershell classes are accessible when running shell commands from ruby
   - set PATH=C:\Ruby22-x64\bin;%PATH%
+  - set PATH=C:\Python27-x64\Scripts;%PATH%
   - bundle install
   - bundle package
   - git clone -b %DD_AGENT_BRANCH% https://github.com/DataDog/dd-agent.git c:\projects\dd-agent

--- a/storm/CHANGELOG.md
+++ b/storm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG - Storm
 
+1.0.2/ Unreleased
+=================
+
+### Changes
+
+* [FIX] Cluster metrics sent with 0 values if unable to connect to Storm UI. Now bails on ConnectionErrors.
+* [FIX] If on Agent6 - TypeError: gauge() got an unexpected keyword argument 'metric'
+* [UPDATE] Redundant environment tags. stormEnvironment replaces env/environment/stormClusterEnviroment ot reduce number of metrics.
+
 1.0.1/ Released
 =================
 

--- a/storm/CHANGELOG.md
+++ b/storm/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * [FIX] Cluster metrics sent with 0 values if unable to connect to Storm UI. Now bails on ConnectionErrors.
 * [FIX] If on Agent6 - TypeError: gauge() got an unexpected keyword argument 'metric'
-* [UPDATE] Redundant environment tags. stormEnvironment replaces env/environment/stormClusterEnviroment to reduce number of metrics.
+* [UPDATE] Redundant environment tags. stormEnvironment replaces env/environment/stormClusterEnviroment ot reduce number of metrics.
 
 1.0.1/ Released
 =================

--- a/storm/CHANGELOG.md
+++ b/storm/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * [FIX] Cluster metrics sent with 0 values if unable to connect to Storm UI. Now bails on ConnectionErrors.
 * [FIX] If on Agent6 - TypeError: gauge() got an unexpected keyword argument 'metric'
-* [UPDATE] Redundant environment tags. stormEnvironment replaces env/environment/stormClusterEnviroment ot reduce number of metrics.
+* [UPDATE] Redundant environment tags. stormEnvironment replaces env/environment/stormClusterEnviroment to reduce number of metrics.
 
 1.0.1/ Released
 =================

--- a/storm/check.py
+++ b/storm/check.py
@@ -5,7 +5,8 @@
 # stdlib
 
 # 3rd party
-import requests, json
+import requests
+import json
 
 # project
 from checks import AgentCheck
@@ -202,7 +203,8 @@ class StormCheck(AgentCheck):
         url = "{}{}".format(self.nimbus_server, url_part)
         try:
             self.log.debug("Fetching url %s", url)
-            if params: self.log.debug("Request params: %s", params)
+            if params: 
+                self.log.debug("Request params: %s", params)
             resp = requests.get(url, params=params)
             resp.encoding = 'utf-8'
             data = resp.json()

--- a/storm/check.py
+++ b/storm/check.py
@@ -203,7 +203,7 @@ class StormCheck(AgentCheck):
         url = "{}{}".format(self.nimbus_server, url_part)
         try:
             self.log.debug("Fetching url %s", url)
-            if params: 
+            if params:
                 self.log.debug("Request params: %s", params)
             resp = requests.get(url, params=params)
             resp.encoding = 'utf-8'

--- a/storm/check.py
+++ b/storm/check.py
@@ -205,13 +205,13 @@ class StormCheck(AgentCheck):
             if params: self.log.debug("Request params: %s", params)
             resp = requests.get(url, params=params)
             resp.encoding = 'utf-8'
-            resp.raise_for_status()
             data = resp.json()
             # Log response data exluding configuration section
             self.log.debug("Response data: %s" % json.dumps({x: data[x] for x in data if x != 'configuration'}))
             if 'error' in data:
-                self.log.warning("[url:{}] {}".format(url, error_message))
-                return {}
+                self.log.warning("Error message returned in JSON response")
+                raise Exception(data['error'])
+            resp.raise_for_status()
             return data
         except requests.exceptions.ConnectionError as e:
             self.log.error("{1} [url:{0}]".format(self.nimbus_server, "Unable to establish a connection to Storm UI"))
@@ -219,7 +219,7 @@ class StormCheck(AgentCheck):
         except Exception as e:
             self.log.warning("[url:{}] {}".format(url, error_message))
             self.log.exception(e)
-            return {}
+            raise
 
     def get_storm_cluster_summary(self):
         """ Make the storm cluster summary metric request.

--- a/storm/check.py
+++ b/storm/check.py
@@ -5,7 +5,7 @@
 # stdlib
 
 # 3rd party
-import requests
+import requests, json
 
 # project
 from checks import AgentCheck
@@ -202,11 +202,13 @@ class StormCheck(AgentCheck):
         url = "{}{}".format(self.nimbus_server, url_part)
         try:
             self.log.debug("Fetching url %s", url)
+            if params: self.log.debug("Request params: %s", params)
             resp = requests.get(url, params=params)
             resp.encoding = 'utf-8'
             resp.raise_for_status()
             data = resp.json()
-            self.log.debug("Response data: %s" % data)
+            # Log response data exluding configuration section
+            self.log.debug("Response data: %s" % json.dumps({x: data[x] for x in data if x != 'configuration'}))
             if 'error' in data:
                 self.log.warning("[url:{}] {}".format(url, error_message))
                 return {}
@@ -225,6 +227,7 @@ class StormCheck(AgentCheck):
         :return: Cluster Summary Stats Response
         :rtype: dict
         """
+        self.log.debug("Retrieving Cluster Summary Stats")
         return self.get_request_json("/api/v1/cluster/summary", "Error retrieving Storm Cluster Summary")
 
     def get_storm_nimbus_summary(self):
@@ -233,6 +236,7 @@ class StormCheck(AgentCheck):
         :return: Nimbus Summary Stats Response
         :rtype: dict
         """
+        self.log.debug("Retrieving Nimbus Summary Stats")
         return self.get_request_json("/api/v1/nimbus/summary", "Error retrieving Storm Nimbus Summary")
 
     def get_storm_supervisor_summary(self):
@@ -241,6 +245,7 @@ class StormCheck(AgentCheck):
         :return: Supervisor Summary Stats Response
         :rtype: dict
         """
+        self.log.debug("Retrieving Supervisor Summary Stats")
         return self.get_request_json("/api/v1/supervisor/summary", "Error retrieving Storm Supervisor Summary")
 
     def get_storm_topology_summary(self):
@@ -249,6 +254,7 @@ class StormCheck(AgentCheck):
         :return: Topology Summary Stats Response
         :rtype: dict
         """
+        self.log.debug("Retrieving Topology Summary Stats")
         return self.get_request_json("/api/v1/topology/summary", "Error retrieving Storm Topology Summary")
 
     def get_topology_info(self, topology_id, interval=60):
@@ -259,6 +265,7 @@ class StormCheck(AgentCheck):
         :return: Topology Info Response
         :rtype: dict
         """
+        self.log.debug("Retrieving Topology Info. Id: %s" % topology_id)
         params = {'window': interval}
         return self.get_request_json("/api/v1/topology/{}".format(topology_id),
                                      "Error retrieving Storm Topology Info for topology:{}".format(topology_id),

--- a/storm/test_storm.py
+++ b/storm/test_storm.py
@@ -1085,10 +1085,10 @@ class TestStorm(AgentCheckTest):
         test_cases = (
             ('upTimeSeconds', 1, 25842, ['stormStatus:leader', 'stormHost:1.2.3.4']),
             ('upTimeSeconds', 1, 0, ['stormStatus:offline', 'stormHost:nimbus01.example.com']),
-            ('numLeaders', 1, 1, []),
-            ('numFollowers', 1, 0, []),
-            ('numOffline', 1, 1, []),
-            ('numDead', 1, 0, [])
+            ('numLeaders', 1, 1, ['stormStatus:leader', 'stormHost:1.2.3.4']),
+            ('numFollowers', 1, 0, ['stormStatus:leader', 'stormHost:1.2.3.4']),
+            ('numOffline', 1, 1, ['stormStatus:leader', 'stormHost:1.2.3.4']),
+            ('numDead', 1, 0, ['stormStatus:leader', 'stormHost:1.2.3.4'])
         )
         test_tags = env_tags + storm_version_tags
 
@@ -1280,8 +1280,7 @@ class TestStorm(AgentCheckTest):
             self.assertMetric(
                 'storm.nimbus.{}'.format(name),
                 count=count,
-                value=value,
-                tags=test_tags + additional_tags
+                value=value
             )
 
         # Supervisor Stats

--- a/storm/test_storm.py
+++ b/storm/test_storm.py
@@ -831,7 +831,7 @@ class TestStorm(AgentCheckTest):
 
         self.check.report_gauge = report_gauge
 
-        self.check.process_cluster_stats('test', TEST_STORM_CLUSTER_SUMMARY)
+        self.check.process_cluster_stats(TEST_STORM_CLUSTER_SUMMARY)
         self.assertEquals(13, len(results))
 
         # Check Cluster Stats
@@ -855,7 +855,7 @@ class TestStorm(AgentCheckTest):
 
         self.check.report_gauge = report_gauge
 
-        self.check.process_nimbus_stats('test', TEST_STORM_NIMBUSES_SUMMARY)
+        self.check.process_nimbus_stats(TEST_STORM_NIMBUSES_SUMMARY)
         self.assertEquals(5, len(results))
 
         # Check Leader Stats
@@ -1045,9 +1045,8 @@ class TestStorm(AgentCheckTest):
         self.run_check(self.STORM_CHECK_CONFIG['instances'][0])
 
         topology_tags = ['topology:my_topology']
-        env_tags = ['env:test', 'environment:test']
+        env_tags = ['stormEnvironment:test']
         storm_version_tags = ['stormVersion:1.0.3']
-        storm_cluster_environment_tags = ['stormClusterEnvironment:test']
 
         # Service Check
         self.assertServiceCheck(
@@ -1073,7 +1072,7 @@ class TestStorm(AgentCheckTest):
             ('totalMem', 1, 0),
             ('memAssignedPercentUtil', 1, 0)
         )
-        test_tags = env_tags + storm_version_tags + storm_cluster_environment_tags
+        test_tags = env_tags + storm_version_tags
         for name, count, value in test_cases:
             self.assertMetric(
                 'storm.cluster.{}'.format(name),
@@ -1091,7 +1090,7 @@ class TestStorm(AgentCheckTest):
             ('numOffline', 1, 1, []),
             ('numDead', 1, 0, [])
         )
-        test_tags = storm_cluster_environment_tags + env_tags + storm_version_tags
+        test_tags = env_tags + storm_version_tags
 
         for name, count, value, additional_tags in test_cases:
             self.assertMetric(
@@ -1231,17 +1230,16 @@ class TestStorm(AgentCheckTest):
             'topology-check.topology',
             count=1,
             status=AgentCheck.OK,
-            tags=['env:integration', 'environment:integration', 'stormVersion:1.1.1']
+            tags=['stormEnvironment:integration', 'stormVersion:1.1.1']
         )
 
         topology_tags = ['topology:topology']
-        env_tags = ['env:integration', 'environment:integration']
+        env_tags = ['stormEnvironment:integration']
         storm_version_tags = ['stormVersion:1.1.1']
-        storm_cluster_environment_tags = ['stormClusterEnvironment:integration']
 
         self.assertMetric(
             'storm.cluster.supervisors', value=1, count=1,
-            tags=storm_cluster_environment_tags + storm_version_tags + env_tags
+            tags= storm_version_tags + env_tags
         )
 
         # Cluster Stats
@@ -1260,7 +1258,7 @@ class TestStorm(AgentCheckTest):
             ('totalMem', 1, None, False),
             ('memAssignedPercentUtil', 1, None, False)
         )
-        test_tags = storm_cluster_environment_tags + storm_version_tags + env_tags
+        test_tags = storm_version_tags + env_tags
         for name, count, value, test_value in test_cases:
             self.assertMetric(
                 'storm.cluster.{}'.format(name),
@@ -1276,7 +1274,7 @@ class TestStorm(AgentCheckTest):
             ('numOffline', 1, 1, []),
             ('numDead', 1, 0, [])
         )
-        test_tags = storm_cluster_environment_tags + env_tags + storm_version_tags
+        test_tags = env_tags + storm_version_tags
 
         for name, count, value, additional_tags in test_cases:
             self.assertMetric(


### PR DESCRIPTION
### What does this PR do?

Bug fix and changes.
+* [FIX] Cluster metrics sent with 0 values if unable to connect to Storm UI. Now bails on ConnectionErrors.
+* [FIX] If on Agent6 - TypeError: gauge() got an unexpected keyword argument 'metric'
+* [UPDATE] Redundant environment tags. all metrics seem to have both env/environment (set in report_gauge) and some other metrics has the stormClusterEnviroment in addition to that - all set with the same value. Replaced env, environment, and stormClusterEnviroment with just stormEnvironment to reduce number of metrics. 

### Motivation

issue

### Versioning

- [ /] Bumped the version check in `manifest.json`
- [/ ] Updated `CHANGELOG.md`
- [ n/a] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repository](https://github.com/DataDog/documentation/issues/new)
