### PR TITLE
Fix Uptime tile app key name

### DIFF
--- a/uptime/README.md
+++ b/uptime/README.md
@@ -21,7 +21,7 @@ The following describes the fields shown when configuring Datadog within your Up
 
 * API key: <span class="hidden-api-key">${api_key}</span>
 
-* Application Key: <span class="app_key" data-name="uptime.com"></span> 
+* Application Key: <span class="app_key" data-name="uptime"></span> 
 
 <li>Once you've configured your Datadog profile, you will need to assign the profile to a contact group located under Alerting>Contacts. The profile is assigned at the Push Notifications field within the contact group.</li> 
 </ul>

--- a/uptime/README.md
+++ b/uptime/README.md
@@ -27,6 +27,7 @@ The following describes the fields shown when configuring Datadog within your Up
 </ul>
 
 ## Data Collected
+
 ### Metrics
 See [metadata.csv][3] for a list of metrics provided by this integration.
 


### PR DESCRIPTION
### What does this PR do?

The app key name must match the name of the integration. The integration name is `uptime`, but the app key name is currently `uptime.com`. It needs to be changed to `uptime` so it matches the integration name.

### Motivation

https://trello.com/c/MC6FarnR/302-uptime-integration-tab-not-providing-key

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Will need to run update the tile  for `uptime` on Jenkins after merging.
