### PR TITLE
Add metric metadata field to integration manifests

### DIFF
--- a/ambassador/manifest.json
+++ b/ambassador/manifest.json
@@ -26,6 +26,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/amixr/manifest.json
+++ b/amixr/manifest.json
@@ -27,6 +27,7 @@
     "dashboards": {},
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/apollo/manifest.json
+++ b/apollo/manifest.json
@@ -28,7 +28,10 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   },
-  "aliases": ["/integrations/apollo_engine"]
+  "aliases": [
+    "/integrations/apollo_engine"
+  ]
 }

--- a/aqua/manifest.json
+++ b/aqua/manifest.json
@@ -28,6 +28,7 @@
     "dashboards": {
       "aqua": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/auth0/manifest.json
+++ b/auth0/manifest.json
@@ -15,7 +15,10 @@
     "windows"
   ],
   "public_title": "Datadog-Auth0 Integration",
-  "categories": ["log collection" , "security"],
+  "categories": [
+    "log collection",
+    "security"
+  ],
   "type": "check",
   "is_public": true,
   "integration_id": "auth0",
@@ -23,6 +26,7 @@
     "dashboards": {},
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/aws_pricing/manifest.json
+++ b/aws_pricing/manifest.json
@@ -26,6 +26,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/bind9/manifest.json
+++ b/bind9/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/bluematador/manifest.json
+++ b/bluematador/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "dashboards": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/bonsai/manifest.json
+++ b/bonsai/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/botprise/manifest.json
+++ b/botprise/manifest.json
@@ -25,6 +25,7 @@
     "dashboards": {},
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/buddy/manifest.json
+++ b/buddy/manifest.json
@@ -22,6 +22,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cert_manager/manifest.json
+++ b/cert_manager/manifest.json
@@ -27,6 +27,7 @@
     "dashboards": {},
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/concourse_ci/manifest.json
+++ b/concourse_ci/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/contrastsecurity/manifest.json
+++ b/contrastsecurity/manifest.json
@@ -26,6 +26,7 @@
       "Contrast Security Integration Overview": "assets/dashboards/contrast_security_protect.json"
     },
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/convox/manifest.json
+++ b/convox/manifest.json
@@ -22,6 +22,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cyral/manifest.json
+++ b/cyral/manifest.json
@@ -29,6 +29,7 @@
     },
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/federatorai/manifest.json
+++ b/federatorai/manifest.json
@@ -22,16 +22,17 @@
   "integration_id": "federatorai",
   "assets": {
     "dashboards": {
-		"ProphetStor Federator.ai Kafka Overview": "assets/dashboards/overview.json",
-		"ProphetStor Federator.ai Cluster Overview": "assets/dashboards/cluster-overview.json",
-		"ProphetStor Federator.ai Application Overview": "assets/dashboards/application-overview.json",
-		"ProphetStor Federator.ai Cost Analysis Overview": "assets/dashboards/cost-analysis-overview.json"
-	},
+      "ProphetStor Federator.ai Kafka Overview": "assets/dashboards/overview.json",
+      "ProphetStor Federator.ai Cluster Overview": "assets/dashboards/cluster-overview.json",
+      "ProphetStor Federator.ai Application Overview": "assets/dashboards/application-overview.json",
+      "ProphetStor Federator.ai Cost Analysis Overview": "assets/dashboards/cost-analysis-overview.json"
+    },
     "saved_views": {},
     "monitors": {
-		"Node CPU Load Prediction in Next 24 Hours is High": "assets/recommended_monitors/federatorai_node_cpu_prediction.json",
-		"Node Memory Usage Prediction in Next 24 Hours is High": "assets/recommended_monitors/federatorai_node_mem_prediction.json"
-	},
-    "service_checks": "assets/service_checks.json"
+      "Node CPU Load Prediction in Next 24 Hours is High": "assets/recommended_monitors/federatorai_node_cpu_prediction.json",
+      "Node Memory Usage Prediction in Next 24 Hours is High": "assets/recommended_monitors/federatorai_node_mem_prediction.json"
+    },
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -26,6 +26,7 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/gnatsd/manifest.json
+++ b/gnatsd/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/gnatsd_streaming/manifest.json
+++ b/gnatsd_streaming/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/gremlin/manifest.json
+++ b/gremlin/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/hbase_master/manifest.json
+++ b/hbase_master/manifest.json
@@ -30,6 +30,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "hbase"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/hbase_regionserver/manifest.json
+++ b/hbase_regionserver/manifest.json
@@ -30,6 +30,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "hbase"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/jfrog_platform/manifest.json
+++ b/jfrog_platform/manifest.json
@@ -28,6 +28,7 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/k6/manifest.json
+++ b/k6/manifest.json
@@ -28,6 +28,7 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kernelcare/manifest.json
+++ b/kernelcare/manifest.json
@@ -29,6 +29,7 @@
     "dashboards": {},
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/lacework/manifest.json
+++ b/lacework/manifest.json
@@ -16,7 +16,7 @@
   ],
   "public_title": "Datadog-Lacework Integration",
   "categories": [
-    "security", 
+    "security",
     "log collection"
   ],
   "type": "check",
