### PR TITLE
[pihole] update constructor for pihole check

### DIFF
--- a/pihole/datadog_checks/pihole/pihole.py
+++ b/pihole/datadog_checks/pihole/pihole.py
@@ -2,7 +2,7 @@ from datadog_checks.base import AgentCheck, ConfigurationError
 
 
 class PiholeCheck(AgentCheck):
-    def __init__(self, name, init_config, instances=None):
+    def __init__(self, name, init_config, instances):
         super(PiholeCheck, self).__init__(name, init_config, instances)
         host = self.instance.get('host')
         if not host:  # Check if a host parameter exsists in conf.yaml

--- a/pihole/datadog_checks/pihole/pihole.py
+++ b/pihole/datadog_checks/pihole/pihole.py
@@ -2,8 +2,8 @@ from datadog_checks.base import AgentCheck, ConfigurationError
 
 
 class PiholeCheck(AgentCheck):
-    def __init__(self, name, init_config, instance):
-        super(PiholeCheck, self).__init__(name, init_config, instance)
+    def __init__(self, name, init_config, instances=None):
+        super(PiholeCheck, self).__init__(name, init_config, instances)
         host = self.instance.get('host')
         if not host:  # Check if a host parameter exsists in conf.yaml
             raise ConfigurationError('Error, please fix pihole.d/conf.yaml, host parameter is required')


### PR DESCRIPTION
### What does this PR do?

Fixes pi hole check. Previously returned:

could not invoke 'pihole' python check constructor. New constructor API returned:
__init__() got an unexpected keyword argument 'instances'Deprecated constructor API returned:
__init__() got an unexpected keyword argument 'instances'


### Motivation

Want to monitor my pihole