### PR TITLE
fixing broken link in Convox readme

### DIFF
--- a/convox/README.md
+++ b/convox/README.md
@@ -46,6 +46,6 @@ The Convox check does not include any service checks.
 Need help? Contact [Datadog support][4].
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/convox/images/snapshot.png
-[2]: https://convox.com/docs/datadog/
+[2]: https://docs.convox.com/external-services/datadog
 [3]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwet.html
 [4]: http://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?

Fixes the broken link to the external Convox docs.

### Motivation

It's broken.
