### PR TITLE
Configure mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@ wheelhouse/
 
 .pytest_cache
 
+# Type checking
+.mypy_cache
+
 # by default, ignore in-toto metadata from the command line
 .links/
 *.link

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,16 @@
+; See: https://mypy.readthedocs.io/en/stable/config_file.html
+
+[mypy]
+; Follows imports and type-check imported modules.
+follow_imports = normal
+
+; Ignore errors about imported packages that don't provide type hints.
+ignore_missing_imports = true
+
+; Don't require that all functions be annotated, as it would create
+; a lot of noise for imported modules that aren't annotated yet.
+; Note that this is the default behavior, but we're making our choice explicit here.
+disallow_untyped_defs = false
+
+; Include column numbers in errors.
+show_column_numbers = true


### PR DESCRIPTION
### What does this PR do?
- Add `mypy.ini` (same as in `integrations-core`).
- Add `.mypy_cache` to `.gitignore` so that contributors don't commit it accidentally.

**Motivation**
Allow contributors to start using mypy in integrations (via `dd_check_types = true` in `tox.ini`).