### PR TITLE
Using doc canonical links

### DIFF
--- a/ambassador/README.md
+++ b/ambassador/README.md
@@ -46,5 +46,5 @@ Need help? Contact [Datadog support][4].
 [1]: https://www.getambassador.io
 [2]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/ambassador/images/upstream-req-time.png
 [3]: https://github.com/DataDog/integrations-extras/blob/master/ambassador/metadata.csv
-[4]: https://docs.datadoghq.com/help
+[4]: https://docs.datadoghq.com/help/
 [5]: https://www.getambassador.io/docs/latest/topics/running/statistics/#exposing-statistics-via-statsd

--- a/apollo/README.md
+++ b/apollo/README.md
@@ -80,5 +80,5 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [6]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/apollo/images/settings-toggle.png
 [7]: https://www.apollographql.com/docs/graph-manager/datadog-integration/
 [8]: https://github.com/DataDog/integrations-extras/blob/master/apollo/metadata.csv
-[9]: https://docs.datadoghq.com/help
+[9]: https://docs.datadoghq.com/help/
 [10]: https://www.datadoghq.com/blog

--- a/aqua/README.md
+++ b/aqua/README.md
@@ -122,12 +122,12 @@ Need help? Contact [Datadog support][17].
 
 [1]: https://www.aquasec.com
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [5]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [6]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [7]: https://app.datadoghq.com/account/settings#agent
-[8]: https://docs.datadoghq.com/getting_started/integrations
+[8]: https://docs.datadoghq.com/getting_started/integrations/
 [9]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory
 [10]: https://github.com/DataDog/integrations-extras/blob/master/aqua/datadog_checks/aqua/data/conf.yaml.example
 [11]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
@@ -136,4 +136,4 @@ Need help? Contact [Datadog support][17].
 [14]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/#create-manifest
 [15]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
 [16]: https://github.com/DataDog/integrations-extras/blob/master/aqua/metadata.csv
-[17]: https://docs.datadoghq.com/help
+[17]: https://docs.datadoghq.com/help/

--- a/auth0/README.md
+++ b/auth0/README.md
@@ -53,7 +53,7 @@ auth0 does not include any events.
 
 Need help? Contact [Datadog support][1].
 
-[1]: https://docs.datadoghq.com/help
+[1]: https://docs.datadoghq.com/help/
 [2]: https://manage.auth0.com
 [4]: https://app.datadoghq.com/account/settings#api
 [5]: https://auth0.com/docs/logs/references/log-event-type-codes

--- a/aws_pricing/README.md
+++ b/aws_pricing/README.md
@@ -48,6 +48,6 @@ Need help? Contact [Datadog support][5].
 [2]: https://github.com/DataDog/integrations-extras/blob/master/aws_pricing/datadog_checks/aws_pricing/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/#restart-the-agent
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-information
-[5]: https://docs.datadoghq.com/help
+[5]: https://docs.datadoghq.com/help/
 [6]: https://github.com/DataDog/integrations-extras/blob/master/aws_pricing/metadata.csv
 [7]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/

--- a/bind9/README.md
+++ b/bind9/README.md
@@ -86,14 +86,14 @@ Please refer to the [main documentation][13] for more details about how to test 
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/bind9/images/snapshot.png
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [5]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [6]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/bind9/datadog_checks/bind9/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [11]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
 [12]: https://github.com/DataDog/cookiecutter-datadog-check/blob/master/%7B%7Bcookiecutter.check_name%7D%7D/metadata.csv
-[13]: https://docs.datadoghq.com/developers
+[13]: https://docs.datadoghq.com/developers/

