### PR TITLE
Migrate integration dashboards to new payload format

### DIFF
--- a/contrastsecurity/assets/dashboards/contrast_security_protect.json
+++ b/contrastsecurity/assets/dashboards/contrast_security_protect.json
@@ -1,305 +1,290 @@
 {
-  "board_title":"Contrast Security - Protect",
-  "read_only":false,
-  "description":null,
-  "created":"2019-11-07T16:17:55.348192+00:00",
-  "new_id":"8g4-chd-xe8",
-  "modified":"2019-11-07T16:17:55.348200+00:00",
-  "created_by":{
-    "disabled":false,
-    "handle":"support@contrastsecurity.com",
-    "name":"Contrast Security",
-    "is_admin":true,
-    "role":null,
-    "access_role":"adm",
-    "verified":true,
-    "email":"support@contrastsecurity.com",
-    "icon":"https://secure.gravatar.com/avatar/d73205b1733e96eb14269e55be9f35e6?s=48&d=retro"
+  "title": "Contrast Security - Protect",
+  "description": "",
+  "author_info": {
+    "name":"Contrast Security"
   },
-  "template_variables":null,
-  "widgets":[
+  "widgets": [
     {
-      "logset":"17533",
-      "title_size":"16",
-      "title":true,
-      "title_align":"left",
-      "title_text":"Attack logs",
-      "height":47,
-      "width":91,
-      "query":"source:contrastsecurity",
-      "time":{
-        "live_span":"1w"
+      "id": 0,
+      "definition": {
+        "type": "log_stream",
+        "query": "source:contrastsecurity",
+        "sort": {
+          "column": "time",
+          "order": "desc"
+        },
+        "columns": [
+          "core_host",
+          "core_service",
+          "log_network.source.ip",
+          "log_evt.action",
+          "log_evt.outcome"
+        ],
+        "show_date_column": true,
+        "show_message_column": true,
+        "message_display": "expanded-md",
+        "title": "Attack logs",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {
+          "live_span": "1w"
+        }
       },
-      "y":18,
-      "x":46,
-      "type":"log_stream",
-      "id":3270922425130730,
-      "columns":"[\"core_host\", \"core_service\", \"log_network.source.ip\", \"log_evt.action\", \"log_evt.outcome\"]"
+      "layout": {
+        "x": 46,
+        "y": 18,
+        "width": 91,
+        "height": 47
+      }
     },
     {
-      "title_size":"16",
-      "title":true,
-      "title_align":"left",
-      "title_text":"Attacks by Rule",
-      "height":13,
-      "tile_def":{
-        "viz":"toplist",
-        "requests":[
+      "id": 1,
+      "definition": {
+        "type": "toplist",
+        "requests": [
           {
-            "conditional_formats":[
-
-            ],
-            "style":{
-              "palette":"dog_classic"
-            },
-            "log_query":{
+            "log_query": {
               "index": "*",
-              "search":{
-                "query":"source:contrastsecurity"
+              "compute": {
+                "aggregation": "count"
               },
-              "compute":{
-                "aggregation":"count"
+              "search": {
+                "query": "source:contrastsecurity"
               },
-              "groupBy":[
+              "group_by": [
                 {
-                  "facet":"@evt.action",
-                  "limit":10
+                  "facet": "@evt.action",
+                  "limit": 10
                 }
               ]
+            },
+            "style": {
+              "palette": "dog_classic"
             }
           }
-        ]
+        ],
+        "custom_links": [],
+        "title": "Attacks by Rule",
+        "title_size": "16",
+        "title_align": "left"
       },
-      "width":45,
-      "time":{
-        "live_span":"15d"
-      },
-      "y":2,
-      "x":46,
-      "type":"toplist",
-      "id":3614430225474568
+      "layout": {
+        "x": 46,
+        "y": 2,
+        "width": 45,
+        "height": 15
+      }
     },
     {
-      "title_size":"16",
-      "title":true,
-      "title_align":"left",
-      "title_text":"Attacks by Application",
-      "height":13,
-      "tile_def":{
-        "viz":"toplist",
-        "requests":[
+      "id": 2,
+      "definition": {
+        "type": "toplist",
+        "requests": [
           {
-            "conditional_formats":[
-
-            ],
-            "style":{
-              "palette":"dog_classic"
-            },
-            "log_query":{
+            "log_query": {
               "index": "*",
-              "search":{
-                "query":"source:contrastsecurity"
+              "compute": {
+                "aggregation": "count"
               },
-              "compute":{
-                "aggregation":"count"
+              "search": {
+                "query": "source:contrastsecurity"
               },
-              "groupBy":[
+              "group_by": [
                 {
-                  "facet":"service",
-                  "limit":10
+                  "facet": "service",
+                  "limit": 10
                 }
               ]
+            },
+            "style": {
+              "palette": "dog_classic"
             }
           }
-        ]
+        ],
+        "custom_links": [],
+        "title": "Attacks by Application",
+        "title_size": "16",
+        "title_align": "left"
       },
-      "width":45,
-      "time":{
-        "live_span":"15d"
-      },
-      "y":2,
-      "x":92,
-      "type":"toplist",
-      "id":8176736338122666
+      "layout": {
+        "x": 92,
+        "y": 2,
+        "width": 45,
+        "height": 15
+      }
     },
     {
-      "title_size":"16",
-      "title":true,
-      "title_align":"left",
-      "title_text":"Attacks by Result",
-      "height":13,
-      "tile_def":{
-        "viz":"toplist",
-        "requests":[
+      "id": 3,
+      "definition": {
+        "type": "toplist",
+        "requests": [
           {
-            "conditional_formats":[
-
-            ],
-            "style":{
-              "palette":"dog_classic"
-            },
-            "log_query":{
+            "log_query": {
               "index": "*",
-              "search":{
-                "query":"source:contrastsecurity"
+              "compute": {
+                "aggregation": "count"
               },
-              "compute":{
-                "aggregation":"count"
+              "search": {
+                "query": "source:contrastsecurity"
               },
-              "groupBy":[
+              "group_by": [
                 {
-                  "facet":"@evt.outcome",
-                  "limit":10
+                  "facet": "@evt.outcome",
+                  "limit": 10
                 }
               ]
+            },
+            "style": {
+              "palette": "dog_classic"
             }
           }
-        ]
+        ],
+        "custom_links": [],
+        "title": "Attacks by Result",
+        "title_size": "16",
+        "title_align": "left"
       },
-      "width":45,
-      "time":{
-        "live_span":"15d"
-      },
-      "y":2,
-      "x":0,
-      "type":"toplist",
-      "id":2912918488546613
+      "layout": {
+        "x": 0,
+        "y": 2,
+        "width": 45,
+        "height": 15
+      }
     },
     {
-      "title_size":"16",
-      "title":true,
-      "title_align":"left",
-      "title_text":"Rules",
-      "height":13,
-      "tile_def":{
-        "viz":"timeseries",
-        "requests":[
+      "id": 4,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
           {
-            "style":{
-              "width":"normal",
-              "palette":"dog_classic",
-              "type":"solid"
-            },
-            "type":"bars",
-            "log_query":{
+            "log_query": {
               "index": "*",
-              "search":{
-                "query":"source:contrastsecurity"
+              "compute": {
+                "aggregation": "count"
               },
-              "compute":{
-                "aggregation":"count"
+              "search": {
+                "query": "source:contrastsecurity"
               },
-              "groupBy":[
+              "group_by": [
                 {
-                  "facet":"@evt.action",
-                  "limit":10
+                  "facet": "@evt.action",
+                  "limit": 10
                 }
               ]
+            },
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
             }
           }
-        ]
+        ],
+        "custom_links": [],
+        "title": "Rules",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width":45,
-      "legend":false,
-      "time":{
-        "live_span":"15d"
-      },
-      "y":18,
-      "x":0,
-      "legend_size":"0",
-      "type":"timeseries",
-      "id":2727566696392112
+      "layout": {
+        "x": 0,
+        "y": 18,
+        "width": 45,
+        "height": 15
+      }
     },
     {
-      "title_size":"16",
-      "title":true,
-      "title_align":"left",
-      "title_text":"Applications",
-      "height":13,
-      "tile_def":{
-        "viz":"timeseries",
-        "requests":[
+      "id": 5,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
           {
-            "style":{
-              "width":"normal",
-              "palette":"dog_classic",
-              "type":"solid"
-            },
-            "type":"bars",
-            "log_query":{
+            "log_query": {
               "index": "*",
-              "search":{
-                "query":"source:contrastsecurity"
+              "compute": {
+                "aggregation": "count"
               },
-              "compute":{
-                "aggregation":"count"
+              "search": {
+                "query": "source:contrastsecurity"
               },
-              "groupBy":[
+              "group_by": [
                 {
-                  "facet":"service",
-                  "limit":10
+                  "facet": "service",
+                  "limit": 10
                 }
               ]
+            },
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
             }
           }
-        ]
+        ],
+        "custom_links": [],
+        "title": "Applications",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width":45,
-      "legend":false,
-      "time":{
-        "live_span":"15d"
-      },
-      "y":34,
-      "x":0,
-      "legend_size":"0",
-      "type":"timeseries",
-      "id":6264513347703014
+      "layout": {
+        "x": 0,
+        "y": 34,
+        "width": 45,
+        "height": 15
+      }
     },
     {
-      "title_size":"16",
-      "title":true,
-      "title_align":"left",
-      "title_text":"Results",
-      "height":13,
-      "tile_def":{
-        "viz":"timeseries",
-        "requests":[
+      "id": 6,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
           {
-            "style":{
-              "width":"normal",
-              "palette":"dog_classic",
-              "type":"solid"
-            },
-            "type":"bars",
-            "log_query":{
+            "log_query": {
               "index": "*",
-              "search":{
-                "query":"source:contrastsecurity"
+              "compute": {
+                "aggregation": "count"
               },
-              "compute":{
-                "aggregation":"count"
+              "search": {
+                "query": "source:contrastsecurity"
               },
-              "groupBy":[
+              "group_by": [
                 {
-                  "facet":"@evt.outcome",
-                  "limit":10
+                  "facet": "@evt.outcome",
+                  "limit": 10
                 }
               ]
+            },
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
             }
           }
-        ]
+        ],
+        "custom_links": [],
+        "title": "Results",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width":45,
-      "legend":false,
-      "time":{
-        "live_span":"15d"
-      },
-      "y":50,
-      "x":0,
-      "legend_size":"0",
-      "type":"timeseries",
-      "id":1384435236113198
+      "layout": {
+        "x": 0,
+        "y": 50,
+        "width": 45,
+        "height": 15
+      }
     }
   ],
-  "id":887621
+  "template_variables": [],
+  "layout_type": "free",
+  "is_read_only": true,
+  "notify_list": [],
+  "id": 30296
 }

--- a/cyral/assets/dashboards/cyral_overview.json
+++ b/cyral/assets/dashboards/cyral_overview.json
@@ -1,265 +1,295 @@
 {
+    "title": "Cyral",
+    "description": "",
     "author_info": {
         "author_name": "Cyral"
     },
-    "board_title": "Cyral",
-    "description": "",
-    "template_variables": [],
     "widgets": [
-        {
-            "height": 12,
-            "sizing": "fit",
-            "type": "image",
-            "url": "https://s34378.pcdn.co/wp-content/themes/cyral20/assets/img/logo.svg?t=1592861649",
-            "width": 24,
-            "x": 0,
-            "y": 0
+      {
+        "id": 0,
+        "definition": {
+          "type": "image",
+          "url": "https://s34378.pcdn.co/wp-content/themes/cyral20/assets/img/logo.svg?t=1592861649",
+          "sizing": "fit"
         },
-        {
-            "height": 13,
-            "legend": true,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:cyral.cyral_wire_parse_duration{*}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Wire Parse Duration",
-            "type": "timeseries",
-            "width": 30,
-            "x": 25,
-            "y": 8
-        },
-        {
-            "height": 13,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:cyral.cyral_policy_eval_time{*}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Policy Evaluation Time",
-            "type": "timeseries",
-            "width": 30,
-            "x": 25,
-            "y": 23
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:cyral.cyral_query_duration_sum{*}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Query Duration Sum",
-            "type": "timeseries",
-            "width": 30,
-            "x": 25,
-            "y": 38
-        },
-        {
-            "bgcolor": "white",
-            "font_size": "24",
-            "height": 7,
-            "html": "Durations",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "left",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 30,
-            "x": 25,
-            "y": 0
-        },
-        {
-            "height": 13,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:cyral.cyral_policy_violation_count{*}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Policy Violations Count",
-            "type": "timeseries",
-            "width": 30,
-            "x": 56,
-            "y": 8
-        },
-        {
-            "height": 13,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:cyral.cyral_high_latency_query_count{*}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "High Latency Query Count",
-            "type": "timeseries",
-            "width": 30,
-            "x": 56,
-            "y": 23
-        },
-        {
-            "height": 13,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:cyral.cyral_row_count{*}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Row Count",
-            "type": "timeseries",
-            "width": 30,
-            "x": 56,
-            "y": 38
-        },
-        {
-            "bgcolor": "white",
-            "font_size": "24",
-            "height": 7,
-            "html": "Security",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "left",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 30,
-            "x": 56,
-            "y": 0
+        "layout": {
+          "x": 0,
+          "y": 0,
+          "width": 24,
+          "height": 12
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:cyral.cyral_wire_parse_duration{*}.as_count()",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Wire Parse Duration",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": true
+        },
+        "layout": {
+          "x": 25,
+          "y": 8,
+          "width": 30,
+          "height": 15
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:cyral.cyral_policy_eval_time{*}.as_count()",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Policy Evaluation Time",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": true,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 25,
+          "y": 23,
+          "width": 30,
+          "height": 15
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:cyral.cyral_query_duration_sum{*}.as_count()",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Query Duration Sum",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 25,
+          "y": 38,
+          "width": 30,
+          "height": 15
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "note",
+          "content": "Durations",
+          "background_color": "white",
+          "font_size": "24",
+          "text_align": "center",
+          "show_tick": false,
+          "tick_pos": "50%",
+          "tick_edge": "left"
+        },
+        "layout": {
+          "x": 25,
+          "y": 0,
+          "width": 30,
+          "height": 7
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:cyral.cyral_policy_violation_count{*}.as_count()",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Policy Violations Count",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": true,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 56,
+          "y": 8,
+          "width": 30,
+          "height": 15
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:cyral.cyral_high_latency_query_count{*}.as_count()",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "High Latency Query Count",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": true,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 56,
+          "y": 23,
+          "width": 30,
+          "height": 15
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:cyral.cyral_row_count{*}.as_count()",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Row Count",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": true,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 56,
+          "y": 38,
+          "width": 30,
+          "height": 15
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "note",
+          "content": "Security",
+          "background_color": "white",
+          "font_size": "24",
+          "text_align": "center",
+          "show_tick": false,
+          "tick_pos": "50%",
+          "tick_edge": "left"
+        },
+        "layout": {
+          "x": 56,
+          "y": 0,
+          "width": 30,
+          "height": 7
+        }
+      }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30346
+  }

--- a/federatorai/assets/dashboards/overview.json
+++ b/federatorai/assets/dashboards/overview.json
@@ -1,289 +1,310 @@
 {
+    "title": "ProphetStor Federator.ai Kafka Overview",
+    "description": "[ProphetStor Federator.ai][1] is an AI-based solution that helps enterprise manage, optimize, auto-scale resources for any applications on Kubernetes. Using advanced machine learning algorithms to predict application workload, Federator.ai scales the right amount of resources at the right time for optimized application performance.\n\n* AI-based workload prediction for Kafka or any applications\n* Resource recommendation based on workload prediction, application, Kubernetes and other related metrics\n* Automatic scaling of application containers through [Datadog Watermark Pod Autoscaler (WPA)][4]\n\n[1]: https://www.prophetstor.com/federator-ai-for-aiops/federator-ai-datadog-integration/\n[4]: https://github.com/DataDog/watermarkpodautoscaler\n\n[Federator.ai/version:v4.2.790]",
     "author_info": {
         "author_name": "Datadog"
     },
-    "board_title": "ProphetStor Federator.ai Kafka Overview",
-    "description": "[ProphetStor Federator.ai][1] is an AI-based solution that helps enterprise manage, optimize, auto-scale resources for any applications on Kubernetes. Using advanced machine learning algorithms to predict application workload, Federator.ai scales the right amount of resources at the right time for optimized application performance.\n\n* AI-based workload prediction for Kafka or any applications\n* Resource recommendation based on workload prediction, application, Kubernetes and other related metrics\n* Automatic scaling of application containers through [Datadog Watermark Pod Autoscaler (WPA)][4]\n\n[1]: https://www.prophetstor.com/federator-ai-for-aiops/federator-ai-datadog-integration/\n[4]: https://github.com/DataDog/watermarkpodautoscaler\n\n[Federator.ai/version:v4.2.790]",
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "kube_cluster",
-            "prefix": "kube_cluster"
-        },
-        {
-            "default": "*",
-            "name": "kube_namespace",
-            "prefix": "kube_namespace"
-        },
-        {
-            "default": "*",
-            "name": "kube_deployment",
-            "prefix": "kube_deployment"
-        },
-        {
-            "default": "*",
-            "name": "topic",
-            "prefix": "topic"
-        },
-        {
-            "default": "*",
-            "name": "consumer_group",
-            "prefix": "consumer_group"
-        }
-    ],
     "widgets": [
-        {
-            "height": 13,
-            "margin": "small",
-            "sizing": "fit",
-            "type": "image",
-            "url": "https://raw.githubusercontent.com/DataDog/integrations-extras/master/federatorai/images/prophetstor_logos-bot-for-dashboard.png",
-            "width": 29,
-            "x": 0,
-            "y": 1
+      {
+        "id": 0,
+        "definition": {
+          "type": "image",
+          "url": "https://raw.githubusercontent.com/DataDog/integrations-extras/master/federatorai/images/prophetstor_logos-bot-for-dashboard.png",
+          "sizing": "fit",
+          "margin": "small"
         },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:federatorai.recommendation{$kube_cluster,$kube_namespace,$kube_deployment}",
-                        "style": {
-                            "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:kubernetes_state.deployment.replicas_available{$kube_cluster,$kube_namespace,$kube_deployment}",
-                        "style": {
-                            "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:kubernetes_state.deployment.replicas_desired{$kube_cluster,$kube_namespace,$kube_deployment}",
-                        "style": {
-                            "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Recommended Replicas vs Current/Desired Replicas",
-            "type": "timeseries",
-            "width": 47,
-            "x": 0,
-            "y": 15
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:federatorai.kafka.broker_offset_rate{$kube_cluster,$topic}, avg:federatorai.kafka.consumer_offset_rate{$kube_cluster,$topic,$consumer_group}, avg:federatorai.prediction.kafka{source_metric:federatorai.kafka.broker_offset_rate,$kube_cluster,$topic}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Production vs Consumption vs Production Prediction",
-            "type": "timeseries",
-            "width": 47,
-            "x": 48,
-            "y": 15
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "metadata": {
-                            "sum:kafka.consumer_lag{$kube_cluster,$consumer_group,$topic}/count_not_null(sum:kafka.consumer_lag{$kube_cluster,$consumer_group,$topic} by {host})": {
-                                "alias": "kafka.consumer_lag_sum_by_partition"
-                            }
-                        },
-                        "q": "sum:kafka.consumer_lag{$kube_cluster,$consumer_group,$topic}/count_not_null(sum:kafka.consumer_lag{$kube_cluster,$consumer_group,$topic} by {host})",
-                        "style": {
-                            "palette": "purple",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Kafka Consumer Lag",
-            "type": "timeseries",
-            "width": 47,
-            "x": 0,
-            "y": 31
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "(sum:kafka.consumer_lag{$kube_cluster,$topic,$consumer_group}/count_not_null(sum:kafka.consumer_lag{$kube_cluster,$topic,$consumer_group} by {host})/avg:federatorai.kafka.consumer_offset_rate{$kube_cluster,$topic,$consumer_group})*60*1000",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": false
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Consumer Queue Latency (msec)",
-            "type": "timeseries",
-            "width": 47,
-            "x": 48,
-            "y": 31
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "sum:kubernetes.memory.usage{$kube_cluster,$kube_namespace,$kube_deployment}",
-                        "style": {
-                            "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Deployment Memory Usage",
-            "type": "timeseries",
-            "width": 47,
-            "x": 0,
-            "y": 47
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "sum:kubernetes.cpu.usage.total{$kube_cluster,$kube_namespace,$kube_deployment}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Deployment CPU Usage",
-            "type": "timeseries",
-            "width": 47,
-            "x": 48,
-            "y": 47
-        },
-        {
-            "bgcolor": "green",
-            "font_size": "14",
-            "height": 13,
-            "html": "With integration of [ProphetStor Federator.ai][1], users can easily track the Kafka message production/consumption rate, as well as the prediction of message production rate from Federator.ai dashboard. Based on the prediction or message production rate, Federator.ai automatically scales Kafka consumer replicas to handle the workload. This can be visualized from Federator.ai dashboard where the recommended consumer replicas and the current number of consumer replicas are shown. Additionally, overall consumer lags as well as the average latency in the queue before a message is received by a consumer are also shown on the dashboard for better performance monitoring.\n\n[1]: https://www.prophetstor.com/federator-ai-for-aiops/federator-ai-datadog-integration/",
-            "text_align": "left",
-            "tick": false,
-            "tick_edge": "left",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 64,
-            "x": 31,
-            "y": 1
+        "layout": {
+          "x": 0,
+          "y": 1,
+          "width": 29,
+          "height": 13
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:federatorai.recommendation{$kube_cluster,$kube_namespace,$kube_deployment}",
+              "display_type": "line",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:kubernetes_state.deployment.replicas_available{$kube_cluster,$kube_namespace,$kube_deployment}",
+              "display_type": "line",
+              "style": {
+                "palette": "cool",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:kubernetes_state.deployment.replicas_desired{$kube_cluster,$kube_namespace,$kube_deployment}",
+              "display_type": "line",
+              "style": {
+                "palette": "cool",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Recommended Replicas vs Current/Desired Replicas",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 0,
+          "y": 15,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:federatorai.kafka.broker_offset_rate{$kube_cluster,$topic}, avg:federatorai.kafka.consumer_offset_rate{$kube_cluster,$topic,$consumer_group}, avg:federatorai.prediction.kafka{source_metric:federatorai.kafka.broker_offset_rate,$kube_cluster,$topic}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Production vs Consumption vs Production Prediction",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 48,
+          "y": 15,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:kafka.consumer_lag{$kube_cluster,$consumer_group,$topic}/count_not_null(sum:kafka.consumer_lag{$kube_cluster,$consumer_group,$topic} by {host})",
+              "metadata": [
+                {
+                  "expression": "sum:kafka.consumer_lag{$kube_cluster,$consumer_group,$topic}/count_not_null(sum:kafka.consumer_lag{$kube_cluster,$consumer_group,$topic} by {host})",
+                  "alias_name": "kafka.consumer_lag_sum_by_partition"
+                }
+              ],
+              "display_type": "bars",
+              "style": {
+                "palette": "purple",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Kafka Consumer Lag",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 0,
+          "y": 31,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "(sum:kafka.consumer_lag{$kube_cluster,$topic,$consumer_group}/count_not_null(sum:kafka.consumer_lag{$kube_cluster,$topic,$consumer_group} by {host})/avg:federatorai.kafka.consumer_offset_rate{$kube_cluster,$topic,$consumer_group})*60*1000",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "include_zero": false
+          },
+          "title": "Consumer Queue Latency (msec)",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 48,
+          "y": 31,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:kubernetes.memory.usage{$kube_cluster,$kube_namespace,$kube_deployment}",
+              "display_type": "area",
+              "style": {
+                "palette": "cool",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Deployment Memory Usage",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 0,
+          "y": 47,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:kubernetes.cpu.usage.total{$kube_cluster,$kube_namespace,$kube_deployment}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Deployment CPU Usage",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 48,
+          "y": 47,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "note",
+          "content": "With integration of [ProphetStor Federator.ai][1], users can easily track the Kafka message production/consumption rate, as well as the prediction of message production rate from Federator.ai dashboard. Based on the prediction or message production rate, Federator.ai automatically scales Kafka consumer replicas to handle the workload. This can be visualized from Federator.ai dashboard where the recommended consumer replicas and the current number of consumer replicas are shown. Additionally, overall consumer lags as well as the average latency in the queue before a message is received by a consumer are also shown on the dashboard for better performance monitoring.\n\n[1]: https://www.prophetstor.com/federator-ai-for-aiops/federator-ai-datadog-integration/",
+          "background_color": "green",
+          "font_size": "14",
+          "text_align": "left",
+          "show_tick": false,
+          "tick_pos": "50%",
+          "tick_edge": "left"
+        },
+        "layout": {
+          "x": 31,
+          "y": 1,
+          "width": 64,
+          "height": 13
+        }
+      }
+    ],
+    "template_variables": [
+      {
+        "name": "kube_cluster",
+        "default": "*",
+        "prefix": "kube_cluster"
+      },
+      {
+        "name": "kube_namespace",
+        "default": "*",
+        "prefix": "kube_namespace"
+      },
+      {
+        "name": "kube_deployment",
+        "default": "*",
+        "prefix": "kube_deployment"
+      },
+      {
+        "name": "topic",
+        "default": "*",
+        "prefix": "topic"
+      },
+      {
+        "name": "consumer_group",
+        "default": "*",
+        "prefix": "consumer_group"
+      }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30332
+  }

--- a/k6/assets/dashboards/overview.json
+++ b/k6/assets/dashboards/overview.json
@@ -1,315 +1,297 @@
 {
-  "board_title": "k6",
-  "read_only": true,
+  "title": "k6",
   "description": "This dashboard allows visualizing some of the performance testing metrics collected by [k6](https://k6.io/). \n\nFor further information about exporting metrics from k6 OSS, read the [Datadog's k6 integration docs](https://k6.io/docs/getting-started/results-output/datadog).\n\nFor more information about the integration with the k6 Cloud, visit [Cloud APM docs](https://k6.io/docs/cloud/integrations/cloud-apm).\n\nClone this template dashboard to make changes and add other graph widgets.",
-  "created": "2020-04-18T18:12:41.589692+00:00",
-  "new_id": "n5h-2xn-956",
-  "id": 22975,
-  "modified": "2020-04-18T19:33:14.567237+00:00",
-  "created_by": {
-    "disabled": false,
-    "handle": "support@loadimpact.com",
-    "name": "k6",
-    "title": null,
-    "is_admin": true,
-    "role": null,
-    "access_role": "adm",
-    "verified": true,
-    "email": "support@loadimpact.com",
-    "icon": "https://secure.gravatar.com/avatar/6580edf56e434f4abafa24fac926002f?s=48&d=retro"
+  "author_info": {
+    "name": "k6"
   },
-  "template_variables": [
-    {
-      "name": "test_run_id",
-      "default": "*",
-      "prefix": "test_run_id"
-    }
-  ],
   "widgets": [
     {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Virtual users",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 0,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "max:k6.vus{$test_run_id}",
+            "display_type": "line",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
         "custom_links": [],
         "yaxis": {
+          "label": "",
           "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Virtual users",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 47,
-      "y": 0,
-      "x": 14,
-      "type": "timeseries",
-      "legend": false
+      "layout": {
+        "x": 14,
+        "y": 0,
+        "width": 47,
+        "height": 15
+      }
     },
     {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Request per second",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 1,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "avg:k6.http_reqs{$test_run_id}.as_rate()",
+            "display_type": "line",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
         "custom_links": [],
         "yaxis": {
+          "label": "",
           "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Request per second",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 47,
-      "y": 17,
-      "x": 14,
-      "type": "timeseries",
-      "legend": false
+      "layout": {
+        "x": 14,
+        "y": 17,
+        "width": 47,
+        "height": 15
+      }
     },
     {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Data sent/received",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 2,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "cumsum(avg:k6.data_sent{$test_run_id})",
+            "metadata": [
+              {
+                "expression": "cumsum(avg:k6.data_sent{$test_run_id})",
+                "alias_name": "data_sent"
+              }
+            ],
+            "display_type": "line",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line",
-            "metadata": {
-              "cumsum(avg:k6.data_sent{$test_run_id})": {
-                "alias": "data_sent"
-              }
+              "line_type": "solid",
+              "line_width": "normal"
             }
           },
           {
             "q": "cumsum(avg:k6.data_received{$test_run_id})",
+            "metadata": [
+              {
+                "expression": "cumsum(avg:k6.data_received{$test_run_id})",
+                "alias_name": "data_received"
+              }
+            ],
+            "display_type": "line",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line",
-            "metadata": {
-              "cumsum(avg:k6.data_received{$test_run_id})": {
-                "alias": "data_received"
-              }
+              "line_type": "solid",
+              "line_width": "normal"
             }
           }
         ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
         "events": [
           {
             "q": "tag:test_run_id:22",
             "tags_execution": "and"
           }
         ],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
+        "title": "Data sent/received",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 47,
-      "time": {},
-      "y": 34,
-      "x": 14,
-      "type": "timeseries",
-      "legend": false
+      "layout": {
+        "x": 14,
+        "y": 34,
+        "width": 47,
+        "height": 15
+      }
     },
     {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "HTTP request duration",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 3,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "max:k6.http_req_duration.95percentile{$test_run_id}",
+            "display_type": "line",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           },
           {
             "q": "max:k6.http_req_duration.max{$test_run_id}",
+            "display_type": "line",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           },
           {
             "q": "max:k6.http_req_duration.avg{$test_run_id}",
+            "display_type": "line",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           },
           {
             "q": "max:k6.http_req_duration.median{$test_run_id}",
+            "display_type": "line",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
         "custom_links": [],
         "yaxis": {
+          "label": "",
           "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "HTTP request duration",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 47,
-      "y": 0,
-      "x": 67,
-      "type": "timeseries",
-      "legend": false
+      "layout": {
+        "x": 67,
+        "y": 0,
+        "width": 47,
+        "height": 15
+      }
     },
     {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Response timings - 95th",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 4,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "max:k6.http_req_blocked.95percentile{$test_run_id}",
+            "display_type": "bars",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           },
           {
             "q": "max:k6.http_req_sending.95percentile{$test_run_id}",
+            "display_type": "bars",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           },
           {
             "q": "max:k6.http_req_waiting.95percentile{$test_run_id}",
+            "display_type": "bars",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           },
           {
             "q": "max:k6.http_req_blocked.95percentile{$test_run_id}",
+            "display_type": "bars",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           },
           {
             "q": "max:k6.http_req_receiving.95percentile{$test_run_id}",
+            "display_type": "bars",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           },
           {
             "q": "max:k6.http_req_connecting.95percentile{$test_run_id}",
+            "display_type": "bars",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           },
           {
             "q": "max:k6.http_req_tls_handshaking.95percentile{$test_run_id}",
+            "display_type": "bars",
             "style": {
               "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
         "custom_links": [],
         "yaxis": {
+          "label": "",
           "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Response timings - 95th",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 47,
-      "y": 17,
-      "x": 67,
-      "type": "timeseries",
-      "legend": false
+      "layout": {
+        "x": 67,
+        "y": 17,
+        "width": 47,
+        "height": 15
+      }
     },
     {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Response time 95th - HeatMap",
-      "height": 13,
-      "tile_def": {
-        "viz": "heatmap",
+      "id": 5,
+      "definition": {
+        "type": "heatmap",
         "requests": [
           {
             "q": "max:k6.http_req_duration.95percentile{$test_run_id}",
@@ -318,22 +300,43 @@
             }
           }
         ],
-        "custom_links": []
+        "custom_links": [],
+        "title": "Response time 95th - HeatMap",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 47,
-      "y": 34,
-      "x": 67,
-      "type": "heatmap",
-      "legend": false
+      "layout": {
+        "x": 67,
+        "y": 34,
+        "width": 47,
+        "height": 15
+      }
     },
     {
-      "sizing": "zoom",
-      "y": 0,
-      "width": 8,
-      "url": "https://i.postimg.cc/J762mtP0/logo-k6.png",
-      "x": 1,
-      "type": "image",
-      "height": 8
+      "id": 6,
+      "definition": {
+        "type": "image",
+        "url": "https://i.postimg.cc/J762mtP0/logo-k6.png",
+        "sizing": "zoom"
+      },
+      "layout": {
+        "x": 1,
+        "y": 0,
+        "width": 8,
+        "height": 8
+      }
     }
-  ]
+  ],
+  "template_variables": [
+    {
+      "name": "test_run_id",
+      "default": "*",
+      "prefix": "test_run_id"
+    }
+  ],
+  "layout_type": "free",
+  "is_read_only": true,
+  "notify_list": [],
+  "id": 30318
 }

--- a/nomad/assets/dashboards/overview.json
+++ b/nomad/assets/dashboards/overview.json
@@ -1,978 +1,1054 @@
 {
+    "title": "Nomad Overview",
+    "description": "This Nomad dashboard provides a quick overview on the performance of your Nomad Host, Data centers and Clients. Included are also some high level views of Raft, Consul and RPC metrics. Further reading on Nomad can be found in the following:\n\n- [What is Nomad](https://www.nomadproject.io/intro)\n- [Datadog Nomad Integration](https://docs.datadoghq.com/integrations/nomad/)\n- [Additional Nomad Metrics Documentation](https://www.nomadproject.io/docs/telemetry/metrics)\n\n\nClone this template dashboard to make changes and add your own graph widgets.",
     "author_info": {
         "author_name": "Datadog"
     },
-    "board_title": "Nomad Overview",
-    "description": "This Nomad dashboard provides a quick overview on the performance of your Nomad Host, Data centers and Clients. Included are also some high level views of Raft, Consul and RPC metrics. Further reading on Nomad can be found in the following:\n\n- [What is Nomad](https://www.nomadproject.io/intro)\n- [Datadog Nomad Integration](https://docs.datadoghq.com/integrations/nomad/)\n- [Additional Nomad Metrics Documentation](https://www.nomadproject.io/docs/telemetry/metrics)\n\n\nClone this template dashboard to make changes and add your own graph widgets.",
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "host",
-            "prefix": "host"
-        },
-        {
-            "default": "*",
-            "name": "node_id",
-            "prefix": "node_id"
-        },
-        {
-            "default": "*",
-            "name": "datacenter",
-            "prefix": "datacenter"
-        },
-        {
-            "default": "*",
-            "name": "client_id",
-            "prefix": "client"
-        }
-    ],
     "widgets": [
-        {
-            "height": 10,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "custom_unit": "Hrs",
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "avg:nomad.client.uptime{$host,$node_id,$datacenter}/3600"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Client Uptime",
-            "type": "query_value",
-            "width": 20,
-            "x": 30,
-            "y": 0
+      {
+        "id": 0,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.client.uptime{$host,$node_id,$datacenter}/3600",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Client Uptime",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "custom_unit": "Hrs",
+          "precision": 2
         },
-        {
-            "height": 12,
-            "sizing": "fit",
-            "type": "image",
-            "url": "https://github.com/DataDog/integrations-extras/blob/734fb8f604e29036eb427beff7689ee4c0142b4b/nomad/assets/logos/saas_logos-bot.png?raw=true",
-            "width": 29,
-            "x": 0,
-            "y": 0
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:nomad.client.host.memory.free{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.host.memory.used{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.host.memory.available{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.host.memory.total{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Host memory",
-            "type": "timeseries",
-            "width": 37,
-            "x": 0,
-            "y": 19
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:nomad.client.allocated.memory{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.unallocated.memory{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Host memory allocation",
-            "type": "timeseries",
-            "width": 37,
-            "x": 0,
-            "y": 35
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:nomad.client.host.cpu.idle{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.host.cpu.total{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.host.cpu.user{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.host.cpu.system{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Host CPU",
-            "type": "timeseries",
-            "width": 37,
-            "x": 38,
-            "y": 19
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:nomad.client.allocated.cpu{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.unallocated.cpu{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Host CPU Allocation",
-            "type": "timeseries",
-            "width": 37,
-            "x": 38,
-            "y": 35
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:nomad.client.host.disk.available{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.host.disk.used{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.host.disk.size{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Host Disk",
-            "type": "timeseries",
-            "width": 37,
-            "x": 76,
-            "y": 19
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:nomad.client.allocated.disk{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "avg:nomad.client.unallocated.disk{$host,$node_id,$datacenter}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Disk Allocation",
-            "type": "timeseries",
-            "width": 37,
-            "x": 76,
-            "y": 35
-        },
-        {
-            "height": 10,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "custom_unit": "%",
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "(avg:nomad.client.host.memory.used{$host,$node_id,$datacenter}/avg:nomad.client.host.memory.total{$host,$node_id,$datacenter})*100"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Memory Usage",
-            "type": "query_value",
-            "width": 20,
-            "x": 51,
-            "y": 0
-        },
-        {
-            "height": 10,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "custom_unit": "%",
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "(avg:nomad.client.host.cpu.user{$host,$node_id,$datacenter}+avg:nomad.client.host.cpu.system{$host,$node_id,$datacenter})"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "CPU Usage",
-            "type": "query_value",
-            "width": 20,
-            "x": 72,
-            "y": 0
-        },
-        {
-            "height": 10,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "custom_unit": "%",
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "(avg:nomad.client.host.disk.used{$host,$node_id,$datacenter}/avg:nomad.client.host.disk.size{$host,$node_id,$datacenter})*100"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Disk Usage",
-            "type": "query_value",
-            "width": 20,
-            "x": 93,
-            "y": 0
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 5,
-            "html": "Broker Metrics",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 18,
-            "x": 75,
-            "y": 52
-        },
-        {
-            "height": 8,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.nomad.broker.total_ready{$host}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Brokers Ready",
-            "type": "query_value",
-            "width": 18,
-            "x": 75,
-            "y": 58
-        },
-        {
-            "height": 8,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.nomad.broker.total_blocked{$host}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Brokers Blocked",
-            "type": "query_value",
-            "width": 18,
-            "x": 75,
-            "y": 69
-        },
-        {
-            "height": 8,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.nomad.broker.total_unacked{$host}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Brokers Unacked",
-            "type": "query_value",
-            "width": 18,
-            "x": 75,
-            "y": 80
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 5,
-            "html": "RPC Metrics",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 18,
-            "x": 95,
-            "y": 52
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 5,
-            "html": "Consul Metrics",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 37,
-            "x": 75,
-            "y": 92
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 5,
-            "html": "Raft Metrics",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 73,
-            "x": 0,
-            "y": 92
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 5,
-            "html": "Runtime Metrics",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 73,
-            "x": 0,
-            "y": 52
-        },
-        {
-            "height": 8,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.nomad.rpc.query{$host}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total RPC Query",
-            "type": "query_value",
-            "width": 18,
-            "x": 95,
-            "y": 58
-        },
-        {
-            "height": 8,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.nomad.rpc.request{$host}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total RPC Requests",
-            "type": "query_value",
-            "width": 18,
-            "x": 95,
-            "y": 69
-        },
-        {
-            "height": 8,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.nomad.rpc.request_error{$host}.as_count()"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total RPC Requests Errors",
-            "type": "query_value",
-            "width": 18,
-            "x": 95,
-            "y": 80
-        },
-        {
-            "height": 8,
-            "tile_def": {
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "avg:nomad.runtime.num_goroutines{$host,$client_id}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Goroutines",
-            "type": "query_value",
-            "width": 18,
-            "x": 0,
-            "y": 58
-        },
-        {
-            "height": 8,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "avg:nomad.runtime.heap_objects{$host,$node_id} by {client,host}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Heap Objects",
-            "type": "query_value",
-            "width": 18,
-            "x": 0,
-            "y": 80
-        },
-        {
-            "height": 28,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:nomad.runtime.alloc_bytes{$host,$client_id} by {host,client}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory Utilization",
-            "type": "timeseries",
-            "width": 54,
-            "x": 19,
-            "y": 58
-        },
-        {
-            "height": 10,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.raft.apply{$host}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Transactions",
-            "type": "query_value",
-            "width": 18,
-            "x": 0,
-            "y": 98
-        },
-        {
-            "height": 15,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:nomad.raft.rpc.appendEntries.avg{$host} by {host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total Transaction Time",
-            "type": "timeseries",
-            "width": 54,
-            "x": 19,
-            "y": 98
-        },
-        {
-            "height": 10,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.client.consul.services{$host}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Services Running",
-            "type": "query_value",
-            "width": 18,
-            "x": 75,
-            "y": 104
-        },
-        {
-            "height": 10,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.client.consul.check_registrations{$host}.as_count()"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Checks Registered",
-            "type": "query_value",
-            "width": 18,
-            "x": 94,
-            "y": 117
-        },
-        {
-            "height": 10,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.client.consul.checks{$host}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Checks Running",
-            "type": "query_value",
-            "width": 18,
-            "x": 75,
-            "y": 117
-        },
-        {
-            "height": 15,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "q": "avg:nomad.raft.leader.lastContact.avg{$host} by {host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Time Since Contact With Leader",
-            "type": "timeseries",
-            "width": 54,
-            "x": 19,
-            "y": 116
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Host Metrics",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 113,
-            "x": 0,
-            "y": 13
-        },
-        {
-            "height": 10,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.client.consul.service_registrations{$host}.as_count()"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total Service Registered",
-            "type": "query_value",
-            "width": 18,
-            "x": 94,
-            "y": 104
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 5,
-            "html": "Consul Registrations",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 18,
-            "x": 94,
-            "y": 98
-        },
-        {
-            "height": 8,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:nomad.runtime.total_gc_runs{$host,$client_id}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Total GC runs",
-            "type": "query_value",
-            "width": 18,
-            "x": 0,
-            "y": 69
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 5,
-            "html": "Running",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 18,
-            "x": 75,
-            "y": 98
+        "layout": {
+          "x": 30,
+          "y": 0,
+          "width": 20,
+          "height": 12
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "image",
+          "url": "https://github.com/DataDog/integrations-extras/blob/734fb8f604e29036eb427beff7689ee4c0142b4b/nomad/assets/logos/saas_logos-bot.png?raw=true",
+          "sizing": "fit"
+        },
+        "layout": {
+          "x": 0,
+          "y": 0,
+          "width": 29,
+          "height": 12
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:nomad.client.host.memory.free{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.host.memory.used{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.host.memory.available{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.host.memory.total{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Host memory",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 0,
+          "y": 19,
+          "width": 37,
+          "height": 15
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:nomad.client.allocated.memory{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.unallocated.memory{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Host memory allocation",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 0,
+          "y": 35,
+          "width": 37,
+          "height": 15
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:nomad.client.host.cpu.idle{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.host.cpu.total{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.host.cpu.user{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.host.cpu.system{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Host CPU",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 38,
+          "y": 19,
+          "width": 37,
+          "height": 15
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:nomad.client.allocated.cpu{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.unallocated.cpu{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Host CPU Allocation",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 38,
+          "y": 35,
+          "width": 37,
+          "height": 15
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:nomad.client.host.disk.available{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.host.disk.used{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.host.disk.size{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Host Disk",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 76,
+          "y": 19,
+          "width": 37,
+          "height": 15
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:nomad.client.allocated.disk{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:nomad.client.unallocated.disk{$host,$node_id,$datacenter}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Disk Allocation",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 76,
+          "y": 35,
+          "width": 37,
+          "height": 15
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "(avg:nomad.client.host.memory.used{$host,$node_id,$datacenter}/avg:nomad.client.host.memory.total{$host,$node_id,$datacenter})*100",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Memory Usage",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "custom_unit": "%",
+          "precision": 2
+        },
+        "layout": {
+          "x": 51,
+          "y": 0,
+          "width": 20,
+          "height": 12
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "(avg:nomad.client.host.cpu.user{$host,$node_id,$datacenter}+avg:nomad.client.host.cpu.system{$host,$node_id,$datacenter})",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "CPU Usage",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "custom_unit": "%",
+          "precision": 2
+        },
+        "layout": {
+          "x": 72,
+          "y": 0,
+          "width": 20,
+          "height": 12
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "(avg:nomad.client.host.disk.used{$host,$node_id,$datacenter}/avg:nomad.client.host.disk.size{$host,$node_id,$datacenter})*100",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Disk Usage",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "custom_unit": "%",
+          "precision": 2
+        },
+        "layout": {
+          "x": 93,
+          "y": 0,
+          "width": 20,
+          "height": 12
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "note",
+          "content": "Broker Metrics",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 75,
+          "y": 52,
+          "width": 18,
+          "height": 5
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.nomad.broker.total_ready{$host}",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Brokers Ready",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 75,
+          "y": 58,
+          "width": 18,
+          "height": 10
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.nomad.broker.total_blocked{$host}",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Brokers Blocked",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 75,
+          "y": 69,
+          "width": 18,
+          "height": 10
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.nomad.broker.total_unacked{$host}",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Brokers Unacked",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 75,
+          "y": 80,
+          "width": 18,
+          "height": 10
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "note",
+          "content": "RPC Metrics",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 95,
+          "y": 52,
+          "width": 18,
+          "height": 5
+        }
+      },
+      {
+        "id": 16,
+        "definition": {
+          "type": "note",
+          "content": "Consul Metrics",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "center",
+          "show_tick": false,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 75,
+          "y": 92,
+          "width": 37,
+          "height": 5
+        }
+      },
+      {
+        "id": 17,
+        "definition": {
+          "type": "note",
+          "content": "Raft Metrics",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 0,
+          "y": 92,
+          "width": 73,
+          "height": 5
+        }
+      },
+      {
+        "id": 18,
+        "definition": {
+          "type": "note",
+          "content": "Runtime Metrics",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 0,
+          "y": 52,
+          "width": 73,
+          "height": 5
+        }
+      },
+      {
+        "id": 19,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.nomad.rpc.query{$host}",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total RPC Query",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 95,
+          "y": 58,
+          "width": 18,
+          "height": 10
+        }
+      },
+      {
+        "id": 20,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.nomad.rpc.request{$host}",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total RPC Requests",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 95,
+          "y": 69,
+          "width": 18,
+          "height": 10
+        }
+      },
+      {
+        "id": 21,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.nomad.rpc.request_error{$host}.as_count()",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total RPC Requests Errors",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 95,
+          "y": 80,
+          "width": 18,
+          "height": 10
+        }
+      },
+      {
+        "id": 22,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.runtime.num_goroutines{$host,$client_id}",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Goroutines",
+          "title_size": "16",
+          "title_align": "center",
+          "precision": 2
+        },
+        "layout": {
+          "x": 0,
+          "y": 58,
+          "width": 18,
+          "height": 10
+        }
+      },
+      {
+        "id": 23,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.runtime.heap_objects{$host,$node_id} by {client,host}",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Heap Objects",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 0,
+          "y": 80,
+          "width": 18,
+          "height": 10
+        }
+      },
+      {
+        "id": 24,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:nomad.runtime.alloc_bytes{$host,$client_id} by {host,client}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Memory Utilization",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 19,
+          "y": 58,
+          "width": 54,
+          "height": 30
+        }
+      },
+      {
+        "id": 25,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.raft.apply{$host}",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Transactions",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 0,
+          "y": 98,
+          "width": 18,
+          "height": 12
+        }
+      },
+      {
+        "id": 26,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:nomad.raft.rpc.appendEntries.avg{$host} by {host}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Total Transaction Time",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 19,
+          "y": 98,
+          "width": 54,
+          "height": 17
+        }
+      },
+      {
+        "id": 27,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.client.consul.services{$host}",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Services Running",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 75,
+          "y": 104,
+          "width": 18,
+          "height": 12
+        }
+      },
+      {
+        "id": 28,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.client.consul.check_registrations{$host}.as_count()",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Checks Registered",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 94,
+          "y": 117,
+          "width": 18,
+          "height": 12
+        }
+      },
+      {
+        "id": 29,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.client.consul.checks{$host}",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Checks Running",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 75,
+          "y": 117,
+          "width": 18,
+          "height": 12
+        }
+      },
+      {
+        "id": 30,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:nomad.raft.leader.lastContact.avg{$host} by {host}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Time Since Contact With Leader",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 19,
+          "y": 116,
+          "width": 54,
+          "height": 17
+        }
+      },
+      {
+        "id": 31,
+        "definition": {
+          "type": "note",
+          "content": "Host Metrics",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 0,
+          "y": 13,
+          "width": 113,
+          "height": 5
+        }
+      },
+      {
+        "id": 32,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.client.consul.service_registrations{$host}.as_count()",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Service Registered",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 94,
+          "y": 104,
+          "width": 18,
+          "height": 12
+        }
+      },
+      {
+        "id": 33,
+        "definition": {
+          "type": "note",
+          "content": "Consul Registrations",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 94,
+          "y": 98,
+          "width": 18,
+          "height": 5
+        }
+      },
+      {
+        "id": 34,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:nomad.runtime.total_gc_runs{$host,$client_id}",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total GC runs",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 0,
+          "y": 69,
+          "width": 18,
+          "height": 10
+        }
+      },
+      {
+        "id": 35,
+        "definition": {
+          "type": "note",
+          "content": "Running",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 75,
+          "y": 98,
+          "width": 18,
+          "height": 5
+        }
+      }
+    ],
+    "template_variables": [
+      {
+        "name": "host",
+        "default": "*",
+        "prefix": "host"
+      },
+      {
+        "name": "node_id",
+        "default": "*",
+        "prefix": "node_id"
+      },
+      {
+        "name": "datacenter",
+        "default": "*",
+        "prefix": "datacenter"
+      },
+      {
+        "name": "client_id",
+        "default": "*",
+        "prefix": "client"
+      }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30336
+  }

--- a/perimeterx/assets/dashboards/PerimeterX_Bot_Defender_Dashboard.json
+++ b/perimeterx/assets/dashboards/PerimeterX_Bot_Defender_Dashboard.json
@@ -1,430 +1,472 @@
 {
+    "title": "PerimeterX Bot Defender Dashboard",
+    "description": "## PerimeterX Bot Defender Dashboard\n\nThis is a snapshot of data for the PerimeterX and Datadog integration. Additional details can be obtained by also visiting your [PerimeterX Portal](https://console.perimeterx.com/botDefender/dashboard)",
     "author_info": {
         "author_name": "PerimeterX"
     },
-    "board_title": "PerimeterX Bot Defender Dashboard",
-    "description": "## PerimeterX Bot Defender Dashboard\n\nThis is a snapshot of data for the PerimeterX and Datadog integration. Additional details can be obtained by also visiting your [PerimeterX Portal](https://console.perimeterx.com/botDefender/dashboard)",
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "EventName",
-            "prefix": "@evt.name"
-        },
-        {
-            "default": "*",
-            "name": "TrueIP",
-            "prefix": "@network.client.ip"
-        },
-        {
-            "default": "*",
-            "name": "Continent",
-            "prefix": "@network.client.geoip.continent.name"
-        },
-        {
-            "default": "*",
-            "name": "Country",
-            "prefix": "@network.client.geoip.country.name"
-        },
-        {
-            "default": "*",
-            "name": "Domain",
-            "prefix": "@http.url_details.host"
-        },
-        {
-            "default": "*",
-            "name": "ApplicationID",
-            "prefix": "@px_app_id"
-        }
-    ],
     "widgets": [
-        {
-            "height": 12,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "log_query": {
-                            "compute": {
-                                "aggregation": "count"
-                            },
-                            "groupBy": [
-                                {
-                                    "facet": "@evt.name",
-                                    "limit": 10,
-                                    "sort": {
-                                        "aggregation": "count",
-                                        "order": "desc"
-                                    }
-                                }
-                            ],
-                            "index": "*",
-                            "search": {
-                                "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
-                            }
-                        },
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+      {
+        "id": 0,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "log_query": {
+                "index": "*",
+                "compute": {
+                  "aggregation": "count"
+                },
+                "search": {
+                  "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
+                },
+                "group_by": [
+                  {
+                    "facet": "@evt.name",
+                    "limit": 10,
+                    "sort": {
+                      "aggregation": "count",
+                      "order": "desc"
                     }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Traffic Over Time",
-            "type": "timeseries",
-            "width": 51,
-            "x": 12,
-            "y": 0
+                  }
+                ]
+              },
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Traffic Over Time",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
         },
-        {
-            "height": 14,
-            "sizing": "fit",
-            "type": "image",
-            "url": "https://console-cdn.perimeterx.com/botdefender/static/media/logo.3887ccd4.svg",
-            "width": 12,
-            "x": 0,
-            "y": 0
-        },
-        {
-            "height": 13,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "log_query": {
-                            "compute": {
-                                "aggregation": "count"
-                            },
-                            "groupBy": [
-                                {
-                                    "facet": "@http.url_details.path",
-                                    "limit": 10,
-                                    "sort": {
-                                        "aggregation": "count",
-                                        "order": "desc"
-                                    }
-                                }
-                            ],
-                            "index": "*",
-                            "search": {
-                                "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
-                            }
-                        }
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Top Paths",
-            "type": "toplist",
-            "width": 47,
-            "x": -1,
-            "y": 55
-        },
-        {
-            "height": 12,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "log_query": {
-                            "compute": {
-                                "aggregation": "count"
-                            },
-                            "groupBy": [
-                                {
-                                    "facet": "@px_app_id",
-                                    "limit": 10,
-                                    "sort": {
-                                        "aggregation": "count",
-                                        "order": "desc"
-                                    }
-                                }
-                            ],
-                            "index": "*",
-                            "search": {
-                                "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
-                            }
-                        }
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Top Application IDs",
-            "type": "toplist",
-            "width": 33,
-            "x": 63,
-            "y": 0
-        },
-        {
-            "height": 13,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "log_query": {
-                            "compute": {
-                                "aggregation": "cardinality",
-                                "facet": "@network.client.ip"
-                            },
-                            "groupBy": [
-                                {
-                                    "facet": "@network.client.geoip.country.iso_code",
-                                    "limit": 10,
-                                    "sort": {
-                                        "aggregation": "cardinality",
-                                        "facet": "@network.client.ip",
-                                        "order": "desc"
-                                    }
-                                }
-                            ],
-                            "index": "*",
-                            "search": {
-                                "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
-                            }
-                        }
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Top Countries By Number of IP Addresses",
-            "type": "toplist",
-            "width": 47,
-            "x": 0,
-            "y": 35
-        },
-        {
-            "height": 13,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "log_query": {
-                            "compute": {
-                                "aggregation": "count"
-                            },
-                            "groupBy": [
-                                {
-                                    "facet": "@user_agent",
-                                    "limit": 10,
-                                    "sort": {
-                                        "aggregation": "count",
-                                        "order": "desc"
-                                    }
-                                }
-                            ],
-                            "index": "*",
-                            "search": {
-                                "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
-                            }
-                        }
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Top User Agents",
-            "type": "toplist",
-            "width": 47,
-            "x": 49,
-            "y": 35
-        },
-        {
-            "height": 13,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "log_query": {
-                            "compute": {
-                                "aggregation": "count"
-                            },
-                            "groupBy": [
-                                {
-                                    "facet": "@http.url_details.host",
-                                    "limit": 10,
-                                    "sort": {
-                                        "aggregation": "count",
-                                        "order": "desc"
-                                    }
-                                }
-                            ],
-                            "index": "*",
-                            "search": {
-                                "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
-                            }
-                        }
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Top Target Hosts",
-            "type": "toplist",
-            "width": 47,
-            "x": 49,
-            "y": 55
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 5,
-            "html": "# Client Related Data",
-            "text_align": "left",
-            "tick": false,
-            "tick_edge": "left",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 96,
-            "x": 0,
-            "y": 14
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 5,
-            "html": "# Server Related Information",
-            "text_align": "left",
-            "tick": false,
-            "tick_edge": "left",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 96,
-            "x": 0,
-            "y": 50
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "# Log Stream",
-            "text_align": "left",
-            "tick": false,
-            "tick_edge": "left",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 96,
-            "x": 0,
-            "y": 70
-        },
-        {
-            "columns": "[\"@network.client.ip\", \"@http.useragent_details.browser.family\", \"@http.useragent_details.os.family\", \"@network.client.geoip.country.name\", \"@title\"]",
-            "height": 36,
-            "indexes": [],
-            "message_display": "inline",
-            "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID",
-            "show_date_column": true,
-            "show_message_column": false,
-            "sort": {
-                "column": "time",
-                "order": "desc"
-            },
-            "title": false,
-            "type": "log_stream",
-            "width": 96,
-            "x": 0,
-            "y": 75
-        },
-        {
-            "height": 13,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "log_query": {
-                            "compute": {
-                                "aggregation": "count"
-                            },
-                            "groupBy": [
-                                {
-                                    "facet": "@http.useragent_details.browser.family",
-                                    "limit": 10,
-                                    "sort": {
-                                        "aggregation": "count",
-                                        "order": "desc"
-                                    }
-                                }
-                            ],
-                            "index": "*",
-                            "search": {
-                                "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
-                            }
-                        }
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Top Browser Types",
-            "type": "toplist",
-            "width": 47,
-            "x": 49,
-            "y": 19
-        },
-        {
-            "height": 13,
-            "tile_def": {
-                "custom_links": [],
-                "requests": [
-                    {
-                        "log_query": {
-                            "compute": {
-                                "aggregation": "count"
-                            },
-                            "groupBy": [
-                                {
-                                    "facet": "@network.client.asn",
-                                    "limit": 10,
-                                    "sort": {
-                                        "aggregation": "count",
-                                        "order": "desc"
-                                    }
-                                }
-                            ],
-                            "index": "*",
-                            "search": {
-                                "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
-                            }
-                        }
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Top Network Providers",
-            "type": "toplist",
-            "width": 47,
-            "x": 0,
-            "y": 19
+        "layout": {
+          "x": 12,
+          "y": 0,
+          "width": 51,
+          "height": 14
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "image",
+          "url": "https://console-cdn.perimeterx.com/botdefender/static/media/logo.3887ccd4.svg",
+          "sizing": "fit"
+        },
+        "layout": {
+          "x": 0,
+          "y": 0,
+          "width": 12,
+          "height": 14
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "log_query": {
+                "index": "*",
+                "compute": {
+                  "aggregation": "count"
+                },
+                "search": {
+                  "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
+                },
+                "group_by": [
+                  {
+                    "facet": "@http.url_details.path",
+                    "limit": 10,
+                    "sort": {
+                      "aggregation": "count",
+                      "order": "desc"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Top Paths",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": -1,
+          "y": 55,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "log_query": {
+                "index": "*",
+                "compute": {
+                  "aggregation": "count"
+                },
+                "search": {
+                  "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
+                },
+                "group_by": [
+                  {
+                    "facet": "@px_app_id",
+                    "limit": 10,
+                    "sort": {
+                      "aggregation": "count",
+                      "order": "desc"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Top Application IDs",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 63,
+          "y": 0,
+          "width": 33,
+          "height": 14
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "log_query": {
+                "index": "*",
+                "compute": {
+                  "aggregation": "cardinality",
+                  "facet": "@network.client.ip"
+                },
+                "search": {
+                  "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
+                },
+                "group_by": [
+                  {
+                    "facet": "@network.client.geoip.country.iso_code",
+                    "limit": 10,
+                    "sort": {
+                      "aggregation": "cardinality",
+                      "order": "desc",
+                      "facet": "@network.client.ip"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Top Countries By Number of IP Addresses",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 0,
+          "y": 35,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "log_query": {
+                "index": "*",
+                "compute": {
+                  "aggregation": "count"
+                },
+                "search": {
+                  "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
+                },
+                "group_by": [
+                  {
+                    "facet": "@user_agent",
+                    "limit": 10,
+                    "sort": {
+                      "aggregation": "count",
+                      "order": "desc"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Top User Agents",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 49,
+          "y": 35,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "log_query": {
+                "index": "*",
+                "compute": {
+                  "aggregation": "count"
+                },
+                "search": {
+                  "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
+                },
+                "group_by": [
+                  {
+                    "facet": "@http.url_details.host",
+                    "limit": 10,
+                    "sort": {
+                      "aggregation": "count",
+                      "order": "desc"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Top Target Hosts",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 49,
+          "y": 55,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "note",
+          "content": "# Client Related Data",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "left",
+          "show_tick": false,
+          "tick_pos": "50%",
+          "tick_edge": "left"
+        },
+        "layout": {
+          "x": 0,
+          "y": 14,
+          "width": 96,
+          "height": 5
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "note",
+          "content": "# Server Related Information",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "left",
+          "show_tick": false,
+          "tick_pos": "50%",
+          "tick_edge": "left"
+        },
+        "layout": {
+          "x": 0,
+          "y": 50,
+          "width": 96,
+          "height": 5
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "note",
+          "content": "# Log Stream",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "left",
+          "show_tick": false,
+          "tick_pos": "50%",
+          "tick_edge": "left"
+        },
+        "layout": {
+          "x": 0,
+          "y": 70,
+          "width": 96,
+          "height": 5
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "log_stream",
+          "indexes": [],
+          "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID",
+          "sort": {
+            "column": "time",
+            "order": "desc"
+          },
+          "columns": [
+            "@network.client.ip",
+            "@http.useragent_details.browser.family",
+            "@http.useragent_details.os.family",
+            "@network.client.geoip.country.name",
+            "@title"
+          ],
+          "show_date_column": true,
+          "show_message_column": false,
+          "message_display": "inline"
+        },
+        "layout": {
+          "x": 0,
+          "y": 75,
+          "width": 96,
+          "height": 36
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "log_query": {
+                "index": "*",
+                "compute": {
+                  "aggregation": "count"
+                },
+                "search": {
+                  "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
+                },
+                "group_by": [
+                  {
+                    "facet": "@http.useragent_details.browser.family",
+                    "limit": 10,
+                    "sort": {
+                      "aggregation": "count",
+                      "order": "desc"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Top Browser Types",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 49,
+          "y": 19,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "log_query": {
+                "index": "*",
+                "compute": {
+                  "aggregation": "count"
+                },
+                "search": {
+                  "query": "source:perimeterx $EventName $TrueIP $Continent $Country $Domain $ApplicationID"
+                },
+                "group_by": [
+                  {
+                    "facet": "@network.client.asn",
+                    "limit": 10,
+                    "sort": {
+                      "aggregation": "count",
+                      "order": "desc"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Top Network Providers",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 0,
+          "y": 19,
+          "width": 47,
+          "height": 15
+        }
+      }
+    ],
+    "template_variables": [
+      {
+        "name": "EventName",
+        "default": "*",
+        "prefix": "@evt.name"
+      },
+      {
+        "name": "TrueIP",
+        "default": "*",
+        "prefix": "@network.client.ip"
+      },
+      {
+        "name": "Continent",
+        "default": "*",
+        "prefix": "@network.client.geoip.continent.name"
+      },
+      {
+        "name": "Country",
+        "default": "*",
+        "prefix": "@network.client.geoip.country.name"
+      },
+      {
+        "name": "Domain",
+        "default": "*",
+        "prefix": "@http.url_details.host"
+      },
+      {
+        "name": "ApplicationID",
+        "default": "*",
+        "prefix": "@px_app_id"
+      }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30353
+  }


### PR DESCRIPTION
### What does this PR do?
Migrate the integration dashboards to use the new "dashboard" payload format instead of the older "screenbaord/timeboard" formats.

The only thing manually changed in some boards is the `author_name` dictionary that includes the name of the author of the board. This is so we can soon properly show in app who owns this dashboard. There are a few that were previously marked as Datadog that I left, but for any that had a `created_by` object, I took the name from there. 

### Motivation
We're moving away from the older boards format and trying to complete this migration. 
There are no functional changes to any of these dashboards, just the payload format. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
