### PR TITLE
Traefik configuration now allows scheme parameter

### DIFF
--- a/traefik/CHANGELOG.md
+++ b/traefik/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - traefik
 
+## 0.2.0
+
+* [FEATURE] configuration now allows scheme parameter
+
 ## 0.1.0
 
 * [FEATURE] first version

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -60,6 +60,7 @@ instances:
   - host: 10.1.2.3
     port: "8080"
     path: "/health"
+    scheme: "http"
 ```
 
 Configuration Options:
@@ -67,6 +68,7 @@ Configuration Options:
 - host: Traefik endpoint to query. __Required__
 - port: API listener of Traefik endpoint. Default value `8080`. _Optional_
 - path: Path of Traefik health check endpoint. Default `/health`. _Optional_
+- scheme: Scheme of Traefik health check endpoint. Default `http`. _Optional_
 
 [Restart the Agent][10] to begin sending Traefik metrics to Datadog.
 

--- a/traefik/datadog_checks/traefik/__about__.py
+++ b/traefik/datadog_checks/traefik/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'

--- a/traefik/datadog_checks/traefik/data/conf.yaml.example
+++ b/traefik/datadog_checks/traefik/data/conf.yaml.example
@@ -16,3 +16,8 @@ instances:
     ## Traefik host endpoint path to gather data from.
     #
     # path: "/health"
+
+    ## @param scheme - string - optional - default: http
+    ## Traefik host scheme to use when reaching `host`.
+    #
+    # scheme: "http"

--- a/traefik/datadog_checks/traefik/traefik.py
+++ b/traefik/datadog_checks/traefik/traefik.py
@@ -12,13 +12,14 @@ class TraefikCheck(AgentCheck):
         host = instance.get('host')
         port = instance.get('port', '8080')
         path = instance.get('path', '/health')
+        scheme = instance.get('scheme', 'http')
 
         if not host:
             self.warning('Configuration error, you must define `host`')
             raise ConfigurationError('Configuration error, you must define `host`')
 
         try:
-            url = 'http://{}:{}{}'.format(host, port, path)
+            url = '{}://{}:{}{}'.format(scheme, host, port, path)
             response = requests.get(url)
             response_status_code = response.status_code
 

--- a/traefik/manifest.json
+++ b/traefik/manifest.json
@@ -2,7 +2,7 @@
   "integration_id": "traefik",
   "display_name": "Traefik",
   "maintainer": "@renaudhager",
-  "manifest_version": "1.0.0",
+  "manifest_version": "1.1.0",
   "name": "traefik",
   "short_description": "collects traefik metrics",
   "support": "contrib",

--- a/traefik/tests/common.py
+++ b/traefik/tests/common.py
@@ -9,9 +9,8 @@ HERE = get_here()
 DOCKER_COMPOSE_FILE = os.path.join(HERE, 'docker', 'docker-compose.yaml')
 HOST = get_docker_hostname()
 PORT = '8080'
+SCHEME = 'http'
 
-INSTANCE = {'host': HOST, 'port': PORT}
-
-INSTANCE_BAD = {'host': 'foobar', 'port': 9000}
-
+INSTANCE = {'scheme': SCHEME, 'host': HOST, 'port': PORT}
+INSTANCE_BAD = {'scheme': 'https', 'host': 'foobar', 'port': 9000}
 INSTANCE_INVALID = {}

--- a/traefik/tests/conftest.py
+++ b/traefik/tests/conftest.py
@@ -7,7 +7,7 @@ from . import common
 
 
 def ping_traefik():
-    response = requests.get('http://{}:{}/health'.format(common.HOST, common.PORT))
+    response = requests.get('{}://{}:{}/health'.format(common.SCHEME, common.HOST, common.PORT))
     response.raise_for_status()
 
     # Trigger a 404


### PR DESCRIPTION
### What does this PR do?

Allows the Traefik configuration to specify either a `http` or `https` scheme for the specified host. The scheme value will default to `http` as previously hard coded.

### Motivation

Currently `https` endpoints for Traefik metrics are not supported.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)