### PR TITLE
New integration for cert-manager

### DIFF
--- a/cert_manager/CHANGELOG.md
+++ b/cert_manager/CHANGELOG.md
@@ -1,0 +1,2 @@
+# CHANGELOG - cert_manager
+

--- a/cert_manager/MANIFEST.in
+++ b/cert_manager/MANIFEST.in
@@ -1,0 +1,10 @@
+graft datadog_checks
+graft tests
+
+include MANIFEST.in
+include README.md
+include requirements.in
+include requirements-dev.txt
+include manifest.json
+
+global-exclude *.py[cod] __pycache__

--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -1,0 +1,120 @@
+# Agent Check: cert_manager
+
+## Overview
+
+This check collects metrics from [cert-manager][1] .
+
+## Setup
+
+Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying these instructions.
+
+### Installation
+
+To install the cert_manager check on your host:
+
+1. Install the [developer toolkit][3].
+2. Clone the integrations-extras repository:
+
+    ```
+    git clone https://github.com/DataDog/integrations-extras.git.
+    ```
+
+3. Update your `ddev` config with the `integrations-extras/` path:
+
+    ```
+    ddev config set extras ./integrations-extras
+    ```
+
+4. To build the `cert_manager` package, run:
+
+    ```
+    ddev -e release build cert_manager
+    ```
+
+5. [Download the manifest to install the Datadog agent as a Daemonset][4].
+6. Create two PersistentVolumeClaim, one for the checks code, one for the configuration.
+7. Add them as volumes to your agent pod template and use them for your checks and configuration as:
+
+   ```
+        env:
+          - name: DD_CONFD_PATH
+            value: "/confd"
+          - name: DD_ADDITIONAL_CHECKSD
+            value: "/checksd"
+      [...]
+        volumeMounts:
+          - name: agent-code-storage 
+            mountPath: /checksd
+          - name: agent-conf-storage 
+            mountPath: /confd
+      [...]
+      volumes:
+        - name: agent-code-storage
+          persistentVolumeClaim:
+            claimName: agent-code-claim
+        - name: agent-conf-storage
+          persistentVolumeClaim:
+            claimName: agent-conf-claim
+    ```
+
+8. Deploy the Datadog agent in your Kubernetes cluster:
+
+   ```
+   kubectl apply -f agent.yaml
+   ```
+
+9. Copy the integration artifact .whl file to your Kubernetes nodes or upload it to a public URL
+
+10. Run the following command to install the integrations wheel with the Agent:
+
+   ```
+   kubectl exec $(kubectl get pods -l app=datadog-agent -o jsonpath='{.items[0].metadata.name}') -- agent integration install -w <PATH_OF_CERT_MANAGER_ARTIFACT_>/<CERT_MANAGER_ARTIFACT_NAME>.whl
+   ```
+
+11. Run the following commands to copy the checks and configuration to the corresponding PVCs:
+
+```
+kubectl exec $(kubectl get pods -l app=datadog-agent -o jsonpath='{.items[0].metadata.name}') -- cp -R /opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/* /checksd
+kubectl exec $(kubectl get pods -l app=datadog-agent -o jsonpath='{.items[0].metadata.name}') -- cp -R /etc/datadog-agent/conf.d/* /confd
+```
+
+12. Restart the Datadog agent pods
+
+### Configuration
+
+1. Edit the `cert_manager.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your cert_manager performance data. See the [sample cert_manager.d/conf.yaml][5] for all available configuration options.
+
+2. [Restart the Agent][6].
+
+### Validation
+
+[Run the Agent's status subcommand][7] and look for `cert_manager` under the Checks section.
+
+## Data Collected
+
+### Metrics
+
+See [metadata.csv][8] for a list of metrics provided by this check.
+
+### Service Checks
+
+`cert_manager.prometheus.health`:
+Returns CRITICAL if the Agent fails to connect to the prometheus endpoint, otherwise returns UP.
+
+### Events
+
+cert_manager does not include any events.
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][9].
+
+[1]: https://github.com/jetstack/cert-manager
+[2]: https://docs.datadoghq.com/agent/autodiscovery/integrations
+[3]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[4]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile
+[5]: https://github.com/DataDog/integrations-extras/blob/master/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
+[6]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[8]: https://github.com/DataDog/integrations-core/blob/master/cert_manager/metadata.csv
+[9]: https://docs.datadoghq.com/help

--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -31,7 +31,7 @@ To install the cert_manager check on your host:
     ddev -e release build cert_manager
     ```
 
