### PR TITLE
Remove id from monitors

### DIFF
--- a/nomad/assets/monitors/nomad_excessive_leadership_losses.json
+++ b/nomad/assets/monitors/nomad_excessive_leadership_losses.json
@@ -1,5 +1,4 @@
 {
-	"id": 20567890,
 	"name": "[Nomad] Excessive Leadership Losses",
 	"type": "query alert",
 	"query": "sum(last_1m):sum:nomad.nomad.leader.establish_leadership.count{*}.as_count() >= 3",

--- a/nomad/assets/monitors/nomad_heartbeats_received.json
+++ b/nomad/assets/monitors/nomad_heartbeats_received.json
@@ -1,5 +1,4 @@
 {
-	"id": 20568506,
 	"name": "[Nomad] Less Than 5 Nomad Client Heartbeats Received",
 	"type": "metric alert",
 	"query": "max(last_5m):max:nomad.nomad.heartbeat.active{*} < 5",

--- a/nomad/assets/monitors/nomad_job_is_failing.json
+++ b/nomad/assets/monitors/nomad_job_is_failing.json
@@ -1,5 +1,4 @@
 {
-	"id": 20568597,
 	"name": "[Nomad] Job Is Failing",
 	"type": "query alert",
 	"query": "avg(last_5m):diff(max:nomad.nomad.job_summary.failed{*} by {job,task_group}) > 3",

--- a/nomad/assets/monitors/nomad_no_jobs_running.json
+++ b/nomad/assets/monitors/nomad_no_jobs_running.json
@@ -1,5 +1,4 @@
 {
-	"id": 20568667,
 	"name": "[Nomad] No Jobs Running",
 	"type": "query alert",
 	"query": "max(last_15m):max:nomad.nomad.job_status.running{*} < 1",

--- a/nomad/assets/monitors/nomad_pending_jobs.json
+++ b/nomad/assets/monitors/nomad_pending_jobs.json
@@ -1,5 +1,4 @@
 {
-	"id": 20568795,
 	"name": "[Nomad] Pending Jobs >= 1 for 15 minutes",
 	"type": "query alert",
 	"query": "min(last_15m):max:nomad.nomad.job_status.pending{*} >= 1",

--- a/sigsci/assets/monitors/excessiveblockedHTTP.json
+++ b/sigsci/assets/monitors/excessiveblockedHTTP.json
@@ -3,7 +3,9 @@
 	"type": "query alert",
 	"query": "avg(last_4h):anomalies(sum:sigsci.agent.waf.block{*}.as_count(), 'agile', 2, direction='above', alert_window='last_5m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
 	"message": "Signal Sciences Web Application Firewall has been blocking an unusually high number of web requests. This may be indicative of a volumetric attack against one or more of your web properties or API endpoints. Details are available in your Signal Sciences console at https://dashboard.signalsciences.net/.",
-	"tags": [],
+	"tags": [
+		"integration:sigsci"
+	],
 	"options": {
 		"notify_audit": false,
 		"locked": false,

--- a/sigsci/assets/monitors/excessiveblockedHTTP.json
+++ b/sigsci/assets/monitors/excessiveblockedHTTP.json
@@ -3,9 +3,7 @@
 	"type": "query alert",
 	"query": "avg(last_4h):anomalies(sum:sigsci.agent.waf.block{*}.as_count(), 'agile', 2, direction='above', alert_window='last_5m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
 	"message": "Signal Sciences Web Application Firewall has been blocking an unusually high number of web requests. This may be indicative of a volumetric attack against one or more of your web properties or API endpoints. Details are available in your Signal Sciences console at https://dashboard.signalsciences.net/.",
-	"tags": [
-		"integration:sigsci"
-	],
+	"tags": [],
 	"options": {
 		"notify_audit": false,
 		"locked": false,

--- a/sigsci/assets/monitors/excessiveblockedHTTP.json
+++ b/sigsci/assets/monitors/excessiveblockedHTTP.json
@@ -1,5 +1,4 @@
 {
-	"id": 20344850,
 	"name": "SigSci - excessive blocked http requests",
 	"type": "query alert",
 	"query": "avg(last_4h):anomalies(sum:sigsci.agent.waf.block{*}.as_count(), 'agile', 2, direction='above', alert_window='last_5m', interval=60, count_default_zero='true', seasonality='daily') >= 1",

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -22,9 +22,7 @@
     "security"
   ],
   "assets": {
-    "monitors": {
-      "SigSci Excessive Blocked Http Requests" : "assets/monitors/excessiveblockedHTTP.json"
-    },
+    "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json"
   }

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -22,7 +22,9 @@
     "security"
   ],
   "assets": {
-    "monitors": {},
+    "monitors": {
+      "SigSci Excessive Blocked Http Requests" : "assets/monitors/excessiveblockedHTTP.json"
+    },
     "dashboards": {},
     "service_checks": "assets/service_checks.json"
   }


### PR DESCRIPTION
Since https://github.com/DataDog/integrations-core/pull/7341

Recommended monitors should not contain `id`.