### PR TITLE
reboot_required: prefer default working directory of /var/tmp over /var/run/dd-agent

### DIFF
--- a/reboot_required/README.md
+++ b/reboot_required/README.md
@@ -31,13 +31,6 @@ To configure the Reboot Required check:
         - reboot_signal_file: "/var/run/reboot-required"
     ```
 
-4. Make sure you create a dd-agent (user that runs the Datadog agent) writable directory for the agent, and used by this check. The default of /var/run/dd-agent is ideal. The snippet below should suffice.
-
-    ```
-    sudo mkdir /var/run/dd-agent
-    sudo chown dd-agent:dd-agent /var/run/dd-agent
-    ```
-
 5. [Restart the Agent][3].
 
 ### Validation

--- a/reboot_required/datadog_checks/reboot_required/data/conf.yaml.example
+++ b/reboot_required/datadog_checks/reboot_required/data/conf.yaml.example
@@ -11,6 +11,6 @@ instances:
   # put the created_at file.
   #
   - reboot_signal_file: "/var/run/reboot-required"
-  # created_at_file: "/var/run/dd-agent/reboot-required.created_at"
+  # created_at_file: "/var/tmp/dd-agent/reboot-required.created_at"
   # days_warning: 7
   # days_critical: 14

--- a/reboot_required/datadog_checks/reboot_required/data/conf.yaml.example
+++ b/reboot_required/datadog_checks/reboot_required/data/conf.yaml.example
@@ -11,6 +11,6 @@ instances:
   # put the created_at file.
   #
   - reboot_signal_file: "/var/run/reboot-required"
-  # created_at_file: "/var/tmp/dd-agent/reboot-required.created_at"
+  # created_at_file: "/var/tmp/reboot-required.created_at"
   # days_warning: 7
   # days_critical: 14

--- a/reboot_required/datadog_checks/reboot_required/reboot_required.py
+++ b/reboot_required/datadog_checks/reboot_required/reboot_required.py
@@ -13,7 +13,7 @@ from datadog_checks.checks import AgentCheck
 class RebootRequiredCheck(AgentCheck):
 
     REBOOT_SIGNAL_FILE = '/var/run/reboot-required'
-    CREATED_AT_FILE = '/var/run/dd-agent/reboot-required.created_at'
+    CREATED_AT_FILE = '/var/tmp/reboot-required.created_at'
 
     def check(self, instance):
         status, days_since, msg = self._check(instance)


### PR DESCRIPTION
After production use it has become clear the default location of `/var/run/dd-agent` for working files by this integration is inappropriate. /var/run is cleared after rebooting and this integration does not ensure the directory `/var/run/dd-agent` exists. This is also a simplification. 

I think a better default is `/var/tmp`. 

See discussion [here](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s13.html) and [here](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s15.html) 