### PR TITLE
Add configuration specs and normalize metric name option

### DIFF
--- a/filebeat/assets/configuration/spec.yaml
+++ b/filebeat/assets/configuration/spec.yaml
@@ -1,0 +1,43 @@
+name: Filebeat
+files:
+- name: filebeat.yaml
+  options:
+  - template: init_config
+    options:
+    - template: init_config/default
+  - template: instances
+    options:
+    - name: registry_file_path
+      required: true
+      description: |
+        The absolute path to the registry file used by Filebeat.
+
+        See https://www.elastic.co/guide/en/beats/filebeat/current/migration-registry-file.html
+      value:
+        type: string
+        example: /var/lib/filebeat/registry
+    - name: stats_endpoint
+      required: true
+      description: |
+        If Filebeat has been started with the `--httpprof [HOST]:PORT` option, then
+        the Datadog agent can gather data about the metrics Filebeat exposes to  http://<HOST>:<PORT>/debug/vars.
+
+        See https://www.elastic.co/guide/en/beats/filebeat/current/command-line-options.html
+        For autodiscovery, use http://%%host%%:%%port%%/stats
+      value: 
+        type: string
+        example: http://localhost:2828/stats
+    - name: only_metrics
+      required: true
+      description: |
+        This should be a list of regular expressions that stipulates which variables should be reported to 
+        Datadog - a Filebeat metric reported by the HTTP profiler will only be reported
+         if it matches at least one of those regexes.
+      value:
+        type: array
+        items: 
+          type: string
+        example:
+          - ^filebeat
+          - ^publish\.events$
+    - template: instances/default

--- a/filebeat/assets/configuration/spec.yaml
+++ b/filebeat/assets/configuration/spec.yaml
@@ -46,4 +46,9 @@ files:
         example:
           - ^filebeat
           - ^publish\.events$
+    - name: timeout
+      description: Timeout in seconds for the connection `registry_file_path`.
+      value:
+        type: integer
+        example: 2
     - template: instances/default

--- a/filebeat/assets/configuration/spec.yaml
+++ b/filebeat/assets/configuration/spec.yaml
@@ -27,6 +27,12 @@ files:
       value: 
         type: string
         example: http://localhost:2828/stats
+    - name: normalize_metrics
+      description: |
+        Normalize metric names to be prefixed with the integration name.
+      value:
+        type: boolean
+        example: false
     - name: only_metrics
       required: true
       description: |

--- a/filebeat/assets/configuration/spec.yaml
+++ b/filebeat/assets/configuration/spec.yaml
@@ -38,7 +38,7 @@ files:
       description: |
         This should be a list of regular expressions that stipulates which variables should be reported to 
         Datadog - a Filebeat metric reported by the HTTP profiler will only be reported
-         if it matches at least one of those regexes.
+        if it matches at least one of those regexes.
       value:
         type: array
         items: 

--- a/filebeat/datadog_checks/filebeat/data/conf.yaml.example
+++ b/filebeat/datadog_checks/filebeat/data/conf.yaml.example
@@ -29,6 +29,11 @@ instances:
     #
     stats_endpoint: http://localhost:2828/stats
 
+    ## @param normalize_metrics - boolean - optional - default: false
+    ## Normalize metric names to be prefixed with the integration name.
+    #
+    # normalize_metrics: false
+
     ## @param only_metrics - list of strings - required
     ## This should be a list of regular expressions that stipulates which variables should be reported to 
     ## Datadog - a Filebeat metric reported by the HTTP profiler will only be reported

--- a/filebeat/datadog_checks/filebeat/data/conf.yaml.example
+++ b/filebeat/datadog_checks/filebeat/data/conf.yaml.example
@@ -1,17 +1,28 @@
+## All options defined here are available to all instances.
+#
 init_config:
 
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Additionally, this sets the default `service` for every log source.
+    #
+    # service: <SERVICE>
+
+## Every instance is scheduled independent of the others.
+#
 instances:
 
     ## @param registry_file_path - string - required
-    ## The absolute path to the registry file used by Filebeat
+    ## The absolute path to the registry file used by Filebeat.
+    ##
     ## See https://www.elastic.co/guide/en/beats/filebeat/current/migration-registry-file.html
     #
   - registry_file_path: /var/lib/filebeat/registry
 
     ## @param stats_endpoint - string - required
     ## If Filebeat has been started with the `--httpprof [HOST]:PORT` option, then
