### PR TITLE
[doc]update_auth0_link

### DIFF
--- a/auth0/README.md
+++ b/auth0/README.md
@@ -57,6 +57,5 @@ Need help? Contact [Datadog support][1].
 
 [1]: https://docs.datadoghq.com/help
 [2]: https://manage.auth0.com
-[3]: https://auth0.com/docs/logs/streams/datadog
 [4]: https://app.datadoghq.com/account/settings#api
 [5]: https://auth0.com/docs/logs/references/log-event-type-codes

--- a/auth0/README.md
+++ b/auth0/README.md
@@ -6,9 +6,7 @@ Use the Datadog-Auth0 integration to view and analyze your log events from Auth0
 
 ## Setup
 
-All configuration happens on the [Auth0 Dashboard][2]. Find details on how to set it up in the [Auth0 Documentation][3].
- 
-### Configuration
+All configuration happens on the [Auth0 Dashboard][2]. 
 
 1. Log in to the [Auth0 Dashboard][2].
 2. Navigate to **Logs** > **Streams**.


### PR DESCRIPTION
The link to the Auth0 documentation is broken -> https://auth0.com/docs/logs/streams/datadog  (could not find one that is current on Auth0)

### What does this PR do?

removes the bad link 

### Motivation

What inspired you to submit this pull request?


### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
