### PR TITLE
Fix instance cache and increment metrics in Filebeat check

### DIFF
--- a/filebeat/check.py
+++ b/filebeat/check.py
@@ -211,11 +211,12 @@ class FilebeatCheck(AgentCheck):
     def check(self, instance):
         instance_key = hash_mutable(instance)
         if instance_key in self.instance_cache:
-            config = self.instance_cache['config']
-            profiler = self.instance_cache['profiler']
+            config = self.instance_cache[instance_key]['config']
+            profiler = self.instance_cache[instance_key]['profiler']
         else:
-            self.instance_cache['config'] = config = FilebeatCheckInstanceConfig(instance)
-            self.instance_cache['profiler'] = profiler = FilebeatCheckHttpProfiler(config)
+            config = FilebeatCheckInstanceConfig(instance)
+            profiler = FilebeatCheckHttpProfiler(config)
+            self.instance_cache[instance_key] = {'config': config, 'profiler': profiler}
 
         self._process_registry(config)
         self._gather_http_profiler_metrics(config, profiler)


### PR DESCRIPTION
### What does this PR do?

Fixes #319 

### Motivation

Most metrics from the Filebeat check were not being successfully reported.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

I tested this on an agent which wasn't reporting metrics and it now reports:

```
    filebeat (custom)
    -----------------
      - instance #0 [OK]
      - Collected 16 metrics, 0 events & 0 service checks
```

The metrics also now show up in the Datadog UI.