### PR TITLE
Add style configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+# TODO: port this to pyproject.toml when supported: https://gitlab.com/pycqa/flake8/merge_requests/245
+
+[flake8]
+select = B,C,E,F,W,B001,B003,B006,B007,B301,B305,B306,B902
+ignore = E203,E722,W503
+exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*
+max-line-length = 120

--- a/.flake8
+++ b/.flake8
@@ -3,5 +3,5 @@
 [flake8]
 select = B,C,E,F,W,B001,B003,B006,B007,B301,B305,B306,B902
 ignore = E203,E722,W503
-exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*
+exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/*/vendor/*
 max-line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+# NOTE: You have to use single-quoted strings in TOML for regular expressions.
+# It's the equivalent of r-strings in Python. Multiline strings are treated as
+# verbose regular expressions by Black. Use [ ] to denote a significant space
+# character.
+
+[tool.black]
+exclude = '''
+# Directories
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+include = '\.pyi?$'
+line-length = 120
+py36 = false
+skip-string-normalization = true
+
+[tool.isort]
+default_section = 'THIRDPARTY'
+force_grid_wrap = 0
+include_trailing_comma = true
+known_first_party = 'datadog_checks'
+line_length = 120
+multi_line_output = 3
+skip_glob = 'datadog_checks/*/vendor/*'
+use_parentheses = true


### PR DESCRIPTION
### What does this PR do?

This adds the flake9 configuration at the root of the extras repository.

### Motivation

The new style check command references a flake8 configuration at the root of
the core repository. To be able to use in extras we need a copy of it.