### PR TITLE
Use the post-signature commit for building wheels

### DIFF
--- a/.gitlab/release/build-packages.sh
+++ b/.gitlab/release/build-packages.sh
@@ -2,8 +2,9 @@
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euxo pipefail
 IFS=$'\n\t'
+CURRENT_COMMIT=$(git rev-parse HEAD)
 curl --request POST --form "token=$CI_JOB_TOKEN" --form ref=master \
-    --form variables[ORIG_CI_BUILD_REF]=$CI_BUILD_REF \
+    --form variables[ORIG_CI_BUILD_REF]=$CURRENT_COMMIT \
     --form variables[ORIG_CI_BUILD_REF_NAME]=$CI_BUILD_REF_NAME \
     --form variables[ROOT_LAYOUT_TYPE]=extras \
     --form variables[REPO_NAME]=integrations-extras \


### PR DESCRIPTION
The integrations-extras pipeline currently works the following way:

- A new commit to master is pushed that updates the version of an integration. Let's call that commit A.
- The CI runs on commit A and automatically detects the version change, adds a "signature" commit B (see https://github.com/DataDog/integrations-extras/blob/master/.in-toto/tag.f284fd5f.link) then create any relevant tag on that commit B.
- Then the CI triggers a build and release based on commit A

This is a mistake, commit A does not contain the signatures, thus the building/releasing pipeline does not know what to build or how to build it. We should instead trigger the build/release pipeline on commit B.

That's what this PR is doing.