### PR TITLE
[Nextcloud] set to public

### DIFF
--- a/nextcloud/manifest.json
+++ b/nextcloud/manifest.json
@@ -20,5 +20,5 @@
     "collaboration"
   ],
   "type": "check",
-  "is_public": false
+  "is_public": true
 }


### PR DESCRIPTION
### What does this PR do?
Set integration to public

### Motivation
All community integrations should be public

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
