### PR TITLE
[aqua] add service check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 *                       @DataDog/agent-integrations
 /aerospike/             r.guo@aerospike.com
 /ambassador/            hello@datawire.io
+/aqua/                  @DataDog/container-integrations
 /buddy/                 support@buddy.works
 /eventstore/            @xorima
 /filebeat/              jean@tripping.com

--- a/aqua/service_checks.json
+++ b/aqua/service_checks.json
@@ -1,0 +1,11 @@
+[
+    {
+        "agent_version": "6.0.0",
+        "integration": "aqua",
+        "check": "aqua.can_connect",
+        "statuses": ["ok", "critical"],
+        "groups": ["host"],
+        "name": "Can Connect",
+        "description": "Returns CRITICAL if the Agent cannot connect to Aqua to collect metrics. Returns OK otherwise."
+    }
+]


### PR DESCRIPTION
### What does this PR do?

Add missing `service check` definition in Aqua integration.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
