### PR TITLE
[Uptime] include events in documentation

### DIFF
--- a/uptime/README.md
+++ b/uptime/README.md
@@ -15,15 +15,15 @@ Get events and metrics from your app in real time to:
 
 In order to activate the integration of Datadog within your Uptime account, go to [Alerting>Push Notifications][2] then choose Datadog as the provider type when adding a new push notifications profile.
 
-The following describes the fields shown when configuring Datadog within your Uptime account: 
+The following describes the fields shown when configuring Datadog within your Uptime account:
 
 * Name: The reference name you desire to assign to your Datadog profile. It can assist you with organizing multiple provider profiles within your Uptime account.
 
 * API key: <span class="hidden-api-key">${api_key}</span>
 
-* Application Key: <span class="app_key" data-name="uptime"></span> 
+* Application Key: <span class="app_key" data-name="uptime"></span>
 
-<li>Once you've configured your Datadog profile, you will need to assign the profile to a contact group located under Alerting>Contacts. The profile is assigned at the Push Notifications field within the contact group.</li> 
+<li>Once you've configured your Datadog profile, you will need to assign the profile to a contact group located under Alerting>Contacts. The profile is assigned at the Push Notifications field within the contact group.</li>
 </ul>
 
 ## Data Collected
@@ -32,7 +32,7 @@ The following describes the fields shown when configuring Datadog within your Up
 See [metadata.csv][3] for a list of metrics provided by this integration.
 
 ### Events
-The Uptime check does not include any events.
+The Uptime integration sends an event to your Datadog Event Stream when an alert happens or resolves.
 
 ### Service Checks
 The Uptime check does not include any service checks.


### PR DESCRIPTION
### What does this PR do?

Update the Uptime integration documentation to mention the events that get sent when alerts happen.

### Motivation

Our documentation is inconsistent with the one from Uptime: https://support.uptime.com/hc/en-us/articles/115002536629-Configuring-Datadog

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
