### PR TITLE
Update links to sync integration tiles with readme

### DIFF
--- a/ambassador/README.md
+++ b/ambassador/README.md
@@ -1,12 +1,12 @@
 ## Overview
 
-Get metrics from [Ambassador][1] in real time to:
+Get metrics from [Ambassador](https://www.getambassador.io) in real time to:
 
 * Visualize the performance of your microservices
 
 * Understand the impact of new versions of your services as you use Ambassador to do a canary rollout
 
-![snapshot][2]
+![snapshot](https://raw.githubusercontent.com/DataDog/integrations-extras/master/ambassador/images/upstream-req-time.png)
 
 ## Setup
 
@@ -71,7 +71,7 @@ kubectl apply -f datadog-statsd-sink.yaml
 
 ### Metrics
 
-See [metadata.csv][3] for a list of metrics provided by this check.
+See [metadata.csv](https://github.com/DataDog/integrations-extras/blob/master/ambassador/metadata.csv) for a list of metrics provided by this check.
 
 ### Events
 
@@ -82,11 +82,11 @@ The Ambassador check does not include any events at this time.
 The Ambassador check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][4].
+Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][5].
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/).
 
 
 [1]: https://www.getambassador.io

--- a/buddy/README.md
+++ b/buddy/README.md
@@ -6,19 +6,19 @@ Enabling this integration will let you:
 *   Correlate deployment details with your Datadog metrics
 *   Detect the sources of performance spikes
 