-5. [Download the manifest to install the Datadog Agent as a DaemonSet][4].
+5. [Download the Agent manifest to install the Datadog Agent as a DaemonSet][4].
 6. Create two `PersistentVolumeClaim`s, one for the checks code, and one for the configuration.
 7. Add them as volumes to your Agent pod template and use them for your checks and configuration:
 
@@ -82,7 +82,7 @@ To install the cert_manager check on your host:
 
 ### Configuration
 
-1. Edit the `cert_manager.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your cert_manager performance data. See the [sample cert_manager.d/conf.yaml][5] for all available configuration options.
+1. Edit the `cert_manager.d/conf.yaml` file, in the `/confd` folder that you added to the Agent pod to start collecting your cert_manager performance data. See the [sample cert_manager.d/conf.yaml][5] for all available configuration options.
 
 2. [Restart the Agent][6].
 
@@ -114,7 +114,7 @@ Need help? Contact [Datadog support][9].
 [3]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [4]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile
 [5]: https://github.com/DataDog/integrations-extras/blob/master/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
-[6]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
-[7]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
+[6]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [8]: https://github.com/DataDog/integrations-core/blob/master/cert_manager/metadata.csv
 [9]: https://docs.datadoghq.com/help

--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This check collects metrics from [cert-manager][1] .
+This check collects metrics from [cert-manager][1].
 
 ## Setup
 
@@ -13,7 +13,7 @@ Follow the instructions below to install and configure this check for an Agent r
 To install the cert_manager check on your host:
 
 1. Install the [developer toolkit][3].
-2. Clone the integrations-extras repository:
+2. Clone the `integrations-extras` repository:
 
     ```
     git clone https://github.com/DataDog/integrations-extras.git.
@@ -31,9 +31,9 @@ To install the cert_manager check on your host:
     ddev -e release build cert_manager
     ```
 
-5. [Download the manifest to install the Datadog agent as a Daemonset][4].
-6. Create two PersistentVolumeClaim, one for the checks code, one for the configuration.
-7. Add them as volumes to your agent pod template and use them for your checks and configuration as:
+5. [Download the manifest to install the Datadog Agent as a DaemonSet][4].
+6. Create two `PersistentVolumeClaim`s, one for the checks code, and one for the configuration.
+7. Add them as volumes to your Agent pod template and use them for your checks and configuration:
 
    ```
         env:
@@ -57,7 +57,7 @@ To install the cert_manager check on your host:
             claimName: agent-conf-claim
     ```
 
-8. Deploy the Datadog agent in your Kubernetes cluster:
+8. Deploy the Datadog Agent in your Kubernetes cluster:
 
    ```
    kubectl apply -f agent.yaml
@@ -67,18 +67,18 @@ To install the cert_manager check on your host:
 
 10. Run the following command to install the integrations wheel with the Agent:
 
-   ```
-   kubectl exec $(kubectl get pods -l app=datadog-agent -o jsonpath='{.items[0].metadata.name}') -- agent integration install -w <PATH_OF_CERT_MANAGER_ARTIFACT_>/<CERT_MANAGER_ARTIFACT_NAME>.whl
-   ```
+    ```
+    kubectl exec $(kubectl get pods -l app=datadog-agent -o jsonpath='{.items[0].metadata.name}') -- agent integration install -w <PATH_OF_CERT_MANAGER_ARTIFACT_>/<CERT_MANAGER_ARTIFACT_NAME>.whl
+    ```
 
 11. Run the following commands to copy the checks and configuration to the corresponding PVCs:
 
-```
-kubectl exec $(kubectl get pods -l app=datadog-agent -o jsonpath='{.items[0].metadata.name}') -- cp -R /opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/* /checksd
-kubectl exec $(kubectl get pods -l app=datadog-agent -o jsonpath='{.items[0].metadata.name}') -- cp -R /etc/datadog-agent/conf.d/* /confd
-```
+    ```
+    kubectl exec $(kubectl get pods -l app=datadog-agent -o jsonpath='{.items[0].metadata.name}') -- cp -R /opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/* /checksd
+    kubectl exec $(kubectl get pods -l app=datadog-agent -o jsonpath='{.items[0].metadata.name}') -- cp -R /etc/datadog-agent/conf.d/* /confd
+    ```
 
-12. Restart the Datadog agent pods
+12. Restart the Datadog Agent pods.
 
 ### Configuration
 
