### PR TITLE
Shorten `public_title` for Ambassador tile

### DIFF
--- a/ambassador/manifest.json
+++ b/ambassador/manifest.json
@@ -8,7 +8,7 @@
   "metric_to_check": "envoy.server.live",
   "creates_events": false,
   "public_title": "Ambassador API Gateway",
-  "type":"agent",
+  "type":"statsd",
   "doc_link": "https://docs.datadoghq.com/integrations/ambassador/",
   "is_public": true,
   "has_logo": true,


### PR DESCRIPTION
### What does this PR do?

Shorten the `public_title` field for the Ambassador tile so that it appears better on the docs page.

Currently, on mouse hover, there is overlapping text:
![image](https://user-images.githubusercontent.com/4007500/39142726-6e56fe9e-46f9-11e8-907b-984d9260e951.png)

Also, change the `type` to `statsd`