### PR TITLE
Track the number old slaves

### DIFF
--- a/redis_sentinel/metadata.csv
+++ b/redis_sentinel/metadata.csv
@@ -4,6 +4,7 @@ redis.sentinel.known_slaves,gauge,,instance,,number of slaves detected,0,redis_s
 redis.sentinel.last_ok_ping_latency,gauge,,second,,number of seconds since last OK ping,0,redis_sentinel,last ok latency
 redis.sentinel.ok_sentinels,gauge,,instance,,number of sentinels up and running,0,redis_sentinel,ok sentinels
 redis.sentinel.ok_slaves,gauge,,instance,,number of slaves up and running,0,redis_sentinel,ok slaves
+redis.sentinel.old_slaves,gauge,,instance,,number of old slaves,0,redis_sentinel,old slaves
 redis.sentinel.link_pending_commands,gauge,,command,,number of pending sentinel commands,0,redis_sentinel,pending commands
 redis.sentinel.ping_latency,gauge,,millisecond,,latency of a sentinel ping,0,redis_sentinel,ping latency
 redis.sentinel.failover,count,,occurrence,,number of failovers detected,0,redis_sentinel,failovers

--- a/redis_sentinel/metadata.csv
+++ b/redis_sentinel/metadata.csv
@@ -4,7 +4,8 @@ redis.sentinel.known_slaves,gauge,,instance,,number of slaves detected,0,redis_s
 redis.sentinel.last_ok_ping_latency,gauge,,second,,number of seconds since last OK ping,0,redis_sentinel,last ok latency
 redis.sentinel.ok_sentinels,gauge,,instance,,number of sentinels up and running,0,redis_sentinel,ok sentinels
 redis.sentinel.ok_slaves,gauge,,instance,,number of slaves up and running,0,redis_sentinel,ok slaves
-redis.sentinel.old_slaves,gauge,,instance,,number of old slaves,0,redis_sentinel,old slaves
+redis.sentinel.odown_slaves,gauge,,instance,,number of slaves that are in the Objectively Down state,0,redis_sentinel,odown slaves
+redis.sentinel.sdown_slaves,gauge,,instance,,number of slaves that are in the Subjectively Down state,0,redis_sentinel,sdown slaves
 redis.sentinel.link_pending_commands,gauge,,command,,number of pending sentinel commands,0,redis_sentinel,pending commands
 redis.sentinel.ping_latency,gauge,,millisecond,,latency of a sentinel ping,0,redis_sentinel,ping latency
 redis.sentinel.failover,count,,occurrence,,number of failovers detected,0,redis_sentinel,failovers

--- a/redis_sentinel/tests/test_redis_sentinel.py
+++ b/redis_sentinel/tests/test_redis_sentinel.py
@@ -3,6 +3,8 @@ import pytest
 from datadog_checks.redis_sentinel import RedisSentinelCheck
 
 METRICS = [
+    'redis.sentinel.odown_slaves',
+    'redis.sentinel.sdown_slaves',
     'redis.sentinel.ok_slaves',
     'redis.sentinel.ok_sentinels',
     'redis.sentinel.known_sentinels',

--- a/redis_sentinel/tox.ini
+++ b/redis_sentinel/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py37
 envlist =
-    py{27,37}-redis_sentinel
+    py{27,37}
 
 [testenv]
 dd_check_style = true


### PR DESCRIPTION
### What does this PR do?

Adds metrics for Redis DB's tracked by Redis Sentinel that are in `odown` and `sdown` states.

### Motivation

The check previously skipped any slaves in `odown` or `sdown` state.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