@@ -99,7 +99,7 @@ See [metadata.csv][8] for a list of metrics provided by this check.
 ### Service Checks
 
 `cert_manager.prometheus.health`:
-Returns CRITICAL if the Agent fails to connect to the prometheus endpoint, otherwise returns UP.
+Returns CRITICAL if the Agent fails to connect to the Prometheus endpoint, otherwise returns UP.
 
 ### Events
 

--- a/cert_manager/assets/service_checks.json
+++ b/cert_manager/assets/service_checks.json
@@ -1,0 +1,11 @@
+[
+    {
+        "agent_version": "6.0.0",
+        "integration":"cert_manager",
+        "check": "cert_manager.prometheus.health",
+        "statuses": ["ok", "critical"],
+        "groups": ["endpoint"],
+        "name": "cert-manager prometheus health",
+        "description": "Returns `CRITICAL` if the agent fails to connect to the prometheus endpoint, otherwise `OK`."
+    }
+]

--- a/cert_manager/assets/service_checks.json
+++ b/cert_manager/assets/service_checks.json
@@ -6,6 +6,6 @@
         "statuses": ["ok", "critical"],
         "groups": ["endpoint"],
         "name": "cert-manager prometheus health",
-        "description": "Returns `CRITICAL` if the agent fails to connect to the prometheus endpoint, otherwise `OK`."
+        "description": "Returns `CRITICAL` if the agent fails to connect to the Prometheus endpoint, otherwise `OK`."
     }
 ]

--- a/cert_manager/datadog_checks/__init__.py
+++ b/cert_manager/datadog_checks/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/cert_manager/datadog_checks/cert_manager/__about__.py
+++ b/cert_manager/datadog_checks/cert_manager/__about__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+__version__ = '0.0.1'

--- a/cert_manager/datadog_checks/cert_manager/__init__.py
+++ b/cert_manager/datadog_checks/cert_manager/__init__.py
@@ -1,0 +1,7 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from .__about__ import __version__
+from .cert_manager import CertManagerCheck
+
+__all__ = ['__version__', 'CertManagerCheck']

--- a/cert_manager/datadog_checks/cert_manager/cert_manager.py
+++ b/cert_manager/datadog_checks/cert_manager/cert_manager.py
@@ -1,0 +1,32 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
+
+from .metrics import METRIC_MAP
+
+
+class CertManagerCheck(OpenMetricsBaseCheck):
+    DEFAULT_METRIC_LIMIT = 0
+    HEALTH_METRIC = 'cert_manager.prometheus.health'
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        default_config = {'cert_manager': {'metrics': [METRIC_MAP]}}
+
+        super(CertManagerCheck, self).__init__(
+            name, init_config, agentConfig, instances, default_config, 'cert_manager'
+        )
+
+    def process(self, scraper_config, metric_transformers=None):
+        # Override the process method to send the health metric, as service checks can be disabled.
+        endpoint = scraper_config.get('prometheus_url')
+        tags = ['endpoint:{}'.format(endpoint)]
+        if scraper_config.get('custom_tags'):
+            tags.extend(scraper_config.get('custom_tags'))
+
+        try:
+            super(CertManagerCheck, self).process(scraper_config, metric_transformers=metric_transformers)
+        except Exception:
+            self.gauge(self.HEALTH_METRIC, 1, tags=tags)
+        else:
+            self.gauge(self.HEALTH_METRIC, 0, tags=tags)

--- a/cert_manager/datadog_checks/cert_manager/cert_manager.py
+++ b/cert_manager/datadog_checks/cert_manager/cert_manager.py
@@ -28,5 +28,6 @@ class CertManagerCheck(OpenMetricsBaseCheck):
             super(CertManagerCheck, self).process(scraper_config, metric_transformers=metric_transformers)
         except Exception:
             self.gauge(self.HEALTH_METRIC, 1, tags=tags)
+            raise
         else:
             self.gauge(self.HEALTH_METRIC, 0, tags=tags)

