### PR TITLE
Fixed two links in the snmpwalk page

### DIFF
--- a/snmpwalk/README.md
+++ b/snmpwalk/README.md
@@ -51,11 +51,10 @@ The check returns:
 * `CRITICAL` if check encounters an error when trying to collect metrics from `snmpwalk`.
 
 ## Troubleshooting
-Need help? Contact [Datadog Support][6].
+Need help? Contact [Datadog Support][5].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://github.com/DataDog/integrations-extras/blob/master/hbase_regionserver/conf.yaml.example
+[2]: https://github.com/DataDog/integrations-extras/blob/master/snmpwalk/check.py
 [3]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [4]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[5]: https://github.com/DataDog/integrations-extras/blob/master/hbase_regionserver/metadata.csv
-[6]: http://docs.datadoghq.com/help/
+[5]: http://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?

Fixed two links in the snmpwalk help page

### Motivation

The link to the `check.py` file was wrong, also the 5th footnote was not referred anywhere and I removed 6th link for that reason.
