### PR TITLE
Accomodate newer lighthouse version json response formatting

### DIFF
--- a/lighthouse/datadog_checks/lighthouse/lighthouse.py
+++ b/lighthouse/datadog_checks/lighthouse/lighthouse.py
@@ -37,7 +37,7 @@ class LighthouseCheck(AgentCheck):
             self.log.warn("lighthouse response JSON different than expected for url: {0}".format(lighthouse_url))
             raise CheckException(error_message, exit_code, e)
 
-        if data["runtimeError"]["code"] == EXPECTED_RESPONSE_CODE:
+        if data.get("runtimeError", {"code": EXPECTED_RESPONSE_CODE}).get("code") == EXPECTED_RESPONSE_CODE:
             score_accessibility = round(data["categories"]["accessibility"]["score"] * 100)
             score_best_practices = round(data["categories"]["best-practices"]["score"] * 100)
             score_performance = round(data["categories"]["performance"]["score"] * 100)

--- a/lighthouse/datadog_checks/lighthouse/lighthouse.py
+++ b/lighthouse/datadog_checks/lighthouse/lighthouse.py
@@ -38,14 +38,14 @@ class LighthouseCheck(AgentCheck):
             raise CheckException(error_message, exit_code, e)
 
         if data.get("runtimeError", {"code": EXPECTED_RESPONSE_CODE}).get("code") == EXPECTED_RESPONSE_CODE:
-            score_accessibility = round(data["categories"]["accessibility"]["score"] * 100)
-            score_best_practices = round(data["categories"]["best-practices"]["score"] * 100)
-            score_performance = round(data["categories"]["performance"]["score"] * 100)
-            score_pwa = round(data["categories"]["pwa"]["score"] * 100)
-            score_seo = round(data["categories"]["seo"]["score"] * 100)
+            score_accessibility = round(data.get("categories", {}).get("accessibility", {}).get("score", 0) * 100)
+            score_best_practices = round(data.get("categories", {}).get("best-practices", {}).get("score", 0) * 100)
+            score_performance = round(data.get("categories", {}).get("performance", {}).get("score", 0) * 100)
+            score_pwa = round(data.get("categories", {}).get("pwa", {}).get("score", 0) * 100)
+            score_seo = round(data.get("categories", {}).get("seo", {}).get("score", 0) * 100)
         else:
-            err_code = data["runtimeError"]["code"]
-            err_msg = data["runtimeError"]["message"]
+            err_code = data.get("runtimeError", {}).get("code")
+            err_msg = data.get("runtimeError", {}).get("message")
             self.log.warn("not collecting lighthouse metrics for url {0} runtimeError code {1} message {2}"
                           .format(lighthouse_url, err_code, err_msg)
                           )


### PR DESCRIPTION
### What does this PR do?

Recent lighthouse versions have removed the redundant `"runtimeError":{"code":  "NO_ERROR"}` response key/value  from the report's JSON response when the report runs successfully, this PR makes the check for this key more defensive to avoid throwing an error on a non-existent key for newer lighthouse versions

https://github.com/GoogleChrome/lighthouse/commit/ffc430dd46167f1aee3619b0e28bafc474f75297

### Motivation

Customers experiencing issues with this

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
