### PR TITLE
replace dash with underscore for the service check name.

### DIFF
--- a/storm/README.md
+++ b/storm/README.md
@@ -42,7 +42,7 @@ See [metadata.csv][5] for a list of metrics provided by this check.
 The Storm check does not include any events at this time.
 
 ### Service Checks
-**`topology-check.{}`**
+**`topology_check.{TOPOLOGY NAME}`**
 
 The check returns:
 

--- a/storm/check.py
+++ b/storm/check.py
@@ -705,7 +705,7 @@ class StormCheck(AgentCheck):
                             topology_status = _get_string(stats, 'unknown', 'status').upper()
                             check_status = AgentCheck.CRITICAL if topology_status != 'ACTIVE' else AgentCheck.OK
                             self.service_check(
-                                'topology-check.{}'.format(topology_name),
+                                'topology_check.{}'.format(topology_name),
                                 status=check_status,
                                 message='{} topology status marked as: {}'.format(topology_name, topology_status),
                                 tags=['stormEnvironment:{}'.format(self.environment_name)] + self.additional_tags


### PR DESCRIPTION
### What does this PR do?
changes dash to underscore for svc check name. Dash/hyphens gets converted to underscore in app anyway since it's not a valid char, so no apparent change for the user.

updates readme as well.

### Motivation
ticket - client asking where/how to get `topology-check.{}`. Found that they already have it as `topology_check.{topology_name}`.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing? nope.
