### PR TITLE
Aqua User / Pass cast to string

### DIFF
--- a/aqua/datadog_checks/aqua/aqua.py
+++ b/aqua/datadog_checks/aqua/aqua.py
@@ -92,7 +92,7 @@ class AquaCheck(AgentCheck):
         Retrieve the Aqua token for next queries.
         """
         headers = {'Content-Type': 'application/json', 'charset': 'UTF-8'}
-        data = {"id": instance['api_user'], "password": instance['password']}
+        data = {"id": str(instance['api_user']), "password": str(instance['password'])}
         res = requests.post(
             instance['url'] + '/api/v1/login',
             data=json.dumps(data),


### PR DESCRIPTION
The Aqua integration requires a string for user and password. If you specify a number in either, Aqua will return a 400 error for a bad request. It requires a string.

### What does this PR do?

Force the username and password to a string before passing it along to the Aqua API.

### Motivation

Issue with integrating with Aqua.

### Review checklist

- [ X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [X ] Feature or bugfix has tests
- [ X] Git history is clean
- [ X] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
