### PR TITLE
Update README.md

### DIFF
--- a/ping/README.md
+++ b/ping/README.md
@@ -26,7 +26,7 @@ If you are using Agent v6.8+ follow the instructions below to install the Ping c
 2. Clone the integrations-extras repository:
 
     ```
-    git clone https://github.com/DataDog/integrations-extras.git.
+    git clone https://github.com/DataDog/integrations-extras.git
     ```
 
 3. Update your `ddev` config with the `integrations-extras/` path:


### PR DESCRIPTION
Removing a dot from git clone command so that customer can simply copy&paste to run it

### What does this PR do?
fix a typo (Removing a dot from git clone command)

### Motivation
With the dot, Git requires username to clone it. 
Without the dot, customer can clone it without username, so it's simple and easy.

in the below ticket, customer faced a trouble. I found the dot was making the trouble.
https://datadog.zendesk.com/agent/tickets/303306

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
