### PR TITLE
update_syntax_for_a6

### DIFF
--- a/hbase_master/conf.yaml.example
+++ b/hbase_master/conf.yaml.example
@@ -110,6 +110,8 @@ init_config:
             metric_type: gauge
             alias: hbase.master.server.tag.is_active_master
             values: {true: 1, false: 0, default: 0}
+            #must wrap true and false in quotes for Agent 6
+            #values: {"true": 1, "false": 0, default: 0}
           # Number of RegionServers
           numRegionServers:
             metric_type: gauge


### PR DESCRIPTION
The syntax in line 112: values: {true: 1, false: 0, default: 0} does not work in agent 6 as true and false are read as booleans and not strings in go

### What does this PR do?

Adds a note to correct a syntax error that comes up in Agent 6

### Motivation

Support Ticket 166416

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