--- a/cert_manager/datadog_checks/cert_manager/cert_manager.py
+++ b/cert_manager/datadog_checks/cert_manager/cert_manager.py
@@ -10,11 +10,11 @@ class CertManagerCheck(OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
     HEALTH_METRIC = 'cert_manager.prometheus.health'
 
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        default_config = {'cert_manager': {'metrics': [METRIC_MAP]}}
+    def __init__(self, name, init_config, instances=None):
+        default_instances = {'cert_manager': {'metrics': [METRIC_MAP]}}
 
         super(CertManagerCheck, self).__init__(
-            name, init_config, agentConfig, instances, default_config, 'cert_manager'
+            name, init_config, instances, default_instances=default_instances, default_namespace='cert_manager'
         )
 
     def process(self, scraper_config, metric_transformers=None):

--- a/cert_manager/datadog_checks/cert_manager/data/auto_conf.yaml
+++ b/cert_manager/datadog_checks/cert_manager/data/auto_conf.yaml
@@ -1,0 +1,10 @@
+ad_identifiers:
+  -  cert-manager-controller
+
+init_config:
+
+instances:
+    ## @param prometheus_url - string - required
+    ## The url where Prometheus metrics are exposed
+    #
+  - prometheus_url: "http://%%host%%:9402/metrics"

--- a/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
+++ b/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
@@ -20,7 +20,7 @@ instances:
     ## Metrics to be extracted from cert-manager
     #
     # metrics:
-    #   - "certmanager_certificate_ready_status": "certificate_ready_status"
+    #   - "certmanager_certificate_ready_status": "certificate.ready_status"
     #   - "<CERTMANAGER_METRIC_NAME>": "<DATADOG_METRIC_NAME>"
 
     ## @param type_overrides - list of key:value element - optional

--- a/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
+++ b/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
@@ -1,0 +1,35 @@
+init_config:
+
+instances:
+
+  - prometheus_url: http://localhost:9402/metrics
+
+    ## @param tags - list of key:value element - optional
+    ## List of tags to attach to every metric, event and service check emitted by this integration.
+    ##
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
+    ## @param metrics - list of key:value element - optional
+    ## Metrics to be extracted from cert-manager
+    #
+    # metrics:
+    #   - "certmanager_certificate_ready_status": "certificate_ready_status"
+    #   - "<CERTMANAGER_METRIC_NAME>": "<DATADOG_METRIC_NAME>"
+
+    ## @param type_overrides - list of key:value element - optional
+    ## Overrides the type of prometheus metrics /!\ All untyped metric will be ignored /!\
+    ## Valid prometheus types are : ['counter', 'gauge', 'summary', 'histogram']
+    ## You can use 'rate' if you want to get the derivative of a counter/gauge
+    #
+    # type_overrides:
+    #   - "certmanager_certificate_ready_status": "gauge"
+    #   - "<CERTMANAGER_METRIC_NAME>": "<DATADOG_METRIC_TYPE>"
+
+    ## @param prometheus_timeout - integer - optional - default: 10
+    ## The timeout for connecting to the prometheus_url.
+    #
+    # prometheus_timeout: 10

--- a/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
+++ b/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
@@ -2,6 +2,9 @@ init_config:
 
 instances:
 
+    ## @param prometheus_url - string - required
+    ## The URL where your application cert-manager metrics are exposed by Prometheus.
+    #
   - prometheus_url: http://localhost:9402/metrics
 
     ## @param tags - list of key:value element - optional

--- a/cert_manager/datadog_checks/cert_manager/metrics.py
+++ b/cert_manager/datadog_checks/cert_manager/metrics.py
@@ -1,0 +1,11 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+METRIC_MAP = {
+    'certmanager_certificate_ready_status': 'certificate_ready_status',
+    'certmanager_certificate_expiration_timestamp_seconds': 'certificate_expiration_timestamp',
+    'certmanager_acme_client_request_count': 'acme_client_request_count',
+    'certmanager_acme_client_request_duration_seconds': 'acme_client_request_duration',
+    'certmanager_controller_sync_call_count': 'controller_sync_call_count',
+}

--- a/cert_manager/datadog_checks/cert_manager/metrics.py
+++ b/cert_manager/datadog_checks/cert_manager/metrics.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 METRIC_MAP = {
-    'certmanager_certificate_ready_status': 'certificate_ready_status',
-    'certmanager_certificate_expiration_timestamp_seconds': 'certificate_expiration_timestamp',
-    'certmanager_acme_client_request_count': 'acme_client_request_count',
-    'certmanager_acme_client_request_duration_seconds': 'acme_client_request_duration',
-    'certmanager_controller_sync_call_count': 'controller_sync_call_count',
+    'certmanager_certificate_ready_status': 'certificate.ready_status',
+    'certmanager_certificate_expiration_timestamp_seconds': 'certificate.expiration_timestamp',
+    'certmanager_acme_client_request_count': 'acme_client.request.count',
+    'certmanager_acme_client_request_duration_seconds': 'acme_client.request.duration',
+    'certmanager_controller_sync_call_count': 'controller.sync_call.count',
 }

--- a/cert_manager/manifest.json
+++ b/cert_manager/manifest.json
@@ -1,0 +1,30 @@
+{
+  "display_name": "cert-manager",
+  "maintainer": "ara.pulido@datadoghq.com",
+  "manifest_version": "1.0.0",
+  "name": "cert_manager",
+  "metric_prefix": "cert_manager.",
+  "metric_to_check": "cert_manager.prometheus.health",
+  "creates_events": false,
+  "short_description": "",
+  "guid": "c9bdaf11-fe15-4892-ae30-47c5124144e5",
+  "support": "contrib",
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "public_title": "Datadog-cert_manager Integration",
+  "categories": [
+    ""
+  ],
+  "type": "check",
+  "is_public": false,
+  "integration_id": "cert-manager",
+  "assets": {
+    "dashboards": {},
+    "saved_views": {},
+    "monitors": {},
+    "service_checks": "assets/service_checks.json"
+  }
+}

--- a/cert_manager/manifest.json
+++ b/cert_manager/manifest.json
@@ -6,7 +6,7 @@
   "metric_prefix": "cert_manager.",
   "metric_to_check": "cert_manager.prometheus.health",
   "creates_events": false,
-  "short_description": "",
+  "short_description": "Track all your cert-manager metrics with Datadog",
   "guid": "c9bdaf11-fe15-4892-ae30-47c5124144e5",
   "support": "contrib",
   "supported_os": [

--- a/cert_manager/manifest.json
+++ b/cert_manager/manifest.json
@@ -16,7 +16,9 @@
   ],
   "public_title": "Datadog-cert-manager Integration",
   "categories": [
-    ""
+    "security",
+    "configuration & deployment",
+    "containers"
   ],
   "type": "check",
   "is_public": false,

--- a/cert_manager/manifest.json
+++ b/cert_manager/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-cert_manager Integration",
+  "public_title": "Datadog-cert-manager Integration",
   "categories": [
     ""
   ],

--- a/cert_manager/metadata.csv
+++ b/cert_manager/metadata.csv
@@ -4,6 +4,6 @@ cert_manager.certificate_ready_status,gauge,,,,The ready status of the certifica
 cert_manager.certificate_expiration_timestamp,gauge,,second,,The date after which the certificate expires. Expressed as a Unix Epoch Time,0,cert_manager,cm.cert_exp_time
 cert_manager.acme_client_request_count,count,,,,The number of requests made by the ACME client,1,cert_manager,cm.acme_req_cnt
 cert_manager.acme_client_request_duration.sum,gauge,,,,The sum of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.sum
-cert_manager.acme_client_request_duration.sum,count,,,,The count of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.cnt
-cert_manager.acme_client_request_duration.sum,gauge,,,,The quantiles of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.quant
+cert_manager.acme_client_request_duration.count,gauge,,,,The count of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.cnt
+cert_manager.acme_client_request_duration.quantile,gauge,,,,The quantiles of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.quant
 cert_manager.controller_sync_call_count,count,,,,The number of sync() calls made by a controller,1,cert_manager,cm.sync_call_cnt

--- a/cert_manager/metadata.csv
+++ b/cert_manager/metadata.csv
@@ -1,0 +1,9 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+cert_manager.prometheus.health,gauge,,,,Whether the check is able to connect to the metrics endpoint,0,cert_manager,cm.health
+cert_manager.certificate_ready_status,gauge,,,,The ready status of the certificate,0,cert_manager,cm.cert_ready_status
+cert_manager.certificate_expiration_timestamp,gauge,,second,,The date after which the certificate expires. Expressed as a Unix Epoch Time,0,cert_manager,cm.cert_exp_time
+cert_manager.acme_client_request_count,count,,,,The number of requests made by the ACME client,1,cert_manager,cm.acme_req_cnt
+cert_manager.acme_client_request_duration.sum,gauge,,,,The sum of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.sum
+cert_manager.acme_client_request_duration.sum,count,,,,The count of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.cnt
+cert_manager.acme_client_request_duration.sum,gauge,,,,The quantiles of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.quant
+cert_manager.controller_sync_call_count,count,,,,The number of sync() calls made by a controller,1,cert_manager,cm.sync_call_cnt

--- a/cert_manager/metadata.csv
+++ b/cert_manager/metadata.csv
@@ -1,9 +1,9 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 cert_manager.prometheus.health,gauge,,,,Whether the check is able to connect to the metrics endpoint,0,cert_manager,cm.health
-cert_manager.certificate_ready_status,gauge,,,,The ready status of the certificate,0,cert_manager,cm.cert_ready_status
-cert_manager.certificate_expiration_timestamp,gauge,,second,,The date after which the certificate expires. Expressed as a Unix Epoch Time,0,cert_manager,cm.cert_exp_time
-cert_manager.acme_client_request_count,count,,,,The number of requests made by the ACME client,1,cert_manager,cm.acme_req_cnt
-cert_manager.acme_client_request_duration.sum,gauge,,,,The sum of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.sum
-cert_manager.acme_client_request_duration.count,gauge,,,,The count of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.cnt
-cert_manager.acme_client_request_duration.quantile,gauge,,,,The quantiles of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.quant
-cert_manager.controller_sync_call_count,count,,,,The number of sync() calls made by a controller,1,cert_manager,cm.sync_call_cnt
+cert_manager.certificate.ready_status,gauge,,,,The ready status of the certificate,0,cert_manager,cm.cert_ready_status
+cert_manager.certificate.expiration_timestamp,gauge,,second,,The date after which the certificate expires. Expressed as a Unix Epoch Time,0,cert_manager,cm.cert_exp_time
+cert_manager.acme_client.request.count,count,,,,The number of requests made by the ACME client,1,cert_manager,cm.acme_req_cnt
+cert_manager.acme_client.request.duration.sum,gauge,,,,The sum of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.sum
+cert_manager.acme_client.request.duration.count,gauge,,,,The count of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.cnt
+cert_manager.acme_client.request.duration.quantile,gauge,,,,The quantiles of the HTTP request latencies in seconds for the ACME client,1,cert_manager,cm.req_duration.quant
+cert_manager.controller.sync_call.count,count,,,,The number of sync() calls made by a controller,1,cert_manager,cm.sync_call_cnt

--- a/cert_manager/requirements-dev.txt
+++ b/cert_manager/requirements-dev.txt
@@ -1,1 +1,1 @@
--e ../datadog-checks-dev
+datadog-checks-dev

--- a/cert_manager/requirements-dev.txt
+++ b/cert_manager/requirements-dev.txt
@@ -1,0 +1,1 @@
+-e ../datadog-checks-dev

--- a/cert_manager/setup.py
+++ b/cert_manager/setup.py
@@ -1,0 +1,51 @@
+from codecs import open  # To use a consistent encoding
+from os import path
+
+from setuptools import setup
+
+HERE = path.dirname(path.abspath(__file__))
+
+# Get version info
+ABOUT = {}
+with open(path.join(HERE, 'datadog_checks', 'cert_manager', '__about__.py')) as f:
+    exec(f.read(), ABOUT)
+
+# Get the long description from the README file
+with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
+CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
+
+
+setup(
+    name='datadog-cert_manager',
+    version=ABOUT['__version__'],
+    description='The cert_manager check',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    keywords='datadog agent cert_manager check',
+    # The project's main homepage.
+    url='https://github.com/DataDog/integrations-extras',
+    # Author details
+    author='Ara Pulido',
+    author_email='ara.pulido@datadoghq.com',
+    # License
+    license='BSD-3-Clause',
+    # See https://pypi.org/classifiers
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'Topic :: System :: Monitoring',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
+    ],
+    # The package we're going to ship
+    packages=['datadog_checks.cert_manager'],
+    # Run-time dependencies
+    install_requires=[CHECKS_BASE_REQ],
+    # Extra files to ship with the wheel package
+    include_package_data=True,
+)

