### PR TITLE
Adding comments to `storm/conf.yaml.example` for clarity.

### DIFF
--- a/storm/conf.yaml.example
+++ b/storm/conf.yaml.example
@@ -7,8 +7,9 @@ init_config:
   #   - 60
 
 instances:
-  # - server: http://localhost:9005
-  #   # Always specify the server.
+  # - server: http://localhost:8080
+  #   # Always specify the server with the default storm REST api port.
+  #   # Default is 8080
   #
   #   # Specify the environment
   #   environment: preproduction


### PR DESCRIPTION
### What does this PR do?
Just a brief comments change in `storm/conf.yaml.example` that would be easily discernable which server we are pointing to. 

### Motivation
Was setting up a datadog integration for storm, and needed to look into `storm/checks.py` to make sure it was actually hitting the storm REST API which defaults to port `8080`. Hoping to speed up the process in clarity for the `conf.yaml.example` file.

Storm documentation:
http://storm.apache.org/releases/current/STORM-UI-REST-API.html

Storm default conf:
https://github.com/apache/storm/blob/8f9061a1b7c56499a42bcb406a11287955cfce73/conf/defaults.yaml#L91

### Additional Notes
Should be pretty simple?
