### PR TITLE
Fix integration name in pihole metadata.csv

### DIFF
--- a/pihole/metadata.csv
+++ b/pihole/metadata.csv
@@ -1,15 +1,15 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-pihole.queries_forwarded,gauge,,query,,Queries not blocked,0,Pihole,queries_forwarded
-pihole.domains_being_blocked,gauge,,,,Domains that are currenly being blocked,0,Pihole,domains_being_blocked
-pihole.ads_percent_blocked,gauge,,percent,,Percentage of ads blocked today,0,Pihole,ads_percent_blocked
-pihole.ads_blocked_today,gauge,,,,Number of ads blocked today,0,Pihole,ads_blocked_today
-pihole.dns_queries_today,gauge,,,,Amount of queries made to Pi-hole,0,Pihole,dns_queries_today
-pihole.clients_ever_seen,gauge,,,,Total clients,0,Pihole,clients_ever_seen
-pihole.unique_clients,gauge,,,,Total number of unique clients,0,Pihole,unique_clients
-pihole.queries_cached,gauge,,query,,Number of cached queries,0,Pihole,queries_cached
-pihole.unique_domains,gauge,,,,Number of unique domains seen,0,Pihole,unique_domains
-pihole.reply_nodata,gauge,,,,Number of no data replies,0,Pihole,reply_NODATA
-pihole.reply_cname,gauge,,,,Number of cname replies,0,Pihole,reply_cname
-pihole.reply_ip,gauge,,,,Number of ip replies,0,Pihole,reply_ip
-pihole.reply_nxdomain,gauge,,,,Number of nxdomain replies,0,Pihole,reply_NXDOMAIN
-pihole.dns_queries_all_types,gauge,,,,Amount of queries made to Pi-hole of all types,0,Pihole,dns_queries_all_types
+pihole.queries_forwarded,gauge,,query,,Queries not blocked,0,pihole,queries_forwarded
+pihole.domains_being_blocked,gauge,,,,Domains that are currenly being blocked,0,pihole,domains_being_blocked
+pihole.ads_percent_blocked,gauge,,percent,,Percentage of ads blocked today,0,pihole,ads_percent_blocked
+pihole.ads_blocked_today,gauge,,,,Number of ads blocked today,0,pihole,ads_blocked_today
+pihole.dns_queries_today,gauge,,,,Amount of queries made to Pi-hole,0,pihole,dns_queries_today
+pihole.clients_ever_seen,gauge,,,,Total clients,0,pihole,clients_ever_seen
+pihole.unique_clients,gauge,,,,Total number of unique clients,0,pihole,unique_clients
+pihole.queries_cached,gauge,,query,,Number of cached queries,0,pihole,queries_cached
+pihole.unique_domains,gauge,,,,Number of unique domains seen,0,pihole,unique_domains
+pihole.reply_nodata,gauge,,,,Number of no data replies,0,pihole,reply_NODATA
+pihole.reply_cname,gauge,,,,Number of cname replies,0,pihole,reply_cname
+pihole.reply_ip,gauge,,,,Number of ip replies,0,pihole,reply_ip
+pihole.reply_nxdomain,gauge,,,,Number of nxdomain replies,0,pihole,reply_NXDOMAIN
+pihole.dns_queries_all_types,gauge,,,,Amount of queries made to Pi-hole of all types,0,pihole,dns_queries_all_types


### PR DESCRIPTION
### What does this PR do?
Use the lowercase name of the integration in the pihole metadata.csv file

### Motivation
CI would otherwise start failing after this is merged -
https://github.com/DataDog/integrations-core/pull/7643

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
