### PR TITLE
Removing logging cat and replacing it with log collection

### DIFF
--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -13,7 +13,7 @@
   "supported_os": ["linux","mac_os","windows"],
   "version": "1.0.0",
   "public_title": "Datadog-Logstash Integration",
-  "categories":["logging", "log collection"],
+  "categories":["log collection"],
   "type":"check",
   "aliases":["logs/log_collection/logstash"],
   "doc_link": "https://docs.datadoghq.com/integrations/logstash/",

--- a/portworx/manifest.json
+++ b/portworx/manifest.json
@@ -14,7 +14,7 @@
   "creates_events": false,
   "doc_link": "https://docs.datadoghq.com/integrations/portworx",
   "supported_os": ["linux"],
-  "categories": ["logging"],
+  "categories": ["log collection", "monitoring"],
   "version": "1.0.0",
   "is_public": true,
   "has_logo": true


### PR DESCRIPTION
### What does this PR do?

Removes the `logging` category and leaves only the `log collection` one

### Motivation

Better consistency for integrations categorization