### PR TITLE
[EventStore] Allow passing a custom CA bundle

### DIFF
--- a/eventstore/CHANGELOG.md
+++ b/eventstore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - eventstore
 
+## 1.1.0
+
+* [FEATURE] Allow passing a custom CA bundle
+
 ## 1.0.0
 
 * [FEATURE] Add metrics from multiple API endpoints

--- a/eventstore/datadog_checks/eventstore/__about__.py
+++ b/eventstore/datadog_checks/eventstore/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'

--- a/eventstore/datadog_checks/eventstore/data/conf.yaml.example
+++ b/eventstore/datadog_checks/eventstore/data/conf.yaml.example
@@ -38,6 +38,12 @@ instances:
     #
     # name: '<INSTANCE_NAME>'
 
+    ## @param ca_bundle - string - optional
+    ## The path to a custom CA bundle to use for verifying the EventStore API certificate
+    ## If unset, the certifi bundle shipped with the Requests module will be used
+    #
+    # ca_bundle: '/etc/ssl/certs/ca-certificates.crt'
+
     ## @param json_path - list of strings - required
     ## A list of metrics you wish to capture, with wildcard support
     ## The metric you wish to capture must be defined above, a wildcard captures

--- a/eventstore/datadog_checks/eventstore/eventstore.py
+++ b/eventstore/datadog_checks/eventstore/eventstore.py
@@ -40,6 +40,8 @@ class EventStoreCheck(AgentCheck):
         tag_by_url = instance.get('tag_by_url', False)
         name_tag = instance.get('name', url)
         metric_def = copy.deepcopy(metrics)
+        # Requests defaults to True, which causes Requests to use the certifi CA bundle
+        verify_bundle = instance.get('ca_bundle', True)
 
         user = instance.get('user')
         password = instance.get('password')
@@ -49,7 +51,7 @@ class EventStoreCheck(AgentCheck):
             auth = (user, password)
             self.log.debug('Authenticating as: %s', user)
         try:
-            r = requests.get(url, timeout=timeout, auth=auth)
+            r = requests.get(url, timeout=timeout, auth=auth, verify=verify_bundle)
         except requests.exceptions.Timeout:
             raise CheckException('URL: {} timed out after {} seconds.'.format(url, timeout))
         except requests.exceptions.MissingSchema as e:

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -1,7 +1,7 @@
 {
   "integration_id": "eventstore",
   "maintainer": "@xorima",
-  "manifest_version": "1.0.0",
+  "manifest_version": "1.1.0",
   "name": "eventstore",
   "display_name": "Eventstore",
   "short_description": "Collects Eventstore Metrics",

--- a/eventstore/tests/compose/docker-compose.yml
+++ b/eventstore/tests/compose/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
       - subnet: 172.30.30.0/29
 services:
   web:
-    image: &image eventstore/eventstore:latest
+    image: &image eventstore/eventstore:release-5.0.8
     networks:
       ddev-esnet:
         ipv4_address: &web-ip 172.30.30.2


### PR DESCRIPTION
### What does this PR do?

This makes it possible to pass a custom CA bundle to `requests`

### Motivation

With the introduction of EventStore 6, the HTTP API is now behind SSL. The certificates used are not always publicly trusted, so it is necessary to validate them against a custom CA bundle

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
