### PR TITLE
Set integration public

### DIFF
--- a/federatorai/manifest.json
+++ b/federatorai/manifest.json
@@ -18,7 +18,7 @@
     "orchestration"
   ],
   "type": "check",
-  "is_public": false,
+  "is_public": true,
   "integration_id": "federatorai",
   "assets": {
     "dashboards": {


### PR DESCRIPTION
### What does this PR do?

Set `federatorai` integration to public to enable the doc generation.

### Motivation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
