### PR TITLE
[pihole] RE #626 - Fix pihole constructor

### DIFF
--- a/pihole/datadog_checks/pihole/pihole.py
+++ b/pihole/datadog_checks/pihole/pihole.py
@@ -2,8 +2,8 @@ from datadog_checks.base import AgentCheck, ConfigurationError
 
 
 class PiholeCheck(AgentCheck):
-    def __init__(self, name, init_config, instance):
-        super(PiholeCheck, self).__init__(name, init_config, instance)
+    def __init__(self, name, init_config, instances):
+        super(PiholeCheck, self).__init__(name, init_config, instances)
         host = self.instance.get('host')
         if not host:  # Check if a host parameter exsists in conf.yaml
             raise ConfigurationError('Error, please fix pihole.d/conf.yaml, host parameter is required')


### PR DESCRIPTION
### What does this PR do?

This pr fixes the pihole constructor issue as highlighted in pr #626 

### Motivation
Pr #626 , check failing to run on the latest Datadog agent

```
  could not invoke 'pihole' python check constructor. New constructor API returned:
__init__() got an unexpected keyword argument 'instances'Deprecated constructor API returned:
__init__() got an unexpected keyword argument 'instances'
```

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?

Check is now working as expected with the latest agent:

```
pihole (3.14.1)
Instance ID: pihole:88c9b78c46d50fb4 [OK]
Total Runs: 1
Metric Samples: 14, Total: 14
Events: 0, Total: 0
Service Checks: 1, Total: 1
Average Execution Time : 94ms
Last Execution Date : 2020-06-22 19:38:29.000000 IST
Last Successful Execution Date : 2020-06-22 19:38:29.000000 IST

```
