### PR TITLE
Added TypeError handling for neo4j

### DIFF
--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -130,6 +130,8 @@ class Neo4jCheck(AgentCheck):
             if name in self.keys:
                 try:
                     self.gauge(self.display.get(name, ""), doc['row'][1], tags=tags)
+                except TypeError:
+                    continue
                 except ValueError:
                     continue
 


### PR DESCRIPTION
### What does this PR do?

Handles the TypeError for Neo4j.

### Motivation

Unable to send metrics. When the data is of type 'List', in base.py 'float(value)' throws an error as 

`Error running check neo4j: [{"message": "float() argument must be a string or a number", "traceback": "Traceback (most recent call last):\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 503, in run\n    self.check(instance)\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/neo4j/neo4j.py\", line 132, in check\n    self.gauge(self.display.get(name, \"\"), doc['row'][1], tags=tags)\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 268, in gauge\n    self._submit_metric(aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name)\n  File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 246, in _submit_metric\n    value = float(value)\nTypeError: float() argument must be a string or a number\n"}]`
