### PR TITLE
Fix NVMLError subclass check

### DIFF
--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -43,7 +43,7 @@ class NvmlCall(object):
 
     def __init__(self, name, logger):
         self.name = name
-        self.log  = logger
+        self.log = logger
 
     def __enter__(self):
         pass

--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -51,7 +51,7 @@ class NvmlCall(object):
         # Do nothing if the exception is not from pynvml or there is no exception
         if traceback is None:
             return False
-        if exception_type is not pynvml.NVMLError:
+        if not issubclass(exception_type, pynvml.NVMLError):
             return False
 
         # Suppress pynvml exceptions so we can continue

--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -52,7 +52,7 @@ class NvmlCall(object):
         # Do nothing if the exception is not from pynvml or there is no exception
         if traceback is None:
             return False
-        if not isinstance(exception_type, pynvml.NVMLError):
+        if not issubclass(exception_type, pynvml.NVMLError):
             return False
 
         # Suppress pynvml exceptions so we can continue

--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -14,7 +14,6 @@ from datadog_checks.base import AgentCheck
 from .api_pb2 import ListPodResourcesRequest
 from .api_pb2_grpc import PodResourcesListerStub
 
-previously_printed_errors = set()
 METRIC_PREFIX = "nvml."
 SOCKET_PATH = "/var/lib/kubelet/pod-resources/kubelet.sock"
 """Assumed to be a UDS accessible from this running code"""
@@ -31,6 +30,7 @@ class NvmlInit(object):
 
 
 class NvmlCall(object):
+    previously_printed_errors = set()
     """Wraps a call and checks for an exception (of any type).
 
        Why this exists: If a graphics card doesn't support a nvml method, we don't want to spam the logs with just
@@ -56,10 +56,9 @@ class NvmlCall(object):
             return False
 
         # Suppress pynvml exceptions so we can continue
-        global previously_printed_errors
-        if self.name in previously_printed_errors:
+        if self.name in NvmlCall.previously_printed_errors:
             return True
-        previously_printed_errors.add(self.name)
+        NvmlCall.previously_printed_errors.add(self.name)
         self.log.warning("Unable to execute NVML function: %s: %s", self.name, exception_value)
         return True
 

--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -51,7 +51,7 @@ class NvmlCall(object):
         # Do nothing if the exception is not from pynvml or there is no exception
         if traceback is None:
             return False
-        if not issubclass(exception_type, pynvml.NVMLError):
+        if not isinstance(exception_type, pynvml.NVMLError):
             return False
 
         # Suppress pynvml exceptions so we can continue


### PR DESCRIPTION
### What does this PR do?

It should catch NVMLError exceptions correctly.
Because the current code only performs an equality check, any subclass of NVMLError will never match, so the code will always return False.

### Motivation

As reported in #612, the check fails with an exception on older hardware.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
