### PR TITLE
Add integration_id to manifest.json

### DIFF
--- a/aerospike/manifest.json
+++ b/aerospike/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "aerospike",
   "categories": [
     "data store"
   ],

--- a/ambassador/manifest.json
+++ b/ambassador/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "ambassador",
   "name": "ambassador",
   "guid": "71936a65-1a8c-4f6e-a18e-f71d4236182b",
   "support": "contrib",

--- a/aqua/manifest.json
+++ b/aqua/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "aqua",
   "display_name": "Aqua",
   "maintainer": "oran.moshai@aquasec.com",
   "manifest_version": "1.0.0",

--- a/buddy/manifest.json
+++ b/buddy/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "buddy",
   "name": "buddy",
   "manifest_version": "1.0.2",
   "maintainer": "support@buddy.works",

--- a/concourse_ci/manifest.json
+++ b/concourse_ci/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "concourse-ci",
     "categories": [
         "Collaboration"
     ],

--- a/convox/manifest.json
+++ b/convox/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "convox",
   "name": "convox",
   "manifest_version": "1.0.1",
   "display_name": "Convox",

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "eventstore",
   "maintainer": "@xorima",
   "manifest_version": "1.0.0",
   "name": "eventstore",

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "filebeat",
   "maintainer": "jean@tripping.com",
   "manifest_version": "1.0.0",
   "name": "filebeat",

--- a/gnatsd/manifest.json
+++ b/gnatsd/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "gnatsd",
   "maintainer": "dev@goldstar.com",
   "manifest_version": "1.0.0",
   "name": "gnatsd",

--- a/gnatsd_streaming/manifest.json
+++ b/gnatsd_streaming/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "gnatsd-streaming",
   "maintainer": "dev@goldstar.com",
   "manifest_version": "1.0.0",
   "name": "gnatsd_streaming",

--- a/gremlin/manifest.json
+++ b/gremlin/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "gremlin",
   "categories": ["chaos engineering"],
   "creates_events": true,
   "display_name": "Gremlin",

--- a/hbase_master/manifest.json
+++ b/hbase_master/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "hbase-master",
   "maintainer": "everpeace",
   "manifest_version": "1.0.0",
   "name": "hbase_master",

--- a/hbase_regionserver/manifest.json
+++ b/hbase_regionserver/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "hbase-regionserver",
   "maintainer": "everpeace",
   "manifest_version": "1.0.0",
   "creates_events": false,

--- a/launchdarkly/manifest.json
+++ b/launchdarkly/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "launchdarkly",
   "supported_os": [
     "linux",
     "mac_os",

--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "logstash",
   "maintainer": "ervansetiawan@gmail.com",
   "manifest_version": "1.0.0",
   "name": "logstash",

--- a/logzio/manifest.json
+++ b/logzio/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "logzio",
   "name": "logzio",
   "manifest_version": "1.0.2",
   "display_name": "Logz.io",

--- a/neo4j/manifest.json
+++ b/neo4j/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "neo4j",
   "maintainer": "help@neo4j.com",
   "manifest_version": "1.0.0",
   "name": "neo4j",

--- a/neutrona/manifest.json
+++ b/neutrona/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "neutrona",
   "display_name": "Neutrona",
   "maintainer": "david@neutrona.com",
   "manifest_version": "1.0.0",

--- a/nextcloud/manifest.json
+++ b/nextcloud/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "nextcloud",
   "display_name": "Nextcloud",
   "maintainer": "emeric.planet@gmail.com",
   "manifest_version": "1.0.0",

--- a/nomad/manifest.json
+++ b/nomad/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "nomad",
   "maintainer": "irabinovitch",
   "manifest_version": "1.0.0",
   "name": "nomad",

--- a/portworx/manifest.json
+++ b/portworx/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "portworx",
   "maintainer": "paul@portworx.com",
   "manifest_version": "1.0.0",
   "name": "portworx",

--- a/rbltracker/manifest.json
+++ b/rbltracker/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "rbltracker",
   "name": "rbltracker",
   "manifest_version": "1.0.1",
   "display_name": "RBLTracker",

--- a/reboot_required/manifest.json
+++ b/reboot_required/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "reboot-required",
   "maintainer": "support@krugerheavyindustries.com",
   "manifest_version": "1.0.0",
   "name": "reboot_required",

--- a/redis_sentinel/manifest.json
+++ b/redis_sentinel/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "redis-sentinel",
   "maintainer": "@krasnoukhov",
   "manifest_version": "1.0.0",
   "name": "redis_sentinel",

--- a/riak_repl/manifest.json
+++ b/riak_repl/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "riak-repl",
   "display_name": "Riak MDC Replication",
   "maintainer": "britt.treece@gmail.com",
   "manifest_version": "1.0.0",

--- a/rigor/manifest.json
+++ b/rigor/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "rigor",
   "categories": ["monitoring"],
   "creates_events": true,
   "display_name": "Rigor",

--- a/rookout/manifest.json
+++ b/rookout/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "rookout",
   "name": "rookout",
   "manifest_version": "1.0.0",
   "maintainer": "support@rookout.com",

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "sigsci",
   "name": "sigsci",
   "manifest_version": "1.0.0",
   "guid": "0c92b7cd-0736-4f9d-82ed-16f1bba8c8d0",

--- a/snmpwalk/manifest.json
+++ b/snmpwalk/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "snmpwalk",
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "snmpwalk",

--- a/sortdb/manifest.json
+++ b/sortdb/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "sortdb",
   "maintainer": "namrata.deshpande4@gmail.com",
   "manifest_version": "1.0.0",
   "name": "sortdb",

--- a/split/manifest.json
+++ b/split/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "split",
   "maintainer": "jeremy-lq",
   "manifest_version": "1.0.1",
   "name": "split",

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "storm",
   "maintainer": "@platinummonkey",
   "manifest_version": "1.0.0",
   "name": "storm",

--- a/uptime/manifest.json
+++ b/uptime/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "uptime",
   "maintainer": "jeremy-lq",
   "manifest_version": "1.0.0",
   "name": "uptime",

--- a/vns3/manifest.json
+++ b/vns3/manifest.json
@@ -1,4 +1,5 @@
 {
+  "integration_id": "vns3",
   "name": "vns3",
   "categories": [
     "network"


### PR DESCRIPTION
### What does this PR do?

This adds integration_id to all the manifests missing it.

### Motivation

The next ddev release will enforce this new field, so extras CI will break if
we don't fix it by then.