### PR TITLE
Create signal sciences forceful browsing monitor

### DIFF
--- a/sigsci/monitors/excessiveforcefulbrowsing.json
+++ b/sigsci/monitors/excessiveforcefulbrowsing.json
@@ -1,0 +1,29 @@
+{
+	"id": 20414519,
+	"name": "SigSci - excessive forceful browsing attempts",
+	"type": "query alert",
+	"query": "avg(last_4h):anomalies(sum:sigsci.agent.signal{signal_type:forcefulbrowsing}.as_count(), 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+	"message": "Signal Sciences Web Application Firewall has been detecting an unusually high number of forceful browsing requests. This may be indicative of a concerted effort to enumerate and exfiltrate sensitive data from your web properties or API endpoints. Details are available in your Signal Sciences console at https://dashboard.signalsciences.net/.",
+	"tags": [],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"silenced": {},
+		"include_tags": true,
+		"no_data_timeframe": null,
+		"require_full_window": true,
+		"new_host_delay": 300,
+		"notify_no_data": false,
+		"renotify_interval": 0,
+		"escalation_message": "",
+		"threshold_windows": {
+			"recovery_window": "last_15m",
+			"trigger_window": "last_15m"
+		},
+		"thresholds": {
+			"critical": 1,
+			"critical_recovery": 0
+		}
+	}
+}

--- a/sigsci/monitors/excessiveforcefulbrowsing.json
+++ b/sigsci/monitors/excessiveforcefulbrowsing.json
@@ -25,5 +25,8 @@
 			"critical": 1,
 			"critical_recovery": 0
 		}
+	},
+	"recommended_monitor_metadata": {
+		"description": "Notify your team when Signal Sciences Web Application Firewall has been detecting an unusually high number of forceful browsing requests."
 	}
 }


### PR DESCRIPTION
forceful browsing monitor

### What does this PR do?
add a signal sciences monitor for forceful browsing, a type of malicious behavior


### Motivation

provide signal sciences customers with more visibility via datadog

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
