### PR TITLE
Removing slash from asset service check location

### DIFF
--- a/ambassador/manifest.json
+++ b/ambassador/manifest.json
@@ -26,6 +26,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/apollo/manifest.json
+++ b/apollo/manifest.json
@@ -25,7 +25,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   },
   "aliases": ["/integrations/apollo_engine"]
 }

--- a/aqua/manifest.json
+++ b/aqua/manifest.json
@@ -26,6 +26,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/aws_pricing/manifest.json
+++ b/aws_pricing/manifest.json
@@ -26,6 +26,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/bind9/manifest.json
+++ b/bind9/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/bonsai/manifest.json
+++ b/bonsai/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/buddy/manifest.json
+++ b/buddy/manifest.json
@@ -22,6 +22,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/concourse_ci/manifest.json
+++ b/concourse_ci/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/configcat/manifest.json
+++ b/configcat/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/convox/manifest.json
+++ b/convox/manifest.json
@@ -22,6 +22,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/gnatsd/manifest.json
+++ b/gnatsd/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/gnatsd_streaming/manifest.json
+++ b/gnatsd_streaming/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/gremlin/manifest.json
+++ b/gremlin/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/hbase_master/manifest.json
+++ b/hbase_master/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/hbase_regionserver/manifest.json
+++ b/hbase_regionserver/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/launchdarkly/manifest.json
+++ b/launchdarkly/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/lighthouse/manifest.json
+++ b/lighthouse/manifest.json
@@ -21,7 +21,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   },  
   "is_public": true
 }

--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -27,6 +27,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/logzio/manifest.json
+++ b/logzio/manifest.json
@@ -22,6 +22,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/neo4j/manifest.json
+++ b/neo4j/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/neutrona/manifest.json
+++ b/neutrona/manifest.json
@@ -26,6 +26,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/nextcloud/manifest.json
+++ b/nextcloud/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/nomad/manifest.json
+++ b/nomad/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/portworx/manifest.json
+++ b/portworx/manifest.json
@@ -21,6 +21,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/rbltracker/manifest.json
+++ b/rbltracker/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/reboot_required/manifest.json
+++ b/reboot_required/manifest.json
@@ -20,6 +20,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/redis_sentinel/manifest.json
+++ b/redis_sentinel/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/riak_repl/manifest.json
+++ b/riak_repl/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/rigor/manifest.json
+++ b/rigor/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/rookout/manifest.json
+++ b/rookout/manifest.json
@@ -22,6 +22,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/snmpwalk/manifest.json
+++ b/snmpwalk/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/sortdb/manifest.json
+++ b/sortdb/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/split/manifest.json
+++ b/split/manifest.json
@@ -22,6 +22,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/stardog/manifest.json
+++ b/stardog/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -23,6 +23,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/traefik/manifest.json
+++ b/traefik/manifest.json
@@ -25,6 +25,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/unbound/manifest.json
+++ b/unbound/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/upsc/manifest.json
+++ b/upsc/manifest.json
@@ -21,6 +21,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/uptime/manifest.json
+++ b/uptime/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }

--- a/vns3/manifest.json
+++ b/vns3/manifest.json
@@ -24,6 +24,6 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "/assets/service_checks.json"
+    "service_checks": "assets/service_checks.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?

Remove the first slash from the path to the service_checks.json file in each integration's manifest.json file. This location should be a relative path and the prepending slash is causing issues. (This will match whats in integrations-core)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)