--- a/bonsai/README.md
+++ b/bonsai/README.md
@@ -71,5 +71,5 @@ Learn more about infrastructure monitoring and all Datadog integrations in [our 
 [5]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/bonsai/images/activate_datadog.png
 [6]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/bonsai/images/datadog_activated.png
 [7]: https://github.com/DataDog/integrations-extras/blob/master/bonsai/metadata.csv
-[8]: https://docs.datadoghq.com/help
+[8]: https://docs.datadoghq.com/help/
 [9]: https://www.datadoghq.com/blog

--- a/buddy/README.md
+++ b/buddy/README.md
@@ -57,5 +57,5 @@ Need help? Contact [Datadog support][7].
 [3]: https://app.buddy.works/login
 [4]: https://buddy.works/knowledge/deployments/what-parameters-buddy-use
 [5]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/buddy/images/snapshot.png
-[6]: https://docs.datadoghq.com/events
-[7]: https://docs.datadoghq.com/help
+[6]: https://docs.datadoghq.com/events/
+[7]: https://docs.datadoghq.com/help/

--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -110,11 +110,11 @@ cert_manager does not include any events.
 Need help? Contact [Datadog support][9].
 
 [1]: https://github.com/jetstack/cert-manager
-[2]: https://docs.datadoghq.com/agent/autodiscovery/integrations
+[2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
 [3]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [4]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile
 [5]: https://github.com/DataDog/integrations-extras/blob/master/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [8]: https://github.com/DataDog/integrations-core/blob/master/cert_manager/metadata.csv
-[9]: https://docs.datadoghq.com/help
+[9]: https://docs.datadoghq.com/help/

--- a/concourse_ci/README.md
+++ b/concourse_ci/README.md
@@ -48,7 +48,7 @@ Need help? Contact [Datadog support][6].
 
 [1]: https://concourse-ci.org/concepts.html
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/developers/metrics/custom_metrics
+[3]: https://docs.datadoghq.com/developers/metrics/custom_metrics/
 [4]: https://concourse-ci.org/metrics.html#configuring-metrics
 [5]: https://github.com/DataDog/integrations-extras/blob/master/concourse_ci/metadata.csv
-[6]: https://docs.datadoghq.com/help
+[6]: https://docs.datadoghq.com/help/

--- a/convox/README.md
+++ b/convox/README.md
@@ -55,4 +55,4 @@ Need help? Contact [Datadog support][4].
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/convox/images/snapshot.png
 [2]: https://docs.convox.com/external-services/datadog
 [3]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwet.html
-[4]: https://docs.datadoghq.com/help
+[4]: https://docs.datadoghq.com/help/

--- a/eventstore/README.md
+++ b/eventstore/README.md
@@ -74,12 +74,12 @@ The eventstore check does not include any service checks.
 
 Need help? Contact the [maintainer][12] of this integration.
 
-[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [4]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [5]: https://app.datadoghq.com/account/settings#agent
-[6]: https://docs.datadoghq.com/getting_started/integrations
+[6]: https://docs.datadoghq.com/getting_started/integrations/
 [7]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [8]: https://github.com/DataDog/integrations-extras/blob/master/eventstore/datadog_checks/eventstore/data/conf.yaml.example
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-restart-the-agent

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -72,15 +72,15 @@ The Filebeat check does not include any service checks.
 Need help? Contact [Datadog support][13].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/filebeat/datadog_checks/filebeat/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [11]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
 [12]: https://github.com/DataDog/integrations-extras/blob/master/filebeat/metadata.csv
-[13]: https://docs.datadoghq.com/help
+[13]: https://docs.datadoghq.com/help/

--- a/gnatsd/README.md
+++ b/gnatsd/README.md
@@ -82,15 +82,15 @@ Returns `CRITICAL` if the Agent fails to receive a 200 from the _monitoring_ end
 
 Need help? Contact [Datadog support][12].
 
-[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [4]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [5]: https://app.datadoghq.com/account/settings#agent
-[6]: https://docs.datadoghq.com/getting_started/integrations
+[6]: https://docs.datadoghq.com/getting_started/integrations/
 [7]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [8]: https://github.com/DataDog/integrations-extras/blob/master/gnatsd/datadog_checks/gnatsd/data/conf.yaml.example
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
 [11]: https://github.com/DataDog/datadog-sdk-testing/blob/master/lib/config/metadata.csv
-[12]: https://docs.datadoghq.com/help
+[12]: https://docs.datadoghq.com/help/

--- a/gnatsd_streaming/README.md
+++ b/gnatsd_streaming/README.md
@@ -83,12 +83,12 @@ Returns `CRITICAL` if the Agent fails to receive a 200 from the _monitoring_ end
 
 Need help? Contact [Datadog support][12].
 
-[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [4]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [5]: https://app.datadoghq.com/account/settings#agent
-[6]: https://docs.datadoghq.com/getting_started/integrations
+[6]: https://docs.datadoghq.com/getting_started/integrations/
 [7]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [8]: https://github.com/DataDog/integrations-extras/blob/master/gnatsd_streaming/datadog_checks/gnatsd_streaming/data/conf.yaml.example
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/gremlin/README.md
+++ b/gremlin/README.md
@@ -47,5 +47,5 @@ Learn more about infrastructure monitoring and all our integrations on [our blog
 [2]: https://app.datadoghq.com/event/stream
 [3]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/gremlin/images/events-overlay.png
 [4]: https://app.gremlin.com/settings/integrations
-[5]: https://docs.datadoghq.com/help
+[5]: https://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog

--- a/hbase_master/README.md
+++ b/hbase_master/README.md
@@ -67,12 +67,12 @@ The Hbase_master check does not include any service checks.
 
 Need help? Contact [Datadog support][12].
 
-[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [4]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [5]: https://app.datadoghq.com/account/settings#agent
-[6]: https://docs.datadoghq.com/getting_started/integrations
+[6]: https://docs.datadoghq.com/getting_started/integrations/
 [7]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [8]: https://github.com/DataDog/integrations-extras/blob/master/hbase_master/datadog_checks/hbase_master/data/conf.yaml.example
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/hbase_regionserver/README.md
+++ b/hbase_regionserver/README.md
@@ -72,12 +72,12 @@ The HBase RegionServer check does not include any service checks.
 Need help? Contact [Datadog support][13].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/hbase_regionserver/datadog_checks/hbase_regionserver/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/lacework/README.md
+++ b/lacework/README.md
@@ -54,4 +54,4 @@ Need help? Contact [Datadog support][7].
 [1]: https://docs.datadoghq.com/integrations/lacework/
 [2]: https://www.lacework.com/datadog/
 [3]: https://app.datadoghq.com/account/settings#api
-[7]: https://docs.datadoghq.com/help
+[7]: https://docs.datadoghq.com/help/

--- a/lighthouse/README.md
+++ b/lighthouse/README.md
@@ -141,12 +141,12 @@ Need help? Contact [Datadog support][17].
 
 [1]: https://developers.google.com/web/tools/lighthouse
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [5]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [6]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [7]: https://app.datadoghq.com/account/settings#agent
-[8]: https://docs.datadoghq.com/getting_started/integrations
+[8]: https://docs.datadoghq.com/getting_started/integrations/
 [9]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [10]: https://github.com/DataDog/integrations-extras/blob/master/lighthouse/datadog_checks/lighthouse/data/conf.yaml.example
 [11]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
@@ -155,5 +155,5 @@ Need help? Contact [Datadog support][17].
 [14]: https://github.com/GoogleChrome/puppeteer
 [15]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [16]: https://github.com/DataDog/integrations-extras/blob/master/lighthouse/datadog_checks/lighthouse/metadata.csv
-[17]: https://docs.datadoghq.com/help
+[17]: https://docs.datadoghq.com/help/
 [18]: https://www.chromium.org/

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -187,12 +187,12 @@ Check that the `url` in `conf.yaml` is correct.
 If you need further help, contact [Datadog support][23].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/logstash/datadog_checks/logstash/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/logzio/README.md
+++ b/logzio/README.md
@@ -45,4 +45,4 @@ Need help? Contact [Datadog support][5].
 [2]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/logzio/images/dashboard.png
 [3]: https://app.datadoghq.com/account/settings#api
 [4]: http://logz.io/blog/log-correlation-datadog
-[5]: https://docs.datadoghq.com/help
+[5]: https://docs.datadoghq.com/help/

--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -78,12 +78,12 @@ Returns `CRITICAL` if the Agent fails to receive a 200 from the _monitoring_ end
 Need help? Contact [Datadog support][13].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/neo4j/datadog_checks/neo4j/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/neutrona/README.md
+++ b/neutrona/README.md
@@ -70,15 +70,15 @@ Neutrona does not include any events at this time.
 Need help? Contact [Datadog support][13].
 
 [1]: https://telemetry.neutrona.com
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/neutrona/datadog_checks/neutrona/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [11]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
 [12]: https://github.com/DataDog/integrations-core/blob/master/neutrona/metadata.csv
-[13]: https://docs.datadoghq.com/help
+[13]: https://docs.datadoghq.com/help/

--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -72,15 +72,15 @@ Nextcloud does not include any events.
 Need help? Contact [Datadog support][13].
 
 [1]: https://nextcloud.com
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/nextcloud/datadog_checks/nextcloud/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [11]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
 [12]: https://github.com/DataDog/integrations-extras/blob/master/nextcloud/metadata.csv
-[13]: https://docs.datadoghq.com/help
+[13]: https://docs.datadoghq.com/help/

--- a/nomad/README.md
+++ b/nomad/README.md
@@ -49,4 +49,4 @@ Need help? Contact [Datadog support][3].
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://github.com/DataDog/integrations-extras/blob/master/nomad/metadata.csv
-[3]: https://docs.datadoghq.com/help
+[3]: https://docs.datadoghq.com/help/

--- a/pihole/README.md
+++ b/pihole/README.md
@@ -43,7 +43,7 @@ Returns `CRITICAL` if the Agent cannot communicate with the target host. Returns
 Pi-hole does not include any events.
 
 [1]: https://pi-hole.net/
-[2]: https://docs.datadoghq.com/agent/autodiscovery/integrations
+[2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
 [3]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [4]: https://app.datadoghq.com/account/settings#agent
 [5]: https://github.com/DataDog/integrations-extras/blob/master/pihole/datadog_checks/pihole/data/conf.yaml.example

--- a/ping/README.md
+++ b/ping/README.md
@@ -77,14 +77,14 @@ Need help? Contact [Datadog support][13].
 
 [1]: https://en.wikipedia.org/wiki/Ping_(networking_utility)
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [5]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [6]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [7]: https://app.datadoghq.com/account/settings#agent
-[8]: https://docs.datadoghq.com/getting_started/integrations
+[8]: https://docs.datadoghq.com/getting_started/integrations/
 [9]: https://github.com/DataDog/integrations-extras/blob/master/ping/datadog_checks/ping/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [11]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
 [12]: https://github.com/DataDog/integrations-extras/blob/master/ping/metadata.csv
-[13]: https://docs.datadoghq.com/help
+[13]: https://docs.datadoghq.com/help/

--- a/portworx/README.md
+++ b/portworx/README.md
@@ -90,15 +90,15 @@ Check that the `url` in `portworx.yaml` is correct.
 
 Learn more about infrastructure monitoring and all our integrations on [our blog][12].
 
-[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [4]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [5]: https://app.datadoghq.com/account/settings#agent
-[6]: https://docs.datadoghq.com/getting_started/integrations
+[6]: https://docs.datadoghq.com/getting_started/integrations/
 [7]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [8]: https://github.com/DataDog/integrations-extras/blob/master/portworx/datadog_checks/portworx/data/conf.yaml.example
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[10]: https://docs.datadoghq.com/agent/faq/agent-status-and-information
+[10]: https://docs.datadoghq.com/agent/faq/agent-status-and-information/
 [11]: https://github.com/DataDog/integrations-extras/blob/master/portworx/metadata.csv
 [12]: https://www.datadoghq.com/blog

--- a/rbltracker/README.md
+++ b/rbltracker/README.md
@@ -39,5 +39,5 @@ Need help? Contact [Datadog support][5].
 [1]: https://rbltracker.com
 [2]: https://app.datadoghq.com/account/settings#api
 [3]: https://rbltracker.com/docs/adding-a-datadog-contact-type
-[4]: https://docs.datadoghq.com/events
-[5]: https://docs.datadoghq.com/help
+[4]: https://docs.datadoghq.com/events/
+[5]: https://docs.datadoghq.com/help/

--- a/reboot_required/README.md
+++ b/reboot_required/README.md
@@ -81,12 +81,12 @@ The check returns:
 
 Need help? Contact [Datadog support][11].
 
-[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[1]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [4]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [5]: https://app.datadoghq.com/account/settings#agent
-[6]: https://docs.datadoghq.com/getting_started/integrations
+[6]: https://docs.datadoghq.com/getting_started/integrations/
 [7]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [8]: https://github.com/DataDog/integrations-extras/blob/master/reboot_required/datadog_checks/reboot_required/data/conf.yaml.example
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status

--- a/redis_sentinel/README.md
+++ b/redis_sentinel/README.md
@@ -99,12 +99,12 @@ The check returns:
 Need help? Contact [Datadog support][13].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/redis_sentinel/datadog_checks/redis_sentinel/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/resin/README.md
+++ b/resin/README.md
@@ -54,5 +54,5 @@ Need help? Contact [Datadog support][5].
 [2]: https://github.com/DataDog/integrations-core/blob/master/resin/datadog_checks/resin/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
-[5]: https://docs.datadoghq.com/help
+[5]: https://docs.datadoghq.com/help/
 [6]: https://github.com/DataDog/integrations-extras/blob/master/resin/metadata.csv

--- a/riak_repl/README.md
+++ b/riak_repl/README.md
@@ -66,15 +66,15 @@ riak_repl does not currently include any events.
 
 Need help? Contact [Datadog support][12].
 
-[1]: https://docs.datadoghq.com/integrations/riak_repl
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[1]: https://docs.datadoghq.com/integrations/riak_repl/
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://github.com/DataDog/integrations-extras/blob/master/riak_repl/datadog_checks/riak_repl/data/conf.yaml.example
 [9]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
 [11]: https://github.com/DataDog/integrations-extras/blob/master/riak_repl/metadata.csv
-[12]: https://docs.datadoghq.com/help
+[12]: https://docs.datadoghq.com/help/

--- a/rookout/README.md
+++ b/rookout/README.md
@@ -93,8 +93,8 @@ You can collect custom metrics and events by creating a Datadog output in your R
 
 If you have any questions, contact us at support@rookout.com.
 
-[1]: https://docs.datadoghq.com/getting_started/custom_metrics
-[2]: https://docs.datadoghq.com/agent
+[1]: https://docs.datadoghq.com/getting_started/custom_metrics/
+[2]: https://docs.datadoghq.com/agent/
 [3]: https://docs.rookout.com/docs/getting-started.html
 [4]: https://app.rookout.com
 [5]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/rookout/images/click_rule_action.png
@@ -102,4 +102,4 @@ If you have any questions, contact us at support@rookout.com.
 [7]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/rookout/rule-template.json
 [8]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/rookout/images/datadog_rule_template.png
 [9]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/rookout/images/click_save.png
-[10]: https://docs.datadoghq.com/developers/dogstatsd
+[10]: https://docs.datadoghq.com/developers/dogstatsd/

--- a/rundeck/README.md
+++ b/rundeck/README.md
@@ -83,4 +83,4 @@ Need help? Contact [Datadog support][6].
 [3]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/rundeck/images/dd-search.png
 [4]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/rundeck/images/webhooks-config.png
 [5]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/rundeck/images/webhook-fill.png
-[6]: https://docs.datadoghq.com/help
+[6]: https://docs.datadoghq.com/help/

--- a/sendmail/README.md
+++ b/sendmail/README.md
@@ -67,14 +67,14 @@ Sendmail does not include any events.
 Need help? Contact [Datadog support][12].
 
 [1]: https://www.proofpoint.com/us/open-source-email-solution
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://github.com/DataDog/integrations-extras/blob/master/sendmail/datadog_checks/sendmail/data/conf.yaml.example
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [11]: https://github.com/DataDog/integrations-extras/blob/master/sendmail/metadata.csv
-[12]: https://docs.datadoghq.com/help
+[12]: https://docs.datadoghq.com/help/

--- a/sigsci/README.md
+++ b/sigsci/README.md
@@ -128,7 +128,7 @@ To sign up for the Signal Sciences-Datadog Monitoring, a free service to see att
 [6]: https://dashboard.signalsciences.net
 [7]: https://player.vimeo.com/video/347360711
 [8]: https://docs.signalsciences.net/integrations/datadog/
-[9]: https://docs.datadoghq.com/events
-[10]: https://docs.datadoghq.com/help
+[9]: https://docs.datadoghq.com/events/
+[10]: https://docs.datadoghq.com/help/
 [11]: https://labs.signalsciences.com
 [12]: https://info.signalsciences.com/datadog-security

--- a/snmpwalk/README.md
+++ b/snmpwalk/README.md
@@ -77,12 +77,12 @@ The check returns:
 Need help? Contact [Datadog support][12].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/snmpwalk/datadog_checks/snmpwalk/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/sortdb/README.md
+++ b/sortdb/README.md
@@ -69,12 +69,12 @@ The SortDB check does not currently include any service checks.
 The SortDB check does not currently include any events.
 
 [1]: https://github.com/jehiah/sortdb
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/sortdb/datadog_checks/sortdb/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent

--- a/split/README.md
+++ b/split/README.md
@@ -46,5 +46,5 @@ Need help? Contact [Datadog support][6].
 [2]: http://www.split.io/articles/controlled-rollout
 [3]: https://raw.githubusercontent.com/DataDog/integrations-extras/ilan/split-integration/split/images/in-split.png
 [4]: https://raw.githubusercontent.com/DataDog/integrations-extras/ilan/split-integration/split/images/integrations-datadog.png
-[5]: https://docs.datadoghq.com/events
-[6]: https://docs.datadoghq.com/help
+[5]: https://docs.datadoghq.com/events/
+[6]: https://docs.datadoghq.com/help/

--- a/stardog/README.md
+++ b/stardog/README.md
@@ -72,12 +72,12 @@ The Stardog check does not include any service checks.
 Need help? Contact [Datadog support][13].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/stardog/datadog_checks/stardog/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/storm/README.md
+++ b/storm/README.md
@@ -77,12 +77,12 @@ The check returns:
 Need help? Contact [Datadog support][13].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/storm/datadog_checks/storm/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -133,12 +133,12 @@ Query Traefik and expect `200` as return status code.
 Refer to the [main documentation][15] for more details about how to test and develop Agent based integrations.
 
 [1]: https://traefik.io
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/faq/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/traefik/datadog_checks/traefik/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/faq/agent-commands/#start-stop-restart-the-agent
@@ -146,4 +146,4 @@ Refer to the [main documentation][15] for more details about how to test and dev
 [12]: https://docs.traefik.io/configuration/logs/#traefik-logs
 [13]: https://docs.traefik.io/configuration/logs/#clf-common-log-format
 [14]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
-[15]: https://docs.datadoghq.com/developers
+[15]: https://docs.datadoghq.com/developers/

--- a/unbound/README.md
+++ b/unbound/README.md
@@ -53,11 +53,11 @@ The Unbound check does not include any events.
 Need help? Contact [Datadog support][9].
 
 [1]: https://nlnetlabs.nl/documentation/unbound/unbound-control/
-[2]: https://docs.datadoghq.com/agent
+[2]: https://docs.datadoghq.com/agent/
 [3]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [4]: https://app.datadoghq.com/account/settings#agent
 [5]: https://github.com/DataDog/integrations-extras/blob/master/unbound/datadog_checks/unbound/data/conf.yaml.example
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [8]: https://github.com/DataDog/integrations-extras/blob/master/unbound/metadata.csv
-[9]: https://docs.datadoghq.com/help
+[9]: https://docs.datadoghq.com/help/

--- a/upsc/README.md
+++ b/upsc/README.md
@@ -72,12 +72,12 @@ The UPSC check does not include any service checks.
 Need help? Contact [Datadog support][13].
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
+[2]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker
 [5]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [6]: https://app.datadoghq.com/account/settings#agent
-[7]: https://docs.datadoghq.com/getting_started/integrations
+[7]: https://docs.datadoghq.com/getting_started/integrations/
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [9]: https://github.com/DataDog/integrations-extras/blob/master/upsc/datadog_checks/upsc/data/conf.yaml.example
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/uptime/README.md
+++ b/uptime/README.md
@@ -46,4 +46,4 @@ Need help? Contact [Datadog support][4].
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/uptime/images/snapshot.png
 [2]: https://uptime.com/push-notifications/manage
 [3]: https://github.com/DataDog/integrations-extras/blob/master/uptime/metadata.csv
-[4]: https://docs.datadoghq.com/help
+[4]: https://docs.datadoghq.com/help/

--- a/vespa/README.md
+++ b/vespa/README.md
@@ -69,7 +69,7 @@ Need help? Contact [Datadog support][5].
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[5]: https://docs.datadoghq.com/help
+[5]: https://docs.datadoghq.com/help/
 [6]: https://github.com/DataDog/integrations-extras/blob/master/vespa/metadata.csv
 [7]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
 [8]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory

--- a/vns3/README.md
+++ b/vns3/README.md
@@ -50,4 +50,4 @@ Need help? Contact [Datadog support][7].
 [4]: https://cohesive.net/dnld/Cohesive-Networks_VNS3-DataDog-Container-Guide.pdf
 [5]: https://youtu.be/sTCgCG3m4vk
 [6]: https://github.com/DataDog/integrations-extras/blob/master/vns3/metadata.csv
-[7]: https://docs.datadoghq.com/help
+[7]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?
Updates all documentation link to use the canonical form (with a trailing `/`) in order to avoid redirects within the doc.

### Motivation
Better flow