### PR TITLE
[aerospike] Fix link to check.py

### DIFF
--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -28,17 +28,17 @@ To configure the Aerospike check:
 
 1. Create a `aerospike.d/` folder in the `conf.d/` folder at the root of your Agent's directory. 
 2. Create a `conf.yaml` file in the `aerospike.d/` folder previously created.
-3. Consult the [sample aerospike.yaml][2] file and copy its content in the `conf.yaml` file.
+3. Consult the [sample aerospike.yaml][3] file and copy its content in the `conf.yaml` file.
 4. Edit the `conf.yaml` file to point to your server and port, set the masters to monitor.
-5. [Restart the Agent][3].
+5. [Restart the Agent][4].
 
 ## Validation
 
-[Run the Agent's `status` subcommand][4] and look for `aerospike` under the Checks section.
+[Run the Agent's `status` subcommand][5] and look for `aerospike` under the Checks section.
 
 ## Data Collected
 ### Metrics
-See [metadata.csv][5] for a list of metrics provided by this check.
+See [metadata.csv][6] for a list of metrics provided by this check.
 
 ### Events
 The Aerospike check does not include any events at this time.
@@ -47,11 +47,12 @@ The Aerospike check does not include any events at this time.
 The Aerospike check does not include any service checks at this time.
 
 ## Troubleshooting
-Need help? Contact us in the [Aerospike Forums][6].
+Need help? Contact us in the [Aerospike Forums][7].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://github.com/DataDog/integrations-extras/blob/master/aerospike/conf.yaml.example
-[3]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
-[4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[5]: https://github.com/DataDog/integrations-extras/blob/master/aerospike/metadata.csv
-[6]: http://discuss.aerospike.com
+[2]: https://github.com/DataDog/integrations-extras/blob/master/aerospike/check.py
+[3]: https://github.com/DataDog/integrations-extras/blob/master/aerospike/conf.yaml.example
+[4]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
+[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
+[6]: https://github.com/DataDog/integrations-extras/blob/master/aerospike/metadata.csv
+[7]: http://discuss.aerospike.com


### PR DESCRIPTION
Currently the link to `check.py` actually points to `conf.yaml.example`

### What does this PR do?

Fixes the Aerospike docs so that the link to `check.py` points to the right place.

### Motivation

Tried to follow the docs and noticed the link took me to the wrong place

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
