### PR TITLE
Aerospike is now in integrations-core

### DIFF
--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -1,58 +1,6 @@
 # Aerospike Integration
 
 ## Overview
+As of Agent 6.10, Aerospike is included in [integrations-core][1] and shipped with the Agent. This integration has been deprecated and we recommend using the officially supported version.
 
-Get metrics from Aerospike Database in real time to:
-
-* Visualize and monitor Aerospike states
-* Be notified about Aerospike failovers and events.
-
-Note: Authentication and TLS are not supported.
-
-## Setup
-
-The Aerospike check is **NOT** included in the [Datadog Agent][1] package.
-
-### Installation
-
-To install the Aerospike check on your host:
-
-1. [Download the Datadog Agent][1].
-2. Download the [`check.py` file][2] for Aerospike.
-3. Place it in the Agent's `checks.d` directory.
-4. Rename it to `aerospike.py`.
-
-### Configuration
-
-To configure the Aerospike check: 
-
-1. Create a `aerospike.d/` folder in the `conf.d/` folder at the root of your Agent's directory. 
-2. Create a `conf.yaml` file in the `aerospike.d/` folder previously created.
-3. Consult the [sample aerospike.yaml][3] file and copy its content in the `conf.yaml` file.
-4. Edit the `conf.yaml` file to point to your server and port, set the masters to monitor.
-5. [Restart the Agent][4].
-
-## Validation
-
-[Run the Agent's `status` subcommand][5] and look for `aerospike` under the Checks section.
-
-## Data Collected
-### Metrics
-See [metadata.csv][6] for a list of metrics provided by this check.
-
-### Events
-The Aerospike check does not include any events.
-
-### Service Checks
-The Aerospike check does not include any service checks.
-
-## Troubleshooting
-Need help? Contact us in the [Aerospike Forums][7].
-
-[1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://github.com/DataDog/integrations-extras/blob/master/aerospike/check.py
-[3]: https://github.com/DataDog/integrations-extras/blob/master/aerospike/conf.yaml.example
-[4]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
-[5]: https://docs.datadoghq.com/agent/faq/agent-commands/#agent-status-and-information
-[6]: https://github.com/DataDog/integrations-extras/blob/master/aerospike/metadata.csv
-[7]: http://discuss.aerospike.com
+[1]: https://github.com/DataDog/integrations-core/tree/master/aerospike


### PR DESCRIPTION
### What does this PR do?

Aerospike is now in integrations-core. Note this PR should not be merged until Agent 6.10 is released.

### Motivation

This integration is deprecated. It should eventually be removed in favor of the officially supported integration.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