-![datadog-integration][1]
+![datadog-integration](https://raw.githubusercontent.com/DataDog/integrations-extras/master/buddy/images/datadog-integration.png)
 
 ## Setup
 
-* In your Datadog account settings go to [Integrations -> APIs][2] and copy the **API Key** token
+* In your Datadog account settings go to [Integrations -> APIs](https://app.datadoghq.com/account/settings#api) and copy the **API Key** token
 
-* [Sign in to your Buddy account][3] and go to the pipeline with the deployment action that you want to track
+* [Sign in to your Buddy account](https://app.buddy.works/login) and go to the pipeline with the deployment action that you want to track
 
 * Click the plus at the end of the pipeline and select **Datadog** in the **Notifications** section
 
 * Enter the name of your Datadog account and paste the API key that you copied
 
-* Use [Buddy parameters][4] to define the title of the event and content sent, for example:
+* Use [Buddy parameters](https://buddy.works/knowledge/deployments/what-parameters-buddy-use) to define the title of the event and content sent, for example:
 
 ```
 # Event title
@@ -30,24 +30,24 @@ ${'${execution.to_revision.revision} - ${execution.to_revision.message}'}
 
 * When ready, click **Add action** and run the pipeline. On every successful deployment, Buddy will send an event to Datadog:
 
-![snapshot][5]
+![snapshot](https://raw.githubusercontent.com/DataDog/integrations-extras/master/buddy/images/snapshot.png)
 
 ## Data Collected
 ### Metrics
 The Buddy check does not include any metrics at this time.
 
 ### Events
-All Buddy deployment events are sent to your [Datadog Event Stream][6]
+All Buddy deployment events are sent to your [Datadog Event Stream](https://docs.datadoghq.com/graphing/event_stream/)
 
 ### Service Checks
 The Buddy check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][7].
+Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][8].
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/).
 
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/buddy/images/datadog-integration.png

--- a/convox/README.md
+++ b/convox/README.md
@@ -2,11 +2,11 @@
 
 Get metrics from Convox in real-time to visualize your containers' performance:
 
-![snapshot][1]
+![snapshot](https://raw.githubusercontent.com/DataDog/integrations-extras/master/convox/images/snapshot.png)
 
 ## Setup
 
-Please refer to the [Convox setup doc page][2].
+Please refer to the [Convox setup doc page](https://convox.com/docs/datadog/).
 
 ### Deploy the Datadog Agent
 
@@ -30,7 +30,7 @@ Use a `count` that matches the `InstanceCount` parameter of your Rack.
 
 If autoscaling is enabled on your Rack, you’ll need to dynamically scale the Datadog agent count to match the Rack instance count.
 
-See the [Listening for ECS CloudWatch Events Tutorial][3] for guidance.
+See the [Listening for ECS CloudWatch Events Tutorial](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwet.html) for guidance.
 
 ## Data Collected
 ### Metrics
@@ -43,11 +43,11 @@ The Convox check does not include any events at this time.
 The Convox check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][4].
+Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][5].
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/).
 
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/convox/images/snapshot.png

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -9,14 +9,14 @@ Get metrics from Logstash service in real time to:
 
 ## Setup
 
-The Logstash check is **NOT** included in the [Datadog Agent][1] package.
+The Logstash check is **NOT** included in the [Datadog Agent](https://app.datadoghq.com/account/settings#agent) package.
 
 ### Installation
 
 To install the Logstash check on your host:
 
-1. [Download the Datadog Agent][1].
-2. Download the [`check.py` file][2] for Logstash.
+1. [Download the Datadog Agent](https://app.datadoghq.com/account/settings#agent).
+2. Download the [`check.py` file](https://github.com/DataDog/integrations-extras/blob/master/logstash/conf.yaml.example) for Logstash.
 3. Place it in the Agent's `checks.d` directory.
 4. Rename it to `logstash.py`.
 
@@ -26,9 +26,9 @@ To configure the Logstash check:
 
 1. Create a `logstash.d/` folder in the `conf.d/` folder at the root of your Agent's directory. 
 2. Create a `conf.yaml` file in the `logstash.d/` folder previously created.
-3. Consult the [sample logstash.yaml][2] file and copy its content in the `conf.yaml` file.
+3. Consult the [sample logstash.yaml](https://github.com/DataDog/integrations-extras/blob/master/logstash/conf.yaml.example) file and copy its content in the `conf.yaml` file.
 4. Edit the `conf.yaml`  to start collecting your [metrics](#metric-collection) or [logs](#log-collection)
-5. [Restart the Agent][3].
+5. [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent).
 
 #### Metric Collection
 
@@ -45,16 +45,16 @@ instances:
 
 Configure it to point to your server and port.
 
-See the [sample conf.yaml][2] for all available configuration options.
-* [Restart the Agent][3] to begin sending Logstash metrics to Datadog.
+See the [sample conf.yaml](https://github.com/DataDog/integrations-extras/blob/master/logstash/conf.yaml.example) for all available configuration options.
+* [Restart the Agent](https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent) to begin sending Logstash metrics to Datadog.
 
 #### Log Collection
 
-Follow those [instructions][8] to start forwarding logs to Datadog with Logstash.
+Follow those [instructions](https://docs.datadoghq.com/logs/log_collection/logstash/) to start forwarding logs to Datadog with Logstash.
 
 ## Validation
 
-[Run the Agent's `status` subcommand][4] and look for `logstash` under the Checks section.
+[Run the Agent's `status` subcommand](https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information) and look for `logstash` under the Checks section.
 
 ## Compatibility
 
@@ -62,7 +62,7 @@ The Logstash check is compatible with Logstash 5.6 and possible earlier versions
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][5] for a list of metrics provided by this check.
+See [metadata.csv](https://github.com/DataDog/integrations-extras/blob/master/logstash/metadata.csv) for a list of metrics provided by this check.
 
 ### Events
 The Logstash check does not include any events at this time.
@@ -85,11 +85,11 @@ Returns `Critical` if the Agent cannot connect to Logstash to collect metrics.
 
 Check that the `url` in `conf.yaml` is correct.
 
-If you need further help, contact [Datadog Support][6].
+If you need further help, contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][7]
+Learn more about infrastructure monitoring and all our integrations on [our blog]( https://www.datadoghq.com/blog/)
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://github.com/DataDog/integrations-extras/blob/master/logstash/conf.yaml.example

--- a/logzio/README.md
+++ b/logzio/README.md
@@ -4,11 +4,11 @@ Integrate with Logz.io alerts to see events taking place in real-time
 
 *   Import alerts into Datadog
 
-![import_alert_from_logz][1]
+![import_alert_from_logz](https://raw.githubusercontent.com/DataDog/integrations-extras/master/logzio/images/import_alert_from_logz.jpg)
 
 *   Incorporate the events into a dashboard to identify correlations with metrics
 
-![dashboard][2]
+![dashboard](https://raw.githubusercontent.com/DataDog/integrations-extras/master/logzio/images/dashboard.png)
 
 ## Setup
 
@@ -16,10 +16,10 @@ Integrate with Logz.io alerts to see events taking place in real-time
 
 Import your alerts into Datadog with the following steps:
 
-1.  Use a [Datadog API key][6] to create a new alert endpoint in Logz.io.
+1.  Use a [Datadog API key](https://app.datadoghq.com/account/settings#api) to create a new alert endpoint in Logz.io.
 2.  Create a new alert in Logz.io for a specific query.
 
-For a more detailed setup description, see [the logz.io dedicated datadog documentation][3].
+For a more detailed setup description, see [the logz.io dedicated datadog documentation](http://logz.io/blog/log-correlation-datadog/).
 
 ## Data Collected
 ### Metrics
@@ -32,11 +32,11 @@ The Logz.io check does not include any events at this time.
 The Logz.io check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][4].
+Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][5].
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/).
 
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/logzio/images/import_alert_from_logz.jpg

--- a/nomad/README.md
+++ b/nomad/README.md
@@ -9,7 +9,7 @@ Gather metrics from your Nomad clusters to:
 
 ### Installation
 
-Nomad emits metrics to Datadog via DogStatsD. To enable the Nomad integration, [install the Datadog Agent][4] on each client and server host.  
+Nomad emits metrics to Datadog via DogStatsD. To enable the Nomad integration, [install the Datadog Agent](https://app.datadoghq.com/account/settings#agent) on each client and server host.  
 
 ### Configuration
 
@@ -28,7 +28,7 @@ Next, reload or restart the Nomad agent on each host. You should now begin to se
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][1] for a list of metrics provided by this integration.
+See [metadata.csv](https://github.com/DataDog/integrations-extras/blob/master/nomad/metadata.csv) for a list of metrics provided by this integration.
 
 ### Events
 The Nomad check does not include any events at this time.
@@ -37,11 +37,11 @@ The Nomad check does not include any events at this time.
 The Nomad check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][2].
+Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][3].
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/).
 
 
 [1]: https://github.com/DataDog/integrations-extras/blob/master/nomad/metadata.csv

--- a/rbltracker/README.md
+++ b/rbltracker/README.md
@@ -2,7 +2,7 @@
 
 RBLTracker provides easy-to-use, real-time blacklist monitoring, for your email, website, and social media.
 
-Connect your [RBLTracker][1] account to Datadog to:
+Connect your [RBLTracker](https://rbltracker.com/) account to Datadog to:
 
 *   Push listing events from RBLTracker to your dashboard.
 *   Push de-listing events from RBLTracker to your dashboard.
@@ -11,29 +11,29 @@ Connect your [RBLTracker][1] account to Datadog to:
 
 Setting up RBLTracker using webhooks:
 
-1.  In Datadog, [copy your API key][6] from the **Integrations -> APIs** section.
-2.  In [RBLTracker][1], create a new Datadog contact type from the **Manage -> Contacts** section of the RBLTracker portal.
+1.  In Datadog, [copy your API key](https://app.datadoghq.com/account/settings#api) from the **Integrations -> APIs** section.
+2.  In [RBLTracker](https://rbltracker.com/), create a new Datadog contact type from the **Manage -> Contacts** section of the RBLTracker portal.
 3.  Paste the Datadog **API Key**.
 4.  (optional) adjust the contact schedule for this new contact.
 
-RBLTracker will send listing and delisting alerts to your Datadog events dashboard. Click [here][2] for a full integration guide.
+RBLTracker will send listing and delisting alerts to your Datadog events dashboard. Click [here](https://rbltracker.com/docs/adding-a-datadog-contact-type/) for a full integration guide.
 
 ## Data Collected
 ### Metrics
 The RBLTracker check does not include any metrics at this time.
 
 ### Events
-Push your RBLTracker listing/de-listing events into your [Datadog Event Stream][3].
+Push your RBLTracker listing/de-listing events into your [Datadog Event Stream](https://docs.datadoghq.com/graphing/event_stream/).
 
 ### Service Checks
 The RBLTracker check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][4].
+Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][5].
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/).
 
 
 [1]: https://rbltracker.com/

--- a/split/README.md
+++ b/split/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[Split][1] is a platform for [controlled rollouts][2], helping businesses of all sizes deliver exceptional user experiences and mitigate risk by providing an easy, secure way to target features to customers.
+[Split](http://www.split.io) is a platform for [controlled rollouts](http://www.split.io/articles/controlled-rollout), helping businesses of all sizes deliver exceptional user experiences and mitigate risk by providing an easy, secure way to target features to customers.
 
 Integrate Split with Datadog to:
 
@@ -20,11 +20,11 @@ Integrate Split with Datadog to:
 
  * Go to **Admin Settings** and click **Integrations** and navigate to the Marketplace. Click Add next to Datadog.<br/>
 
-![Split Screenshot][3]
+![Split Screenshot](https://raw.githubusercontent.com/DataDog/integrations-extras/ilan/split-integration/split/images/in-split.png)
 
  * Paste your Datadog API Key and click Save.
 
-![Split Screenshot][4]
+![Split Screenshot](https://raw.githubusercontent.com/DataDog/integrations-extras/ilan/split-integration/split/images/integrations-datadog.png)
 
 Split data should now be flowing into Datadog.
 
@@ -34,17 +34,17 @@ Split data should now be flowing into Datadog.
 The Split check does not include any metrics at this time.
 
 ### Events
-Push your Split listing/de-listing events into your [Datadog Event Stream][5].
+Push your Split listing/de-listing events into your [Datadog Event Stream](https://docs.datadoghq.com/graphing/event_stream/).
 
 ### Service Checks
 The Split check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][6].
+Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][7].
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/).
 
 
 [1]: http://www.split.io

--- a/uptime/README.md
+++ b/uptime/README.md
@@ -7,13 +7,13 @@ Get events and metrics from your app in real time to:
 * Track and notify of any downtime or interruptions.
 * Visualize response time metrics from synthetic requests.
 
-![Uptime.com Graph][1]
+![Uptime.com Graph](https://raw.githubusercontent.com/DataDog/integrations-extras/ilan/uptime/uptime/images/snapshot.png)
 
 ## Setup
 
 ### Configuration
 
-In order to activate the integration of Datadog within your Uptime account, go to [Alerting>Push Notifications][2] then choose Datadog as the provider type when adding a new push notifications profile.
+In order to activate the integration of Datadog within your Uptime account, go to [Alerting>Push Notifications](https://uptime.com/push-notifications/manage/) then choose Datadog as the provider type when adding a new push notifications profile.
 
 The following describes the fields shown when configuring Datadog within your Uptime account: 
 
@@ -28,7 +28,7 @@ The following describes the fields shown when configuring Datadog within your Up
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][3] for a list of metrics provided by this integration.
+See [metadata.csv](https://github.com/DataDog/integrations-extras/blob/master/uptime/metadata.csv) for a list of metrics provided by this integration.
 
 ### Events
 The Uptime check does not include any events at this time.
@@ -37,11 +37,11 @@ The Uptime check does not include any events at this time.
 The Uptime check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][4].
+Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][5].
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/).
 
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/ilan/uptime/uptime/images/snapshot.png

--- a/vns3/README.md
+++ b/vns3/README.md
@@ -4,15 +4,15 @@ Get state information regarding your VNS3 topology's IPSec endpoints/tunnels, VN
 
 *   Peering links Status Check:
 
-    ![peering][1]
+    ![peering](https://raw.githubusercontent.com/DataDog/integrations-extras/master/vns3/images/peering.png)
 
 *   Overlay Clients Status Check:
 
-    ![clients][2]
+    ![clients](https://raw.githubusercontent.com/DataDog/integrations-extras/master/vns3/images/clients.png)
 
 *   IPSec tunnels Status Check:
 
-    ![ipsec][3]
+    ![ipsec](https://raw.githubusercontent.com/DataDog/integrations-extras/master/vns3/images/ipsec.png)
 
 ## Setup
 
@@ -20,13 +20,13 @@ Get state information regarding your VNS3 topology's IPSec endpoints/tunnels, VN
 
 To capture metrics, you need to deploy Cohesive Networks' DataDog container, set up the VNS3 firewall, and configure the container.
 
-Read the guide [here][4].
+Read the guide [here](https://cohesive.net/dnld/Cohesive-Networks_VNS3-DataDog-Container-Guide.pdf).
 
-Watch the video [here][5].
+Watch the video [here](https://youtu.be/sTCgCG3m4vk).
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][6] for a list of metrics provided by this integration.
+See [metadata.csv](https://github.com/DataDog/integrations-extras/blob/master/vns3/metadata.csv) for a list of metrics provided by this integration.
 
 ### Events
 The VNS3 check does not include any events at this time.
@@ -35,11 +35,11 @@ The VNS3 check does not include any events at this time.
 The VNS3 check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][7].
+Need help? Contact [Datadog Support](http://docs.datadoghq.com/help/).
 
 ## Further Reading
 
-Learn more about infrastructure monitoring and all our integrations on [our blog][8].
+Learn more about infrastructure monitoring and all our integrations on [our blog](https://www.datadoghq.com/blog/).
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/vns3/images/peering.png
 [2]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/vns3/images/clients.png


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

Update the integration READMEs to use markdown links

### Motivation

So that we can sync the integration tiles with the updated README's info

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the version check in `manifest.json`
- [ ] Updated `CHANGELOG.md`
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repository](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
