### PR TITLE
Fix storm link for tests

### DIFF
--- a/storm/tests/compose/Dockerfile
+++ b/storm/tests/compose/Dockerfile
@@ -1,9 +1,9 @@
 FROM maven:3.5.0-jdk-7
 
 
-RUN git clone git://github.com/apache/storm.git \
-    && cd storm/examples/storm-starter \
-    && git checkout v1.2.3 \
+RUN curl -fsSL https://github.com/apache/storm/archive/v1.2.3.tar.gz -o storm.tar.gz \
+    && tar -xf storm.tar.gz \
+    && cd storm-*/examples/storm-starter \
     && mvn -Dmaven.test.skip=true package \
     && mv target/storm-starter-*.jar /topology.jar
 

--- a/storm/tests/compose/Dockerfile
+++ b/storm/tests/compose/Dockerfile
@@ -1,10 +1,10 @@
 FROM maven:3.5.0-jdk-7
 
-RUN curl -fsSL https://github.com/platinummonkey/static_ci_files/raw/master/datadog/integrations-extras/apache-storm-1.2.1.tar.gz -o storm.tar.gz \
-    && tar -xf storm.tar.gz \
-    && mv ./apache* storm \
+
+RUN git clone git://github.com/apache/storm.git \
     && cd storm/examples/storm-starter \
-    && mvn package \
+    && git checkout v1.2.3 \
+    && mvn -Dmaven.test.skip=true package \
     && mv target/storm-starter-*.jar /topology.jar
 
 ENTRYPOINT ["/bin/sleep"]


### PR DESCRIPTION
Storm link was hosted on github LFS. We reached the quota and can't download it anymore.

Let's use one of apache mirrors directly