### PR TITLE
remove categories that aren't informative

### DIFF
--- a/gnatsd_streaming/manifest.json
+++ b/gnatsd_streaming/manifest.json
@@ -10,7 +10,7 @@
   "type":"check",
   "doc_link": "link/to/the/dedicated/documentation/page",
   "supported_os": ["linux","mac_os","windows"],
-  "categories":["list of categories","a complete list can be found on our documentation"],
+  "categories":[],
   "version": "0.1.0",
   "is_public": true,
   "has_logo": true


### PR DESCRIPTION
### What does this PR do?

This PR removes the categories from gnatsd_streaming manifest that aren't real. 

### Motivation

The categories cause the documentation website (https://docs.datadoghq.com/integrations/) to show filters that aren't useful. See https://docs.datadoghq.com/integrations/ and notice the "list of categories" & "a complete list can be found on our documentation" filters which show no integrations when selected.
