### PR TITLE
k6: overview content changes

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-Track performance metrics of [k6][1] tests to:
+[k6][1] is an open-source load testing tool that will help you to catch performance issues and performance regressions earlier.
+
+With the k6 integration, you can track performance metrics of k6 tests to:
+
 - Correlate application performance with load testing metrics.
 - Create alerts based on performance testing metrics.
 - Analyze and visualize k6 metrics using the k6 Datadog Dashboard or [Metrics Explorer][5].
@@ -80,7 +83,7 @@ The k6 integration does not include any events.
 Need help? Read the [k6 Datadog documentation](2) or contact [k6 support][10].
 
 [1]: https://k6.io/open-source
-[2]: https://k6.io/docs/getting-started/results-output/datadog 
+[2]: https://k6.io/docs/results-visualization/datadog
 [3]: https://app.datadoghq.com/account/settings#api
 [4]: https://github.com/DataDog/integrations-extras/blob/master/k6/metadata.csv
 [5]: https://docs.datadoghq.com/metrics/explorer/


### PR DESCRIPTION
### What does this PR do?

- adds a brief description of k6.
- fix the format of the list on the `Overview` section
- update URL

### Motivation

The format of the overview content is broken:

<img width="677" alt="Screen Shot 2020-05-05 at 11 03 10 AM" src="https://user-images.githubusercontent.com/825430/81050451-4b839100-8ec0-11ea-842f-5aac1e4c2bc5.png">