--- a/cert_manager/tests/common.py
+++ b/cert_manager/tests/common.py
@@ -1,0 +1,19 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.stubs import aggregator
+
+EXPECTED_METRICS = {
+    'cert_manager.certificate_ready_status': aggregator.GAUGE,
+    'cert_manager.certificate_expiration_timestamp': aggregator.GAUGE,
+    'cert_manager.acme_client_request_count': aggregator.MONOTONIC_COUNT,
+    'cert_manager.acme_client_request_duration.sum': aggregator.GAUGE,
+    'cert_manager.acme_client_request_duration.count': aggregator.GAUGE,
+    'cert_manager.acme_client_request_duration.quantile': aggregator.GAUGE,
+    'cert_manager.controller_sync_call_count': aggregator.MONOTONIC_COUNT,
+    'cert_manager.prometheus.health': aggregator.GAUGE,
+}
+
+MOCK_INSTANCE = {
+    'prometheus_url': 'http://fake.tld/prometheus',
+}

--- a/cert_manager/tests/common.py
+++ b/cert_manager/tests/common.py
@@ -4,13 +4,13 @@
 from datadog_checks.stubs import aggregator
 
 EXPECTED_METRICS = {
-    'cert_manager.certificate_ready_status': aggregator.GAUGE,
-    'cert_manager.certificate_expiration_timestamp': aggregator.GAUGE,
-    'cert_manager.acme_client_request_count': aggregator.MONOTONIC_COUNT,
-    'cert_manager.acme_client_request_duration.sum': aggregator.GAUGE,
-    'cert_manager.acme_client_request_duration.count': aggregator.GAUGE,
-    'cert_manager.acme_client_request_duration.quantile': aggregator.GAUGE,
-    'cert_manager.controller_sync_call_count': aggregator.MONOTONIC_COUNT,
+    'cert_manager.certificate.ready_status': aggregator.GAUGE,
+    'cert_manager.certificate.expiration_timestamp': aggregator.GAUGE,
+    'cert_manager.acme_client.request.count': aggregator.MONOTONIC_COUNT,
+    'cert_manager.acme_client.request.duration.sum': aggregator.GAUGE,
+    'cert_manager.acme_client.request.duration.count': aggregator.GAUGE,
+    'cert_manager.acme_client.request.duration.quantile': aggregator.GAUGE,
+    'cert_manager.controller.sync_call.count': aggregator.MONOTONIC_COUNT,
     'cert_manager.prometheus.health': aggregator.GAUGE,
 }
 

