### PR TITLE
Fix env testing in non local docker

### DIFF
--- a/nextcloud/tests/conftest.py
+++ b/nextcloud/tests/conftest.py
@@ -90,7 +90,7 @@ def nextcloud_add_trusted_domain():
         'config:system:set',
         'trusted_domains',
         '2',
-        '--value="{}"'.format(HOST),
+        '--value={}'.format(HOST),
     ]
     return subprocess.call(status_args) == 0
 

--- a/nextcloud/tox.ini
+++ b/nextcloud/tox.ini
@@ -17,4 +17,4 @@ passenv =
     COMPOSE*
 commands =
     pip install -r requirements.in
-    pytest -v
+    pytest -v {posargs}


### PR DESCRIPTION
When running docker-machine this was not setting the trusted domain properly, this fixes it.