### PR TITLE
Adjust nomad collection interval to 10 seconds in install instructions

### DIFF
--- a/nomad/README.md
+++ b/nomad/README.md
@@ -21,6 +21,7 @@ telemetry {
   publish_node_metrics       = true
   datadog_address = "localhost:8125"
   disable_hostname = true
+  collection_interval = "10s"
 }
 ```
 


### PR DESCRIPTION
### What does this PR do?

Adjust nomad collection interval to 10 seconds in install instructions

### Motivation

Nomad's default metric collection interval is [1 second by default](https://www.nomadproject.io/docs/configuration/telemetry.html#collection_interval) 🤷‍♂️ 

This PR set the interval to 10 second to reduce the CPU load on dogstatsd intake, as gauges will be aggregated on 10 seconds buckets anyway.

![](https://cl.ly/fb6b34a39083/Image%202019-04-10%20at%201.49.53%20PM.png)

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
