### PR TITLE
Added query_setup_time.average to Vespa metric set

### DIFF
--- a/vespa/metadata.csv
+++ b/vespa/metadata.csv
@@ -30,5 +30,6 @@ vespa.content.proton.resource_usage.feeding_blocked.last,gauge,,,,Whether feedin
 vespa.content.proton.documentdb.matching.docs_matched.rate,gauge,,document,second,Number of documents matched,0,vespa,
 vespa.content.proton.documentdb.matching.docs_reranked.rate,gauge,,document,second,Number of documents re-ranked (second phase),0,vespa,
 vespa.content.proton.documentdb.matching.rank_profile.query_latency.average,gauge,,second,,Total latency when matching and ranking a query,-1,vespa,
+vespa.content.proton.documentdb.matching.rank_profile.query_setup_time.average,gauge,,second,,Average time spent setting up and tearing down queries,-1,vespa,
 vespa.content.proton.documentdb.matching.rank_profile.rerank_time.average,gauge,,second,,Time spent on 2nd phase ranking,-1,vespa,
 vespa.content.proton.transactionlog.disk_usage.last,gauge,,byte,,Disk usage of the transaction log,0,vespa,


### PR DESCRIPTION
### What does this PR do?

Adds `vespa.content.proton.documentdb.matching.rank_profile.query_setup_time.average` to the Vespa metadata.csv

### Motivation

The default metric set now includes the aforementioned metric. Should be reflected in the metadata

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
