### PR TITLE
Fix resin JMX metrics

### DIFF
--- a/resin/datadog_checks/resin/data/conf.yaml.example
+++ b/resin/datadog_checks/resin/data/conf.yaml.example
@@ -99,58 +99,19 @@ init_config:
   #
   collect_default_metrics: true
 
-  ## @param conf - list of objects - required
-  ## List of metrics to be collected by the integration
+  ## @param conf - list of mappings - optional
+  ## The list of metrics to be collected by the integration
   ## Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
-  ## Agent 5: Customize all your metrics below
-  ## Agent 6: The default metrics to be collected are kept in metrics.yaml, but you can still add your own metrics here
+  ## The default metrics to be collected are kept in metrics.yaml, but you can still
+  ## add your own metrics here.
   #
-  conf:
-    - include:
-      domain: resin
-      type: ConnectionPool
-      attribute:
-        ConnectionCount:
-          alias: resin.connection_pool.connection_count
-          metric_type: gauge
-        ConnectionActiveCount:
-          alias: resin.connection_pool.connection_active_count
-          metric_type: gauge
-        ConnectionIdleCount:
-          alias: resin.connection_pool.connection_idle_count
-          metric_type: gauge
-        ConnectionCreateCount:
-          alias: resin.connection_pool.connection_create_count
-          metric_type: gauge
-        MaxConnections:
-          alias: resin.connection_pool.max_connections
-          metric_type: gauge
-        MaxOverflowConnections:
-          alias: resin.connection_pool.max_overflow_connections
-          metric_type: gauge
-        MaxCreateConnections:
-          alias: resin.connection_pool.max_create_connections
-          metric_type: gauge
-
-    - include:
-      domain: resin
-      type: ThreadPool
-      attribute:
-        ThreadActiveCount:
-          alias: resin.thread_pool.thread_active_count
-          metric_type: gauge
-        ThreadCount:
-          alias: resin.thread_pool.thread_count
-          metric_type: gauge
-        ThreadIdleCount:
-          alias: resin.thread_pool.thread_idle_count
-          metric_type: gauge
-        ThreadMax:
-          alias: resin.thread_pool.thread_max
-          metric_type: gauge
-        ThreadWaitCount:
-          alias: resin.thread_pool.thread_wait_count
-          metric_type: gauge
+  # conf:
+  #   - include:
+  #       bean: <BEAN_NAME>
+  #       attribute:
+  #         MyAttribute:
+  #           alias: my.metric.name
+  #           metric_type: gauge
 
 ## Log Section (Available for Agent >=6.0)
 ##

--- a/resin/datadog_checks/resin/data/metrics.yaml
+++ b/resin/datadog_checks/resin/data/metrics.yaml
@@ -1,6 +1,6 @@
 # Default metrics collected by this check. You should not have to modify this.
 jmx_metrics:
-    - include:
+  - include:
       domain: resin
       type: ConnectionPool
       attribute:
@@ -26,7 +26,7 @@ jmx_metrics:
           alias: resin.connection_pool.max_create_connections
           metric_type: gauge
 
-    - include:
+  - include:
       domain: resin
       type: ThreadPool
       attribute:

--- a/resin/tests/conftest.py
+++ b/resin/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import pytest
 
@@ -12,4 +13,5 @@ from .common import HERE
 def dd_environment():
     with docker_run(os.path.join(HERE, 'docker', 'docker-compose.yml')):
         instance = load_jmx_config()
+        time.sleep(15)  # TODO: use better strategy, e.g. waiting for specific logs
         yield instance, {'use_jmx': True}

--- a/resin/tests/test_resin.py
+++ b/resin/tests/test_resin.py
@@ -1,4 +1,6 @@
 import pytest
+from datadog_checks.dev.jmx import JVM_E2E_METRICS
+from datadog_checks.dev.utils import get_metadata_metrics
 
 
 @pytest.mark.e2e
@@ -6,20 +8,23 @@ def test_e2e(dd_agent_check):
     instance = {}
     aggregator = dd_agent_check(instance)
     metrics = [
-        'resin.connection_active_count',
-        'resin.connection_idle_count',
-        'resin.connection_busy_count_total',
-        'resin.connection_new_count_total',
-        'resin.max_connections',
-        'resin.max_overflow_connections',
-        'resin.max_create_connections',
-        'resin.thread_active_count',
-        'resin.thread_count',
-        'resin.thread_idle_count',
-        'resin.thread_max',
-        'resin.thread_wait_count',
+        'resin.thread_pool.thread_active_count',
+        'resin.thread_pool.thread_count',
+        'resin.thread_pool.thread_idle_count',
+        'resin.thread_pool.thread_max',
+        'resin.thread_pool.thread_wait_count',
+        'resin.connection_pool.connection_active_count',
+        'resin.connection_pool.connection_count',
+        'resin.connection_pool.connection_create_count',
+        'resin.connection_pool.connection_idle_count',
+        'resin.connection_pool.max_connections',
+        'resin.connection_pool.max_create_connections',
+        'resin.connection_pool.max_overflow_connections',
     ]
-    for metric in metrics:
-        # The metrix are prefixed with jmx because they are the Cluster metrics which do not have an alias
-        aggregator.assert_metric('jmx.' + metric)
+    for metric in metrics + JVM_E2E_METRICS:
+        aggregator.assert_metric(metric)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_E2E_METRICS)
+
     # aggregator.assert_service_check('resin.can_connect') ToDo, uncoment when this is available for jmx checks

--- a/resin/tests/test_resin.py
+++ b/resin/tests/test_resin.py
@@ -1,4 +1,5 @@
 import pytest
+
 from datadog_checks.dev.jmx import JVM_E2E_METRICS
 from datadog_checks.dev.utils import get_metadata_metrics
 


### PR DESCRIPTION
cc @brentm5 @hithwen 

Note: e2e tests might not pass on CI, but seems to be due to flaky resin service (docker container). For example `connection_pool` metrics not being reported.

### What does this PR do?

Fix resin JMX metrics. First implemented here: https://github.com/DataDog/integrations-extras/pull/512

Note that this is a **BREAKING** change since we don't report the old wrong metrics anymore.

Due to invalid `metrics.yaml` (wrong indentation, see PR changes), the integration was reporting metrics like:

```
jmx.resin.connection_active_count
jmx.resin.connection_idle_count
jmx.resin.connection_busy_count_total
jmx.resin.connection_new_count_total
jmx.resin.max_connections
jmx.resin.max_overflow_connections
jmx.resin.max_create_connections
jmx.resin.thread_active_count
jmx.resin.thread_count
jmx.resin.thread_idle_count
jmx.resin.thread_max
jmx.resin.thread_wait_count
```

This is likely constructed by this JMXFetch behaviour: 
https://github.com/DataDog/jmxfetch/blob/3485cb33628334d5a26a680826eb645826534d85/src/main/java/org/datadog/jmxfetch/JmxAttribute.java#L509-L512

The correct metrics to be reported are (from `metrics.yaml`):

```
        'resin.thread_pool.thread_active_count',
        'resin.thread_pool.thread_count',
        'resin.thread_pool.thread_idle_count',
        'resin.thread_pool.thread_max',
        'resin.thread_pool.thread_wait_count',
        'resin.connection_pool.connection_active_count',
        'resin.connection_pool.connection_count',
        'resin.connection_pool.connection_create_count',
        'resin.connection_pool.connection_idle_count',
        'resin.connection_pool.max_connections',
        'resin.connection_pool.max_create_connections',
        'resin.connection_pool.max_overflow_connections',
```