### PR TITLE
Add datadog_checks_dev to req-test file to fix Travis

### DIFF
--- a/reboot_required/requirements-dev.txt
+++ b/reboot_required/requirements-dev.txt
@@ -1,2 +1,1 @@
-mock==2.0.0
-pytest
+datadog-checks-dev

--- a/sortdb/requirements-dev.txt
+++ b/sortdb/requirements-dev.txt
@@ -1,2 +1,1 @@
-mock==2.0.0
-pytest
+datadog-checks-dev


### PR DESCRIPTION
### What does this PR do?

Add datadog_checks_dev to the requirements-test file for Traefik and Reboot_required. 

### Motivation

Tests were failing because the tox files don't currently include the `bench` flag when running `ddev -e test {CHECK}`, so `ddev` includes `--benchmark-skip` when running pytest. Since ddev wasn't a dependency when running tests, pytest-benchmark wasn't being installed and `pytest` failed due to not knowing what `--benchmark-skip` was. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
