### PR TITLE
Storm Check Robustness Improvement and Backwards Compatibility for [1.0.0, 1.2.0) versions

### DIFF
--- a/storm/CHANGELOG.md
+++ b/storm/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG - Storm
 
-1.0.2/ Unreleased
+1.1.1/ Released
+=================
+
+### Changes
+
+* [UPDATE] Make backwards compatible with storm [1.0.0, 1.2.0).
+* [FIX] Make this more robust to api errors.
+
+1.0.2/ Released
 =================
 
 ### Changes

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -8,7 +8,7 @@
   "guid": "5a9ec2c3-8ea0-4337-8c45-a6b8a36b8721",
   "support": "contrib",
   "supported_os": ["linux","mac_os","windows"],
-  "version": "1.1.0",
+  "version": "1.1.1",
   "public_title": "Datadog-Storm Integration",
   "categories":["processing"],
   "type":"check",


### PR DESCRIPTION
### What does this PR do?

Some storm users using versions [1.0.0, 1.2.0) noted that the topology metrics endpoint was failing as this endpoint changed on the 1.2.0 release. This makes it backwards compatible with this version.

It also adds some robustness to the check to continue collecting what metrics are possible before bailing.

### Motivation

Some storm users using versions [1.0.0, 1.2.0) noted that the topology metrics endpoint was failing.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?

While technically this makes it possible for storm users [1.0.0, 1.2.0) to use this check now, it will not be actively tested for regressions.