### PR TITLE
Fixes fixes possible TypeError if `score` exist with a `null` value

### DIFF
--- a/lighthouse/datadog_checks/lighthouse/lighthouse.py
+++ b/lighthouse/datadog_checks/lighthouse/lighthouse.py
@@ -35,11 +35,11 @@ class LighthouseCheck(AgentCheck):
             raise CheckException(error_message, exit_code, e)
 
         if data.get("runtimeError", {"code": EXPECTED_RESPONSE_CODE}).get("code") == EXPECTED_RESPONSE_CODE:
-            score_accessibility = round(data.get("categories", {}).get("accessibility", {}).get("score", 0) * 100)
-            score_best_practices = round(data.get("categories", {}).get("best-practices", {}).get("score", 0) * 100)
-            score_performance = round(data.get("categories", {}).get("performance", {}).get("score", 0) * 100)
-            score_pwa = round(data.get("categories", {}).get("pwa", {}).get("score", 0) * 100)
-            score_seo = round(data.get("categories", {}).get("seo", {}).get("score", 0) * 100)
+            score_accessibility = round(data.get("categories", {}).get("accessibility", {}).get("score") or 0 * 100)
+            score_best_practices = round(data.get("categories", {}).get("best-practices", {}).get("score") or 0 * 100)
+            score_performance = round(data.get("categories", {}).get("performance", {}).get("score") or 0 * 100)
+            score_pwa = round(data.get("categories", {}).get("pwa", {}).get("score") or 0 * 100)
+            score_seo = round(data.get("categories", {}).get("seo", {}).get("score") or 0 * 100)
         else:
             err_code = data.get("runtimeError", {}).get("code")
             err_msg = data.get("runtimeError", {}).get("message")

--- a/lighthouse/datadog_checks/lighthouse/lighthouse.py
+++ b/lighthouse/datadog_checks/lighthouse/lighthouse.py
@@ -35,11 +35,11 @@ class LighthouseCheck(AgentCheck):
             raise CheckException(error_message, exit_code, e)
 
         if data.get("runtimeError", {"code": EXPECTED_RESPONSE_CODE}).get("code") == EXPECTED_RESPONSE_CODE:
-            score_accessibility = round(data.get("categories", {}).get("accessibility", {}).get("score") or 0 * 100)
-            score_best_practices = round(data.get("categories", {}).get("best-practices", {}).get("score") or 0 * 100)
-            score_performance = round(data.get("categories", {}).get("performance", {}).get("score") or 0 * 100)
-            score_pwa = round(data.get("categories", {}).get("pwa", {}).get("score") or 0 * 100)
-            score_seo = round(data.get("categories", {}).get("seo", {}).get("score") or 0 * 100)
+            score_accessibility = round((data.get("categories", {}).get("accessibility", {}).get("score") or 0) * 100)
+            score_best_practices = round((data.get("categories", {}).get("best-practices", {}).get("score") or 0) * 100)
+            score_performance = round((data.get("categories", {}).get("performance", {}).get("score") or 0) * 100)
+            score_pwa = round((data.get("categories", {}).get("pwa", {}).get("score") or 0) * 100)
+            score_seo = round((data.get("categories", {}).get("seo", {}).get("score") or 0) * 100)
         else:
             err_code = data.get("runtimeError", {}).get("code")
             err_msg = data.get("runtimeError", {}).get("message")

--- a/lighthouse/datadog_checks/lighthouse/lighthouse.py
+++ b/lighthouse/datadog_checks/lighthouse/lighthouse.py
@@ -35,11 +35,13 @@ class LighthouseCheck(AgentCheck):
             raise CheckException(error_message, exit_code, e)
 
         if data.get("runtimeError", {"code": EXPECTED_RESPONSE_CODE}).get("code") == EXPECTED_RESPONSE_CODE:
-            score_accessibility = round((data.get("categories", {}).get("accessibility", {}).get("score") or 0) * 100)
-            score_best_practices = round((data.get("categories", {}).get("best-practices", {}).get("score") or 0) * 100)
-            score_performance = round((data.get("categories", {}).get("performance", {}).get("score") or 0) * 100)
-            score_pwa = round((data.get("categories", {}).get("pwa", {}).get("score") or 0) * 100)
-            score_seo = round((data.get("categories", {}).get("seo", {}).get("score") or 0) * 100)
+            score_accessibility = round(((data.get("categories", {}).get("accessibility", {}).get("score") or 0) * 100))
+            score_best_practices = round(
+                ((data.get("categories", {}).get("best-practices", {}).get("score") or 0) * 100)
+            )
+            score_performance = round(((data.get("categories", {}).get("performance", {}).get("score") or 0) * 100))
+            score_pwa = round(((data.get("categories", {}).get("pwa", {}).get("score") or 0) * 100))
+            score_seo = round(((data.get("categories", {}).get("seo", {}).get("score") or 0) * 100))
         else:
             err_code = data.get("runtimeError", {}).get("code")
             err_msg = data.get("runtimeError", {}).get("message")


### PR DESCRIPTION
#185 # What does this PR do?
Fixes possible 
`TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'`

Happens when the `"score": null` exists in the json output.

### Motivation
encountered when replicating

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
