### PR TITLE
Add existing dashboard to manifest

### DIFF
--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -23,7 +23,9 @@
   ],
   "assets": {
     "monitors": {},
-    "dashboards": {},
+    "dashboards": {
+      "Signal Sciences Overview": "assets/dashboards/overview.json"
+    },
     "service_checks": "assets/service_checks.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adds the existing signal sciences dashboard to the manifest.json file under the assets -> dashboards section

### Motivation

The dashboard is available in-app, but was missing from the manifest, so updates weren't getting synced properly. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
