### PR TITLE
Add codewner to ping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@
 /neo4j/                 help@neo4j.com
 /nextcloud/             @eplanet
 /nomad/                 @irabinovitch
+/ping/                  @jstanton617
 /portworx/              paul@portworx.com
 /rbltracker/            @DataDog/container-integrations
 /reboot_required/       support@krugerheavyindustries.com


### PR DESCRIPTION
I think @jstanton617 is the initial commiter of ping integration and as such is must be listed as codeowner