@@ -25,6 +25,7 @@
   "assets": {
     "dashboards": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/launchdarkly/manifest.json
+++ b/launchdarkly/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/lighthouse/manifest.json
+++ b/lighthouse/manifest.json
@@ -21,7 +21,8 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
-  },  
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
+  },
   "is_public": true
 }

--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -27,6 +27,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/logzio/manifest.json
+++ b/logzio/manifest.json
@@ -22,6 +22,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/neo4j/manifest.json
+++ b/neo4j/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/neutrona/manifest.json
+++ b/neutrona/manifest.json
@@ -26,6 +26,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/nextcloud/manifest.json
+++ b/nextcloud/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/nomad/manifest.json
+++ b/nomad/manifest.json
@@ -23,15 +23,16 @@
   "is_public": true,
   "assets": {
     "monitors": {
-      "Nomad Excessive Leadership Losses" : "assets/monitors/nomad_excessive_leadership_losses.json",
-      "Nomad No Jobs Running" : "assets/monitors/nomad_no_jobs_running.json",
-      "Nomad Pending Jobs" : "assets/monitors/nomad_pending_jobs.json",
-      "Nomad Job Is Failing" : "assets/monitors/nomad_job_is_failing.json",
-      "Nomad Heartbeats Received" : "assets/monitors/nomad_heartbeats_received.json"
+      "Nomad Excessive Leadership Losses": "assets/monitors/nomad_excessive_leadership_losses.json",
+      "Nomad No Jobs Running": "assets/monitors/nomad_no_jobs_running.json",
+      "Nomad Pending Jobs": "assets/monitors/nomad_pending_jobs.json",
+      "Nomad Job Is Failing": "assets/monitors/nomad_job_is_failing.json",
+      "Nomad Heartbeats Received": "assets/monitors/nomad_heartbeats_received.json"
     },
     "dashboards": {
       "Nomad Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/nvml/manifest.json
+++ b/nvml/manifest.json
@@ -28,6 +28,7 @@
     "dashboards": {},
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/perimeterx/manifest.json
+++ b/perimeterx/manifest.json
@@ -27,7 +27,8 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   },
   "is_beta": false
 }

--- a/pihole/manifest.json
+++ b/pihole/manifest.json
@@ -28,6 +28,7 @@
     "dashboards": {},
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ping/manifest.json
+++ b/ping/manifest.json
@@ -1,4 +1,3 @@
-
 {
   "categories": [
     "network"
@@ -24,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/pliant/manifest.json
+++ b/pliant/manifest.json
@@ -28,6 +28,7 @@
     "dashboards": {},
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/portworx/manifest.json
+++ b/portworx/manifest.json
@@ -21,6 +21,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/rbltracker/manifest.json
+++ b/rbltracker/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/reboot_required/manifest.json
+++ b/reboot_required/manifest.json
@@ -20,6 +20,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/redis_sentinel/manifest.json
+++ b/redis_sentinel/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/resin/manifest.json
+++ b/resin/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "monitors": {}
+    "monitors": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/riak_repl/manifest.json
+++ b/riak_repl/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/rigor/manifest.json
+++ b/rigor/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/rookout/manifest.json
+++ b/rookout/manifest.json
@@ -22,6 +22,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/rundeck/manifest.json
+++ b/rundeck/manifest.json
@@ -26,6 +26,7 @@
     "dashboards": {},
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/sendmail/manifest.json
+++ b/sendmail/manifest.json
@@ -22,6 +22,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -26,6 +26,7 @@
     "dashboards": {
       "sigsci": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/snmpwalk/manifest.json
+++ b/snmpwalk/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/sortdb/manifest.json
+++ b/sortdb/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/speedtest/manifest.json
+++ b/speedtest/manifest.json
@@ -31,6 +31,7 @@
     },
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/split/manifest.json
+++ b/split/manifest.json
@@ -22,6 +22,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/squadcast/manifest.json
+++ b/squadcast/manifest.json
@@ -28,6 +28,7 @@
     "dashboards": {},
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/stardog/manifest.json
+++ b/stardog/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -23,6 +23,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/traefik/manifest.json
+++ b/traefik/manifest.json
@@ -25,6 +25,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/unbound/manifest.json
+++ b/unbound/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/upsc/manifest.json
+++ b/upsc/manifest.json
@@ -21,6 +21,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/uptime/manifest.json
+++ b/uptime/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/vespa/manifest.json
+++ b/vespa/manifest.json
@@ -22,6 +22,7 @@
   "assets": {
     "dashboards": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/vns3/manifest.json
+++ b/vns3/manifest.json
@@ -24,6 +24,7 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds the path to the metadata.csv file to the integration's manifest.json file
This is to further standardize how we look for integration assets (and is currently what we do for service_checks.json files)

Same as the PR for integrations-core here - https://github.com/DataDog/integrations-core/pull/7617, I used the same script noted there, but modified the path for integrations-extras. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

There are some style changes just based on the way the script writes the modified yaml back to disk. Aside from the new metrics_metadata field, all other changes should be cosmetic. 