### PR TITLE
Remove unused pyyaml library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ntplib==0.3.3
 simplejson==3.6.5
 tornado==3.2.2
-pyyaml==3.11
 docker-py==1.10.6
 requests==2.19.0


### PR DESCRIPTION
### What does this PR do?

Remove pyyaml because it doesn't seem to be used

### Motivation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
