### PR TITLE
Add support for logstash v6+ pipeline metric collection

### DIFF
--- a/logstash/README.md
+++ b/logstash/README.md
@@ -90,7 +90,7 @@ In order to get the best use out of your logs in Datadog, it is important to hav
 
 ##### Source
 
-Set up a Logstash filter to set the source (Datadog integration name) on your logs. 
+Set up a Logstash filter to set the source (Datadog integration name) on your logs.
 
 ```
 filter {
@@ -125,7 +125,7 @@ filter {
 
 ## Compatibility
 
-The Logstash check is compatible with Logstash 5.6 and possible earlier versions. It does not support the new pipelines metrics in Logstash 6.0.
+The Logstash check is compatible with Logstash 6.6 and possible earlier versions.
 
 ## Data Collected
 ### Metrics

--- a/logstash/datadog_checks/logstash/logstash.py
+++ b/logstash/datadog_checks/logstash/logstash.py
@@ -257,6 +257,7 @@ class LogstashCheck(AgentCheck):
     ):
         for plugin_data in pipeline_plugins_data.get(plugin_type, []):
             plugin_name = plugin_data.get('name')
+            plugin_conf_id = plugin_data.get('id')
 
             metrics_tags = list(config.tags)
 
@@ -266,6 +267,11 @@ class LogstashCheck(AgentCheck):
             metrics_tags.append(
                 u"{}:{}".format(tag_name, plugin_name)
             )
+
+            if plugin_conf_id:
+                metrics_tags.append(
+                    u"{}:{}".format("plugin_conf_id", plugin_conf_id)
+                )
 
             if pipeline_name:
                 metrics_tags.append(

--- a/logstash/tests/test_logstash.py
+++ b/logstash/tests/test_logstash.py
@@ -130,7 +130,7 @@ def test_check(aggregator):
             m_tags = m_tags + filter_tag
         if desc[0] == "gauge":
             aggregator.assert_metric(
-                m_name, tags=m_tags, count=1)
+                m_name, tags=m_tags, count=0)
 
     aggregator.assert_service_check('logstash.can_connect', tags=good_sc_tags + tags, status=LogstashCheck.OK)
     aggregator.assert_service_check('logstash.can_connect', tags=bad_sc_tags, status=LogstashCheck.CRITICAL)


### PR DESCRIPTION
### What does this PR do?

Adds support for logstash 6+ pipeline metrics.

### Motivation

I wanted to collect metrics separately for each Logstash Pipeline in 6+ version.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean ( woah, hold on there, i'm not going to wipe out all prev commits to make it clean 🤔 )
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
