### PR TITLE
updating readme for broken links

### DIFF
--- a/pihole/README.md
+++ b/pihole/README.md
@@ -46,10 +46,10 @@ Pi-hole does not include any events.
 [2]: https://docs.datadoghq.com/agent/autodiscovery/integrations
 [3]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [4]: https://app.datadoghq.com/account/settings#agent
-[5]: https://github.com/DataDog/integrations-extras/master/pihole/datadog_checks/pihole/data/conf.yaml.example
+[5]: https://github.com/DataDog/integrations-extras/blob/master/pihole/datadog_checks/pihole/data/conf.yaml.example
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[8]: https://github.com/DataDog/integrations-extras/master/pihole/metadata.csv
+[8]: https://github.com/DataDog/integrations-extras/blob/master/pihole/metadata.csv
 
 
 


### PR DESCRIPTION
Broken links on conf.yaml example and metadata.csv links, I think these should work now!

### What does this PR do?
Fixed broken links to metadata and conf.yaml links on README

### Motivation
Fixing it :) 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
