### PR TITLE
Fix hbase regionserver docs

### DIFF
--- a/hbase_regionserver/README.md
+++ b/hbase_regionserver/README.md
@@ -1,34 +1,33 @@
-# Hbase_regionserver Integration
+# HBase RegionServer Integration
 
 ## Overview
 
-Get metrics from Hbase_regionserver service in real time to:
+Get metrics from the HBase RegionServer service in real time to:
 
-* Visualize and monitor Hbase_regionserver states.
-* Be notified about Hbase_regionserver failovers and events.
+* Visualize and monitor HBase RegionServer states.
+* Be notified about HBase RegionServer failovers and events.
 
 ## Setup
 
-The Hbase_regionserver check is **NOT** included in the [Datadog Agent][1] package.
+The HBase RegionServer check is **NOT** included in the [Datadog Agent][1] package.
 
 ### Installation
 
-To install the Hbase_regionserver check on your host:
+To install the HBase RegionServer check on your host:
 
 1. [Download the Datadog Agent][1].
-2. Download the [`check.py` file][2] for Hbase_regionserver.
-3. Place it in the Agent's `checks.d` directory.
-4. Rename it to `hbase_regionserver.py`.
+2. Create a `hbase_regionserver.d/` folder in the `conf.d/` folder at the root of your Agent's directory. 
+3. Create a `conf.yaml` file in the `hbase_regionserver.d/` folder previously created.
+4. Consult the [sample hbase_regionserver.yaml][2] file and copy its content in the `conf.yaml` file.
+5. [Restart the Agent][3].
 
 ### Configuration
 
-To configure the Hbase_regionserver check: 
+To configure the HBase RegionServer check: 
 
-1. Create a `hbase_regionserver.d/` folder in the `conf.d/` folder at the root of your Agent's directory. 
-2. Create a `conf.yaml` file in the `hbase_regionserver.d/` folder previously created.
-3. Consult the [sample hbase_regionserver.yaml][2] file and copy its content in the `conf.yaml` file.
-4. Edit the `conf.yaml` file to point to your server and port, set the masters to monitor.
-5. [Restart the Agent][3].
+1. Open the `conf.yaml` file created during installation.
+2. Edit the `conf.yaml` file to point to your server and port, set the masters to monitor.
+3. [Restart the Agent][3].
 
 ## Validation
 
@@ -39,10 +38,10 @@ To configure the Hbase_regionserver check:
 See [metadata.csv][5] for a list of metrics provided by this check.
 
 ### Events
-The Hbase_regionserver check does not include any events.
+The HBase RegionServer check does not include any events.
 
 ### Service Checks
-The Hbase_regionserver check does not include any service checks.
+The HBase RegionServer check does not include any service checks.
 
 ## Troubleshooting
 Need help? Contact [Datadog support][6].


### PR DESCRIPTION
### What does this PR do?

Correct inaccuracy in hbase regionserver docs, this is no longer a check.py to download but rather a JMX based check.

### Motivation

Support request.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)


