### PR TITLE
Add instructions to avoid confusing error

### DIFF
--- a/eventstore/README.md
+++ b/eventstore/README.md
@@ -14,9 +14,10 @@ Get metrics from EventStore in real time to:
 To install the EventStore check on your host:
 
 1. Install the [developer toolkit][1] on any machine.
-2. Run `ddev release build eventstore` to build the package.
-3. [Download the Datadog Agent][2].
-4. Upload the build artifact to any host with an Agent and run `datadog-agent integration install -w path/to/eventstore/dist/<ARTIFACT_NAME>.whl`.
+2. Make sure the repository used is set to integrations-extras where the EventStore integration lives: `ddev config set repo extras`
+3. Run `ddev release build eventstore` to build the package.
+4. [Download the Datadog Agent][2].
+5. Upload the build artifact to any host with an Agent and run `datadog-agent integration install -w path/to/eventstore/dist/<ARTIFACT_NAME>.whl`.
 
 ### Configuration
 


### PR DESCRIPTION
While the setup guide for the Developer Toolkit does talk about the extras repository,
it is formulated as "if you are working with". When a user is just following the
instructions from the datadog official documentation homepage she/he has no
idea about the extras repository. Make it clear this is needed.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