--- a/cert_manager/tests/conftest.py
+++ b/cert_manager/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield
+
+
+@pytest.fixture
+def instance():
+    return {}

--- a/cert_manager/tests/fixtures/cert_manager.txt
+++ b/cert_manager/tests/fixtures/cert_manager.txt
@@ -1,0 +1,25 @@
+# HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
+# TYPE certmanager_certificate_expiration_timestamp_seconds gauge
+certmanager_certificate_expiration_timestamp_seconds{name="something",namespace="default"} 2.208988804e+09
+# HELP certmanager_certificate_ready_status The ready status of the certificate.
+# TYPE certmanager_certificate_ready_status gauge
+certmanager_certificate_ready_status{condition="False",name="something",namespace="default"} 0
+certmanager_certificate_ready_status{condition="True",name="something",namespace="default"} 1
+certmanager_certificate_ready_status{condition="Unknown",name="something",namespace="default"} 0
+# HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
+# TYPE certmanager_controller_sync_call_count counter
+certmanager_controller_sync_call_count{controller="certificaterequests"} 5
+certmanager_controller_sync_call_count{controller="challenges"} 48463
+certmanager_controller_sync_call_count{controller="ingress-shim"} 1
+certmanager_controller_sync_call_count{controller="issuers"} 2
+certmanager_controller_sync_call_count{controller="orders"} 1
+# HELP certmanager_acme_client_request_count The number of requests made by the ACME client.
+# TYPE certmanager_acme_client_request_count counter
+certmanager_acme_client_request_count 3
+# HELP certmanager_acme_client_request_duration_seconds The HTTP request latencies in seconds for the ACME client.
+# TYPE certmanager_acme_client_request_duration_seconds summary 
+certmanager_acme_client_request_duration_seconds{quantile="0.5"} 6.4853e-05
+certmanager_acme_client_request_duration_seconds{quantile="0.9"} 0.00010102
+certmanager_acme_client_request_duration_seconds{quantile="0.99"} 0.000177367
+certmanager_acme_client_request_duration_seconds_sum 1.623860968846092e+06
+certmanager_acme_client_request_duration_seconds_count 1.112293682e+09

