### PR TITLE
Convert author_info to author_name

### DIFF
--- a/contrastsecurity/assets/dashboards/contrast_security_protect.json
+++ b/contrastsecurity/assets/dashboards/contrast_security_protect.json
@@ -1,9 +1,7 @@
 {
   "title": "Contrast Security - Protect",
   "description": "",
-  "author_info": {
-    "name":"Contrast Security"
-  },
+  "author_name": "Contrast Security",
   "widgets": [
     {
       "id": 0,

--- a/cyral/assets/dashboards/cyral_overview.json
+++ b/cyral/assets/dashboards/cyral_overview.json
@@ -1,9 +1,7 @@
 {
     "title": "Cyral",
     "description": "",
-    "author_info": {
-        "author_name": "Cyral"
-    },
+    "author_name": "Cyral",
     "widgets": [
       {
         "id": 0,

--- a/federatorai/assets/dashboards/overview.json
+++ b/federatorai/assets/dashboards/overview.json
@@ -1,9 +1,6 @@
 {
     "title": "ProphetStor Federator.ai Kafka Overview",
     "description": "[ProphetStor Federator.ai][1] is an AI-based solution that helps enterprise manage, optimize, auto-scale resources for any applications on Kubernetes. Using advanced machine learning algorithms to predict application workload, Federator.ai scales the right amount of resources at the right time for optimized application performance.\n\n* AI-based workload prediction for Kafka or any applications\n* Resource recommendation based on workload prediction, application, Kubernetes and other related metrics\n* Automatic scaling of application containers through [Datadog Watermark Pod Autoscaler (WPA)][4]\n\n[1]: https://www.prophetstor.com/federator-ai-for-aiops/federator-ai-datadog-integration/\n[4]: https://github.com/DataDog/watermarkpodautoscaler\n\n[Federator.ai/version:v4.2.790]",
-    "author_info": {
-        "author_name": "Datadog"
-    },
     "widgets": [
       {
         "id": 0,

--- a/jfrog_platform/assets/dashboards/jfrog_artifactory_dashboard.json
+++ b/jfrog_platform/assets/dashboards/jfrog_artifactory_dashboard.json
@@ -1,7 +1,4 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
     "board_title": "Jfrog Artifactory Overview",
     "description": "This dashboard provides usage statistics overview of JFrog Artifactory logs. Included are also some high level views of audit, request and application logs. \n\nA detailed blog post can be found here: [Track JFrog Platform Performance with Datadog Analytics](https://jfrog.com/blog/track-jfrog-platform-performance-with-datadog-analytics/). \n\nSource code is also available in [Github](https://github.com/jfrog/log-analytics/tree/master/log-vendors/datadog)",
     "template_variables": [

--- a/k6/assets/dashboards/overview.json
+++ b/k6/assets/dashboards/overview.json
@@ -1,9 +1,7 @@
 {
   "title": "k6",
   "description": "This dashboard allows visualizing some of the performance testing metrics collected by [k6](https://k6.io/). \n\nFor further information about exporting metrics from k6 OSS, read the [Datadog's k6 integration docs](https://k6.io/docs/getting-started/results-output/datadog).\n\nFor more information about the integration with the k6 Cloud, visit [Cloud APM docs](https://k6.io/docs/cloud/integrations/cloud-apm).\n\nClone this template dashboard to make changes and add other graph widgets.",
-  "author_info": {
-    "name": "k6"
-  },
+  "author_name": "k6",
   "widgets": [
     {
       "id": 0,

--- a/nomad/assets/dashboards/overview.json
+++ b/nomad/assets/dashboards/overview.json
@@ -1,9 +1,6 @@
 {
     "title": "Nomad Overview",
     "description": "This Nomad dashboard provides a quick overview on the performance of your Nomad Host, Data centers and Clients. Included are also some high level views of Raft, Consul and RPC metrics. Further reading on Nomad can be found in the following:\n\n- [What is Nomad](https://www.nomadproject.io/intro)\n- [Datadog Nomad Integration](https://docs.datadoghq.com/integrations/nomad/)\n- [Additional Nomad Metrics Documentation](https://www.nomadproject.io/docs/telemetry/metrics)\n\n\nClone this template dashboard to make changes and add your own graph widgets.",
-    "author_info": {
-        "author_name": "Datadog"
-    },
     "widgets": [
       {
         "id": 0,

--- a/perimeterx/assets/dashboards/PerimeterX_Bot_Defender_Dashboard.json
+++ b/perimeterx/assets/dashboards/PerimeterX_Bot_Defender_Dashboard.json
@@ -1,9 +1,7 @@
 {
     "title": "PerimeterX Bot Defender Dashboard",
     "description": "## PerimeterX Bot Defender Dashboard\n\nThis is a snapshot of data for the PerimeterX and Datadog integration. Additional details can be obtained by also visiting your [PerimeterX Portal](https://console.perimeterx.com/botDefender/dashboard)",
-    "author_info": {
-        "author_name": "PerimeterX"
-    },
+    "author_name": "PerimeterX",
     "widgets": [
       {
         "id": 0,

--- a/sigsci/assets/dashboards/overview.json
+++ b/sigsci/assets/dashboards/overview.json
@@ -1,9 +1,7 @@
 {
 	"board_title": "Signal Sciences - Overview",
 	"read_only": false,
-	"author_info": {
-		"author_name": "Signal Sciences"
-	},
+	"author_name": "Signal Sciences",
 	"description": "## Exposing real time attack data across your web apps\n\nThis dashboard contains a summary of suspicious and anomalous http requests that have been detected by the Signal Sciences agent. These include those attacks identified in the OWASP top 10 [list](https://www.owasp.org/index.php/OWASP_Top_Ten_Cheat_Sheet) as well as certain events that may indicate malicious activity.\n\nIf you are a Signal Sciences customer, you can find more detail in your [dashboard](https://dashboard.signalsciences.net/). If you are not a customer, please contact Signal Sciences for a [free trial](https://info.signalsciences.com/request-a-demo).",
 	"board_bgtype": "board_graph",
 	"created": "2019-05-15T22:43:17.037850+00:00",

--- a/speedtest/assets/dashboards/speedtest.json
+++ b/speedtest/assets/dashboards/speedtest.json
@@ -1,9 +1,6 @@
 {
     "title": "Speedtest",
     "description": "## Speedtest Dashboard\n\nThis dashboard provides quick views of the key Speedtest metrics from your integration check.\n\n- [Speedtest Integration Overview](https://github.com/DataDog/integrations-extras/blob/master/speedtest/README.md)\n- [Speedtest CLI](https://www.speedtest.net/apps/cli)",
-    "author_info": {
-        "author_name": "Datadog"
-    },
     "widgets": [
       {
         "id": 0,


### PR DESCRIPTION
### What does this PR do?
Converts author_info object to just author_name field
If the author is "Datadog", the field can be absent

### Motivation
The new integration dashboard payloads should use this instead of the legacy author_info object.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
