### PR TITLE
Allow for additional chrome-flags

### DIFF
--- a/lighthouse/datadog_checks/lighthouse/data/conf.yaml.example
+++ b/lighthouse/datadog_checks/lighthouse/data/conf.yaml.example
@@ -20,6 +20,15 @@ instances:
     #
     name: <NAME_PLACEHOLDER>
 
+    ## @param extra_chrome_tags - list - optional
+    ## List of chrome-flags in addition to `--headless`
+    ##
+    ## Learn more about flags: https://www.chromium.org/developers/how-tos/run-chromium-with-flags
+    #
+    # extra_chrome_tags:
+    #   - <FLAG_1>
+    #   - <FLAG_2>
+
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.
     ##

--- a/lighthouse/datadog_checks/lighthouse/lighthouse.py
+++ b/lighthouse/datadog_checks/lighthouse/lighthouse.py
@@ -6,18 +6,27 @@ from datadog_checks.base.utils.common import round_value as round
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 EXPECTED_RESPONSE_CODE = "NO_ERROR"
+CHROME_FLAGS = ['--headless']
 
 
 class LighthouseCheck(AgentCheck):
     def check(self, instance):
         lighthouse_url = instance.get('url')
         lighthouse_name = instance.get('name')
+        extra_chrome_flags = instance.get('extra_chrome_flags', [])
 
         if not lighthouse_url or not lighthouse_name:
             self.log.error("missing instance url or name")
             raise CheckException("missing lighthouse instance url or name, please fix yaml")
 
-        cmd = ["lighthouse", lighthouse_url, "--output", "json", "--quiet", "--chrome-flags='--headless'"]
+        cmd = [
+            "lighthouse",
+            lighthouse_url,
+            "--output",
+            "json",
+            "--quiet",
+            "--chrome-flags='{}'".format(" ".join(CHROME_FLAGS + extra_chrome_flags)),
+        ]
 
         json_string, error_message, exit_code = LighthouseCheck._get_lighthouse_report(cmd, self.log, False)
 


### PR DESCRIPTION
### What does this PR do?

Allows for additional chrome-flags.

### Motivation

https://github.com/DataDog/integrations-extras/pull/594

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
