### PR TITLE
Fix automated release CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,13 +6,16 @@ variables:
 stages:
   - release
 
+workflow:
+  rules:
+    - if: $CI_COMMIT_MESSAGE =~ /^\[Release\] Update metadata/
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      when: always
+
 release-auto:
   stage: release
   image: $TAGGER_IMAGE
-  only:
-    - master
-  except:
-    - schedules
   script:
     - ddev --version
     - ddev config set repos.extras .
@@ -22,31 +25,4 @@ release-auto:
     - ./.gitlab/release/git-auth.sh
     # Prefix every line with a timestamp
     - ./.gitlab/release/tag-release.sh 2>&1 | ts "[%H:%M:%S %Z]  "
-  tags: [ "runner:main", "size:large" ]
-
-release-manual:
-  stage: release
-  image: $TAGGER_IMAGE
-  only:
-    # Integration release tags e.g. any_check-X.Y.Z-rc.N
-    - /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
-  except:
-  - schedules
-  script:
-    - ddev --version
-    - ddev config set repos.extras .
-    - ddev config set repo extras
-    - ./.gitlab/release/git-auth.sh
-    # Get tagger info
-    - tagger=$(git for-each-ref refs/tags/$CI_COMMIT_TAG  --format='%(taggername) %(taggeremail)')
-    # The automatic release builder will trigger this job as a side-effect of
-    # tagging releases. To prevent multiple redundant builds we don't trigger
-    # the pipeline unless the tag was applied manually.
-    - |
-      if [[ "$tagger" =~ "$TAGGER_NAME <$TAGGER_EMAIL>" ]]; then
-          echo "Skipping, packages have already been built"
-      else
-          ./.gitlab/release/sign-release.sh
-          ./.gitlab/release/build-packages.sh
-      fi
   tags: [ "runner:main", "size:large" ]


### PR DESCRIPTION
Currently we may face race condition in the release CI.

1. First a commit is pushed to master that updates the version of one integration.
2. Then the CI runs on that commit, signs the code, push the signature commit on the repo and add a tag on that commit.
3. The CI re-runs on that signature commit and will check if the tag already exists. If it doesn't (which can happen because the information hasn't propagated yet), the CI will re-sign the code and add a new signature commit.

We don't want the CI to sign twice the same code as it will trigger two identical releases where one of them will fail.

## The fix
We fix the situation by:

1. Removing the release-manual job altogether, this is not supported in integrations-extras
2. Triggering the `release-auto` job only if the branch is master and the commit message is different thatn "[Release] Update metadata"

## Notes
- I was unable to make an exact match on CI_COMMIT_MESSAGE as the variable may contain a new line character at the end that I couldn't do a match on.
- I wanted to use the commit author as the rule but no predefined variable exposes that information. That means we would need code to check that information, that means we would need a no-op pipeline run for that commit.