### PR TITLE
Adding alias

### DIFF
--- a/apollo/manifest.json
+++ b/apollo/manifest.json
@@ -26,5 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "/assets/service_checks.json"
-  }
+  },
+  "aliases": ["/integrations/apollo_engine"]
 }


### PR DESCRIPTION
### What does this PR do?

Add alias to Apollo documentation page to redirect traffic from `/integrations/apollo_engine` to `/integrations/apollo`

### Motivation

https://github.com/DataDog/documentation/issues/6868