### PR TITLE
Add new metrics from stats endpoint

### DIFF
--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -28,6 +28,7 @@ class FilebeatCheckHttpProfiler:
     """
 
     INCREMENT_METRIC_NAMES = [
+        "filebeat.events.done",
         "filebeat.harvester.closed",
         "filebeat.harvester.files.truncated",
         "filebeat.harvester.open_files",
@@ -56,10 +57,15 @@ class FilebeatCheckHttpProfiler:
         "libbeat.logstash.publish.write_errors",
         "libbeat.logstash.published_and_acked_events",
         "libbeat.logstash.published_but_not_acked_events",
+        "libbeat.output.events.acked",
         "libbeat.output.events.dropped",
         "libbeat.output.events.failed",
+        "libbeat.output.events.total",
         "libbeat.pipeline.events.dropped",
         "libbeat.pipeline.events.failed",
+        "libbeat.pipeline.events.filtered",
+        "libbeat.pipeline.events.published",
+        "libbeat.pipeline.events.total",
         "libbeat.publisher.messages_in_worker_queues",
         "libbeat.publisher.published_events",
         "libbeat.redis.publish.read_bytes",

--- a/filebeat/tests/test_filebeat.py
+++ b/filebeat/tests/test_filebeat.py
@@ -300,7 +300,7 @@ def test_regexes_only_get_compiled_and_run_once():
 
                 re_compile.assert_called_once_with(regex)
                 # once per metric name
-                assert re_search.call_count == 44
+                assert re_search.call_count == 50
 
     with mock_request(
         {"libbeat.logstash.published_and_acked_events": 1138956, "libbeat.kafka.published_and_acked_events": 12}


### PR DESCRIPTION
Add new metrics to Filebeat integration.

Looks like recent Filebeat versions changed some metric names. For example, Filebeat v6.7.0 do not expose in /stats metrics like:
`publish.events`
`libbeat.publisher.published_events`

But exposes metrics like:
`libbeat.pipeline.events.published`
`libbeat.output.events.acked`