### PR TITLE
Re-enable metadata validation on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ script:
   - ddev -e validate manifest -i
   - ddev -e validate config
   - ddev -e validate service-checks
-  # FIXME: fix metadata for all the integrations before enabling the following:
-  # - ddev -e validate metadata ${CHECK}
+  - ddev -e validate metadata ${CHECK}
   - travis_retry ddev -e test ${CHECK}
 
 # Conditional jobs are currently buggy and verbose.
@@ -47,8 +46,7 @@ jobs:
         - ddev -e validate manifest -i
         - ddev -e validate config
         - ddev -e validate service-checks
-        # FIXME: fix metadata for all the integrations before enabling the following:
-        # - ddev -e validate metadata
+        - ddev -e validate metadata
         # with no params, ddev will only test integrations that are part of the branch diff
         - ddev -e test
     - stage: test

--- a/buddy/metadata.csv
+++ b/buddy/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name


### PR DESCRIPTION
### What does this PR do?

Now that all the integrations are complaint, re-enable validation for PRs and merges on `master`.

### Additional notes

Missing header was added to the `buddy` integration to avoid exposing a bug in the validation tool (addressed in a dedicated PR)