-    ## the DD agent can gather data about the metrics Filebeat exposes to
-    ##  http://<HOST>:<PORT>/debug/vars
+    ## the Datadog agent can gather data about the metrics Filebeat exposes to  http://<HOST>:<PORT>/debug/vars.
     ##
     ## See https://www.elastic.co/guide/en/beats/filebeat/current/command-line-options.html
     ## For autodiscovery, use http://%%host%%:%%port%%/stats
@@ -19,16 +30,39 @@ instances:
     stats_endpoint: http://localhost:2828/stats
 
     ## @param only_metrics - list of strings - required
-    ## This should be a list of regular expressions that stipulates
-    ## which variables should be reported to Datadog - a Filebeat metric
-    ## reported by the HTTP profiler will only be reported if it matches at
-    ## least one of those regexes.
+    ## This should be a list of regular expressions that stipulates which variables should be reported to 
+    ## Datadog - a Filebeat metric reported by the HTTP profiler will only be reported
+    ##  if it matches at least one of those regexes.
     #
     only_metrics:
       - ^filebeat
       - ^publish\.events$
 
-    ## @param timeout - integer - optional - default: 2
-    ## timeout in seconds for the connection to `registry_file_path`
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
     #
-    # timeout: 2
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
+
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false

--- a/filebeat/datadog_checks/filebeat/data/conf.yaml.example
+++ b/filebeat/datadog_checks/filebeat/data/conf.yaml.example
@@ -37,7 +37,7 @@ instances:
     ## @param only_metrics - list of strings - required
     ## This should be a list of regular expressions that stipulates which variables should be reported to 
     ## Datadog - a Filebeat metric reported by the HTTP profiler will only be reported
-    ##  if it matches at least one of those regexes.
+    ## if it matches at least one of those regexes.
     #
     only_metrics:
       - ^filebeat

--- a/filebeat/datadog_checks/filebeat/data/conf.yaml.example
+++ b/filebeat/datadog_checks/filebeat/data/conf.yaml.example
@@ -43,6 +43,11 @@ instances:
       - ^filebeat
       - ^publish\.events$
 
+    ## @param timeout - integer - optional - default: 2
+    ## Timeout in seconds for the connection `registry_file_path`.
+    #
+    # timeout: 2
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -14,7 +14,7 @@ import sre_constants
 import requests
 from six import iteritems
 
-from datadog_checks.base import AgentCheck
+from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.containers import hash_mutable
 
 EVENT_TYPE = SOURCE_TYPE_NAME = "filebeat"

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -219,7 +219,7 @@ class FilebeatCheck(AgentCheck):
         self.instance_cache = {}
 
     def check(self, instance):
-        normalize_metrics = instance.get("normalize_metrics")
+        normalize_metrics = is_affirmative(instance.get("normalize_metrics"), False)
 
         instance_key = hash_mutable(instance)
         if instance_key in self.instance_cache:

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -164,6 +164,7 @@ class FilebeatCheckInstanceConfig:
         self._stats_endpoint = instance.get("stats_endpoint")
 
         self._only_metrics = instance.get("only_metrics", [])
