### PR TITLE
Point link to the integrations howto page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For more information on integrations, please reference our [documentation][6] an
 [1]: https://api.travis-ci.com/DataDog/integrations-extras.svg?branch=master
 [2]: https://travis-ci.com/DataDog/integrations-extras
 [3]: https://www.datadoghq.com
-[4]: https://docs.datadoghq.com/developers/integrations/
+[4]: https://docs.datadoghq.com/developers/integrations/new_check_howto/
 [5]: https://github.com/DataDog/integrations-extras/compare
 [6]: http://docs.datadoghq.com
 [7]: https://help.datadoghq.com/hc/en-us


### PR DESCRIPTION
### What does this PR do?

Point the link to dev docs  in the main README to https://docs.datadoghq.com/developers/integrations/new_check_howto/ instead of https://docs.datadoghq.com/developers/integrations

### Motivation

Go straight to the point


