### PR TITLE
Add missing codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,9 @@
 /apollo/                sachin@apollographql.com
 /aqua/                  @DataDog/container-integrations
 /aws_pricing/           tsein@brightcove.com
+/bind9/                 ashuvyas45@gmail.com
 /buddy/                 support@buddy.works
+/cert_manager/          ara.pulido@datadoghq.com
 /convox/                @DataDog/agent-integrations
 /eventstore/            @xorima
 /filebeat/              jean@tripping.com
@@ -15,10 +17,11 @@
 /hbase_master/          @everpeace
 /hbase_regionserver/    @everpeace
 /launchdarkly/          support@launchdarkly.com
-/lighthouse/		@ericmustin
+/lighthouse/            @ericmustin
 /logstash/              ervansetiawan@gmail.com
 /logzio/                @DataDog/agent-integrations
 /neo4j/                 help@neo4j.com
+/neutrona/              david@neutrona.com
 /nextcloud/             @eplanet
 /nomad/                 @irabinovitch
 /pihole/                @monganai
@@ -27,10 +30,11 @@
 /rbltracker/            @DataDog/container-integrations
 /reboot_required/       support@krugerheavyindustries.com
 /redis_sentinel/        @krasnoukhov
-/resin/                 @brentm5 
-/riak_repl/		@abtreece
+/resin/                 @brentm5
+/riak_repl/             @abtreece
 /rigor/                 support@rigor.com
 /rookout/               support@rookout.com
+/sendmail/              david.bouchare@datadoghq.com
 /sigsci/                info@signalsciences.com
 /snmpwalk/              @DataDog/agent-integrations
 /sortdb/                namrata.deshpande4@gmail.com
@@ -38,6 +42,7 @@
 /stardog/               support@stardog.com
 /storm/                 @platinummonkey
 /traefik/               @renaudhager
+/unbound/               david.byron@avast.com
 /upsc/                  @platinummonkey
 /uptime/                @jeremy-lq
 /vespa/                 dd@vespa.ai

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 /bind9/                 ashuvyas45@gmail.com
 /buddy/                 support@buddy.works
 /cert_manager/          ara.pulido@datadoghq.com
+/contrastsecurity       kristiana.mitchell@contrastsecurity.com
 /convox/                @DataDog/agent-integrations
 /eventstore/            @xorima
 /filebeat/              jean@tripping.com
@@ -47,4 +48,3 @@
 /uptime/                @jeremy-lq
 /vespa/                 dd@vespa.ai
 /vns3/                  @DataDog/agent-integrations
-/contrastsecurity       kristiana.mitchell@contrastsecurity.com

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /bind9/                 ashuvyas45@gmail.com
 /buddy/                 support@buddy.works
 /cert_manager/          ara.pulido@datadoghq.com
-/contrastsecurity       kristiana.mitchell@contrastsecurity.com
+/contrastsecurity/       kristiana.mitchell@contrastsecurity.com
 /convox/                @DataDog/agent-integrations
 /eventstore/            @xorima
 /filebeat/              jean@tripping.com


### PR DESCRIPTION
### What does this PR do?
Adds entries to the CODEOWNERS file so that every integration has a codeowner. The new entries were found in the `maintainer` field in `manifest.json`

### Motivation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
