### PR TITLE
Update metadata.csv

### DIFF
--- a/ping/metadata.csv
+++ b/ping/metadata.csv
@@ -1,3 +1,3 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-network.tcp.response_time,gauge,,millisecond,,"The response time of a given host and ping port, tagged with url, e.g. 'host:192.168.1.100'.",-1,ping,ping resp time
+network.ping.response_time,gauge,,millisecond,,"The response time of a given host and ping port, tagged with url, e.g. 'host:192.168.1.100'.",-1,ping,ping resp time
 network.ping.can_connect,gauge,,,,"Value of 1 if the agent can successfully communicate with the target host, 0 otherwise",1,ping,ping can connect


### PR DESCRIPTION
network.tcp.response_time should be network.ping.response_time

### What does this PR do?

Change wording from "tcp" to "ping".

### Motivation

While setting up PING integration, there is no metric for network.tcp.response_time, instead there is network.ping.response_time, might be the documentation need to be update.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
