### PR TITLE
Readme setup typo fix

### DIFF
--- a/nomad/README.md
+++ b/nomad/README.md
@@ -18,7 +18,7 @@ Nomad emits metrics to Datadog via DogStatsD. To enable the Nomad integration, [
 Once the Datadog Agent is installed, add a Telemetry stanza to the Nomad configuration for your clients and servers:
 
 ```conf
-telemetry {shell
+telemetry {
   publish_allocation_metrics = true
   publish_node_metrics       = true
   datadog_address = "localhost:8125"


### PR DESCRIPTION
### What does this PR do?

A quick fix to the readme set up to fix a typo. Specifically the "shell" in the code block for the nomad telemetry setup.

### Motivation

Just to correct the incorrect setup sample

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

N/A
