### PR TITLE
Changing integration type

### DIFF
--- a/bonsai/manifest.json
+++ b/bonsai/manifest.json
@@ -11,7 +11,7 @@
   "metric_to_check": "bonsai.req.total",
   "creates_events": false,
   "public_title": "Datadog-Bonsai Integration",
-  "type": "check",
+  "type": "crawler",
   "is_public": true,
   "categories": [
     "data store"


### PR DESCRIPTION
### What does this PR do?

Changes integration type to `crawler` to avoid confusion

### Motivation

Customer feedback.