+
         if not isinstance(self._only_metrics, list):
             raise Exception(
                 "If given, filebeat's only_metrics must be a list of regexes, got %s" % (self._only_metrics,)
@@ -210,11 +211,16 @@ class FilebeatCheckInstanceConfig:
 
 
 class FilebeatCheck(AgentCheck):
+
+    METRIC_PREFIX = "filebeat."
+
     def __init__(self, *args, **kwargs):
         AgentCheck.__init__(self, *args, **kwargs)
         self.instance_cache = {}
 
     def check(self, instance):
+        normalize_metrics = instance.get("normalize_metrics")
+
         instance_key = hash_mutable(instance)
         if instance_key in self.instance_cache:
             config = self.instance_cache[instance_key]["config"]
@@ -225,7 +231,7 @@ class FilebeatCheck(AgentCheck):
             self.instance_cache[instance_key] = {"config": config, "profiler": profiler}
 
         self._process_registry(config)
-        self._gather_http_profiler_metrics(config, profiler)
+        self._gather_http_profiler_metrics(config, profiler, normalize_metrics)
 
     def _process_registry(self, config):
         registry_contents = self._parse_registry_file(config.registry_file_path)
@@ -270,7 +276,7 @@ class FilebeatCheck(AgentCheck):
     def _is_same_file(self, stats, file_state_os):
         return stats.st_dev == file_state_os["device"] and stats.st_ino == file_state_os["inode"]
 
-    def _gather_http_profiler_metrics(self, config, profiler):
+    def _gather_http_profiler_metrics(self, config, profiler, normalize_metrics):
         try:
             all_metrics = profiler.gather_metrics()
         except Exception as ex:
@@ -283,6 +289,6 @@ class FilebeatCheck(AgentCheck):
             method = getattr(self, action)
 
             for name, value in iteritems(metrics):
-                if not name.startswith('filebeat'):
-                    name = 'filebeat.' + name
+                if not name.startswith(self.METRIC_PREFIX) and normalize_metrics:
+                    name = self.METRIC_PREFIX + name
                 method(name, value, tags)

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -283,4 +283,6 @@ class FilebeatCheck(AgentCheck):
             method = getattr(self, action)
 
             for name, value in iteritems(metrics):
+                if not name.startswith('filebeat'):
+                    name = 'filebeat.' + name
                 method(name, value, tags)

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -219,7 +219,7 @@ class FilebeatCheck(AgentCheck):
         self.instance_cache = {}
 
     def check(self, instance):
-        normalize_metrics = is_affirmative(instance.get("normalize_metrics"), False)
+        normalize_metrics = is_affirmative(instance.get("normalize_metrics", False))
 
         instance_key = hash_mutable(instance)
         if instance_key in self.instance_cache:

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -21,6 +21,9 @@
   "is_public": true,
   "metric_prefix": "filebeat.",
   "assets": {
+    "configuration": {
+      "spec": "assets/configuration/spec.yaml"
+    },
     "monitors": {},
     "dashboards": {},
     "service_checks": "/assets/service_checks.json"

--- a/filebeat/tests/test_filebeat.py
+++ b/filebeat/tests/test_filebeat.py
@@ -452,7 +452,9 @@ def test_normalize_metrics(aggregator):
 
     aggregator.assert_metric("filebeat.harvester.running", metric_type=aggregator.GAUGE, tags=tags)
 
-    with mock_request({"filebeat.libbeat.logstash.published_and_acked_events": 1138956, "filebeat.harvester.running": 9}):
+    with mock_request(
+        {"filebeat.libbeat.logstash.published_and_acked_events": 1138956, "filebeat.harvester.running": 9}
+    ):
         check.check(config)
 
     aggregator.assert_metric(
@@ -461,12 +463,15 @@ def test_normalize_metrics(aggregator):
     aggregator.assert_metric(
         "filebeat.libbeat.kafka.published_and_acked_events", metric_type=aggregator.COUNTER, tags=tags
     )
-    aggregator.assert_metric("filebeat.harvester.running", metric_type=aggregator.GAUGE,tags=tags)
+    aggregator.assert_metric("filebeat.harvester.running", metric_type=aggregator.GAUGE, tags=tags)
 
 
 def test_normalize_metrics_with_an_only_metrics_list(aggregator):
     config = _build_instance(
-        "empty", stats_endpoint="http://localhost:9999", only_metrics=[r"^libbeat.kafka", r"truncated$"], normalize_metrics=True
+        "empty",
+        stats_endpoint="http://localhost:9999",
+        only_metrics=[r"^libbeat.kafka", r"truncated$"],
+        normalize_metrics=True,
     )
     check = FilebeatCheck("filebeat", {}, {})
     tags = ["stats_endpoint:http://localhost:9999"]
@@ -475,7 +480,10 @@ def test_normalize_metrics_with_an_only_metrics_list(aggregator):
         check.check(config)
 
     with mock_request(
-        {"filebeat.libbeat.logstash.published_and_acked_events": 1138956, "libbeat.kafka.published_and_acked_events": 12}
+        {
+            "filebeat.libbeat.logstash.published_and_acked_events": 1138956,
+            "libbeat.kafka.published_and_acked_events": 12,
+        }
     ):
         check.check(config)
 
@@ -489,4 +497,3 @@ def test_normalize_metrics_with_an_only_metrics_list(aggregator):
         "filebeat.libbeat.kafka.call_count.PublishEvents", metric_type=aggregator.COUNTER, value=0, tags=tags
     )
     aggregator.assert_metric("filebeat.harvester.files.truncated", metric_type=aggregator.COUNTER, value=0, tags=tags)
-


### PR DESCRIPTION
### What does this PR do?

This PR adds a standard configuration spec and introduces the `normalize_metrics` configuration option which is disabled by default. The option normalizes the metrics emitted by the filebeat integration to be prefixed with integration name.

### Motivation
Resolves https://github.com/DataDog/integrations-extras/issues/392

Consistent naming conventions to properly identify which integration is emitting the metric.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
