### PR TITLE
Add enable-extensions=G to .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,4 @@ select = B,C,E,F,G,W,B001,B003,B006,B007,B301,B305,B306,B902
 ignore = E203,E722,W503,G200
 exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/*/vendor/*
 max-line-length = 120
+enable-extensions=G


### PR DESCRIPTION
### What does this PR do?

Add enable-extensions=G to .flake8

Due to https://github.com/DataDog/integrations-core/pull/5635