### PR TITLE
[Uptime integration] Fix graph snapshot image link

### DIFF
--- a/uptime/README.md
+++ b/uptime/README.md
@@ -40,7 +40,7 @@ The Uptime check does not include any service checks at this time.
 ## Troubleshooting
 Need help? Contact [Datadog support][4].
 
-[1]: https://raw.githubusercontent.com/DataDog/integrations-extras/ilan/uptime/uptime/images/snapshot.png
+[1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/uptime/images/snapshot.png
 [2]: https://uptime.com/push-notifications/manage/
 [3]: https://github.com/DataDog/integrations-extras/blob/master/uptime/metadata.csv
 [4]: http://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?

[Uptime integration] Fixes the graph snapshot image link in the README.

### Motivation

Image not showing up.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