--- a/cert_manager/tests/test_cert_manager.py
+++ b/cert_manager/tests/test_cert_manager.py
@@ -1,0 +1,60 @@
+# (C) Datadog, Inc. 2019
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
+import mock
+import pytest
+
+from datadog_checks.base.errors import CheckException
+from datadog_checks.cert_manager import CertManagerCheck
+
+from .common import EXPECTED_METRICS, MOCK_INSTANCE
+
+
+def get_response(filename):
+    metrics_file_path = os.path.join(os.path.dirname(__file__), 'fixtures', filename)
+    with open(metrics_file_path, 'r') as f:
+        response = f.read()
+    return response
+
+
+@pytest.fixture()
+def mock_metrics():
+    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'cert_manager.txt')
+    with open(f_name, 'r') as f:
+        text_data = f.read()
+    with mock.patch(
+        'requests.get',
+        return_value=mock.MagicMock(
+            status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
+        ),
+    ):
+        yield
+
+
+@pytest.mark.unit
+def test_config():
+    with pytest.raises(CheckException):
+        CertManagerCheck('cert-manager', {}, {}, [{}])
+
+    # this should not fail
+    CertManagerCheck('cert-manager', {}, {}, [MOCK_INSTANCE])
+
+
+@pytest.mark.unit
+def test_check(aggregator, instance, mock_metrics):
+    check = CertManagerCheck('cert_manager', {}, {}, [MOCK_INSTANCE])
+    check.check(MOCK_INSTANCE)
+
+    for metric_name, metric_type in EXPECTED_METRICS.items():
+        aggregator.assert_metric(metric_name, metric_type=metric_type)
+
+    aggregator.assert_all_metrics_covered()
+
+    aggregator.assert_service_check(
+        'cert_manager.prometheus.health',
+        status=CertManagerCheck.OK,
+        tags=['endpoint:http://fake.tld/prometheus'],
+        count=1,
+    )

