### PR TITLE
Making Auth0 private until release

### DIFF
--- a/auth0/manifest.json
+++ b/auth0/manifest.json
@@ -17,7 +17,7 @@
   "public_title": "Datadog-Auth0 Integration",
   "categories": ["log collection" , "security"],
   "type": "check",
-  "is_public": true,
+  "is_public": false,
   "integration_id": "auth0",
   "assets": {
     "dashboards": {},


### PR DESCRIPTION
Auth0 is set for 15th April release. Setting is_public flag to false until then.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
