### PR TITLE
Fix connected but no active fullsync replication exception

### DIFF
--- a/riak_repl/datadog_checks/riak_repl/riak_repl.py
+++ b/riak_repl/datadog_checks/riak_repl/riak_repl.py
@@ -97,6 +97,8 @@ class RiakReplCheck(AgentCheck):
 
         for c in stats['connected_clusters']:
             cluster = c.replace("-", "_")
+            if c not in stats['fullsync_coordinator']:
+                continue
             for key, val in stats['fullsync_coordinator'][c].iteritems():
                 if key in self.FULLSYNC_COORDINATOR:
                     self.safe_submit_metric("riak_repl.fullsync_coordinator."


### PR DESCRIPTION
### What does this PR do?

The agent was throwing an exception when there is a connected cluster but no active fullsync replication. 

This fix will ignore fullsync replication metrics when there is no active  fullsync coordinator, which means a fullsync is not happening for this  specific cluster.

### Motivation
In our use case riak is connected to multiple clusters but the fullsync replication is not active to all of those clusters. 

We tested and applied the proposed change and were able to get the metrics for the current active fullsync replication.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [X] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