--- a/cert_manager/tests/test_cert_manager.py
+++ b/cert_manager/tests/test_cert_manager.py
@@ -36,15 +36,15 @@ def mock_metrics():
 @pytest.mark.unit
 def test_config():
     with pytest.raises(CheckException):
-        CertManagerCheck('cert_manager', {}, {}, [{}])
+        CertManagerCheck('cert_manager', {}, [{}])
 
     # this should not fail
-    CertManagerCheck('cert_manager', {}, {}, [MOCK_INSTANCE])
+    CertManagerCheck('cert_manager', {}, [MOCK_INSTANCE])
 
 
 @pytest.mark.unit
 def test_check(aggregator, instance, mock_metrics):
-    check = CertManagerCheck('cert_manager', {}, {}, [MOCK_INSTANCE])
+    check = CertManagerCheck('cert_manager', {}, [MOCK_INSTANCE])
     check.check(MOCK_INSTANCE)
 
     for metric_name, metric_type in EXPECTED_METRICS.items():

--- a/cert_manager/tests/test_cert_manager.py
+++ b/cert_manager/tests/test_cert_manager.py
@@ -21,9 +21,7 @@ def get_response(filename):
 
 @pytest.fixture()
 def mock_metrics():
-    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'cert_manager.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
+    text_data = get_response('cert_manager.txt')
     with mock.patch(
         'requests.get',
         return_value=mock.MagicMock(

--- a/cert_manager/tests/test_cert_manager.py
+++ b/cert_manager/tests/test_cert_manager.py
@@ -36,10 +36,10 @@ def mock_metrics():
 @pytest.mark.unit
 def test_config():
     with pytest.raises(CheckException):
-        CertManagerCheck('cert-manager', {}, {}, [{}])
+        CertManagerCheck('cert_manager', {}, {}, [{}])
 
     # this should not fail
-    CertManagerCheck('cert-manager', {}, {}, [MOCK_INSTANCE])
+    CertManagerCheck('cert_manager', {}, {}, [MOCK_INSTANCE])
 
 
 @pytest.mark.unit

--- a/cert_manager/tox.ini
+++ b/cert_manager/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+minversion = 2.0
+skip_missing_interpreters = true
+basepython = py37
+envlist =
+    py{27,37}
+
+[testenv]
+dd_check_style = true
+usedevelop = true
+platform = linux|darwin|win32
+deps =
+    datadog-checks-base[deps]>=6.6.0
+    -rrequirements-dev.txt
+passenv =
+    DOCKER*
+    COMPOSE*
+commands =
+    pip install -r requirements.in
+    pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

This PRs adds a new integration for [cert-manager](https://github.com/jetstack/cert-manager), based on the OpenMetricsBaseCheck.

### Motivation

[cert-manager](https://github.com/jetstack/cert-manager) is a popular tool (4.7k github stars) within the Kubernetes community to automatically issue TLS certificates and to keep them up to date (renew them before they expire). As a popular tool, it would be helpful to have a specific integration for it.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

This integration only has unit tests for now (no e2e tests). This requires a full kubernetes environment, as `cert-manager` is basically a Kubernetes controller for a set of CRDs that it sets up. Using `docker-compose` is therefore not an option.