### PR TITLE
Change nomad default monitor tag to "integration"

### DIFF
--- a/nomad/assets/monitors/nomad_excessive_leadership_losses.json
+++ b/nomad/assets/monitors/nomad_excessive_leadership_losses.json
@@ -5,7 +5,7 @@
 	"query": "sum(last_1m):sum:nomad.nomad.leader.establish_leadership.count{*}.as_count() >= 3",
 	"message": "Nomad has excessive leadership losses.\n** This monitor relies on a sparse metric which can be hard to resolve, it will therefore automatically expire after 1 hour **\nDocumentation: [Nomad Runbook](https://hashicorp.atlassian.net/wiki/spaces/CLOUD/pages/690028745/Nomad+experiencing+excessive+leader+elections)",
 	"tags": [
-        "service:nomad"
+        "integration:nomad"
     ],
 	"options": {
 		"notify_audit": false,

--- a/nomad/assets/monitors/nomad_heartbeats_received.json
+++ b/nomad/assets/monitors/nomad_heartbeats_received.json
@@ -5,7 +5,7 @@
 	"query": "max(last_5m):max:nomad.nomad.heartbeat.active{*} < 5",
 	"message": "nomad-client is only reporting {{value}} client heartbeats active\n\nDocumentation: [Nomad client count below configured level](https://hashicorp.atlassian.net/wiki/spaces/CLOUD/pages/612466710/Nomad+server+count+below+configured+level)\n\nNotify:",
 	"tags": [
-		"service:nomad"
+		"integration:nomad"
 	],
 	"options": {
 		"notify_audit": false,

--- a/nomad/assets/monitors/nomad_job_is_failing.json
+++ b/nomad/assets/monitors/nomad_job_is_failing.json
@@ -5,7 +5,7 @@
 	"query": "avg(last_5m):diff(max:nomad.nomad.job_summary.failed{*} by {job,task_group}) > 3",
 	"message": "{{#is_alert}}\nObserved at least 3 failures of job: {{job.name}} task: {{task_group.name}} in the last 5 minutes.\n\nThis is an indicator of the following scenarios:\n\n- A misconfiguration in the job\n- The job is not starting successfully\n\nNotify:\n{{/is_alert}}\n\n{{#is_warning}}\nObserved 1 failures of job: {{job.name}} task: {{task_group.name}} in the last 5 minutes.\nNotify:\n{{/is_warning}}\n\n{{#is_alert_recovery}}\nFailure of job: {{job.name}} task: {{task_group.name}} has recovered from previous failures.\nNotify:\n{{/is_alert_recovery}}\n\n{{#is_warning_recovery}}\nFailure of job: {{job.name}} task: {{task_group.name}} has recovered from previous failures.\nNotify:\n{{/is_warning_recovery}}",
 	"tags": [
-		"service:nomad"
+		"integration:nomad"
 	],
 	"options": {
 		"notify_audit": false,

--- a/nomad/assets/monitors/nomad_no_jobs_running.json
+++ b/nomad/assets/monitors/nomad_no_jobs_running.json
@@ -5,7 +5,7 @@
 	"query": "max(last_15m):max:nomad.nomad.job_status.running{*} < 1",
 	"message": "There are no Nomad jobs running.",
 	"tags": [
-		"service:nomad"
+		"integration:nomad"
 	],
 	"options": {
 		"notify_audit": false,

--- a/nomad/assets/monitors/nomad_pending_jobs.json
+++ b/nomad/assets/monitors/nomad_pending_jobs.json
@@ -5,7 +5,7 @@
 	"query": "min(last_15m):max:nomad.nomad.job_status.pending{*} >= 1",
 	"message": "Observed jobs in pending status for > 15 minutes.\n\nThis can be caused by one (or more) of the following scenarios:\n\n- Nomad can't find resources to schedule a job\n- A job is repeatedly exiting and being scheduled again\n- Many jobs are being scheduled normally, but in a short period",
 	"tags": [
-		"service:nomad"
+		"integration:nomad"
 	],
 	"options": {
 		"notify_audit": false,


### PR DESCRIPTION
### What does this PR do?

Changes the default tag for Nomad monitors from "service" to "integration".
