### PR TITLE
Add service check to filebeat integration

### DIFF
--- a/filebeat/CHANGELOG.md
+++ b/filebeat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - Filebeat Integration
 
+0.3.0
+=====
+
+### Add service check
+
+* [FEATURE] Add [Service check](https://docs.datadoghq.com/developers/service_checks/agent_service_checks_submission/)
+
 0.2.0
 =====
 

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -65,9 +65,12 @@ The Filebeat check does not include any events.
 
 ### Service Checks
 
-The Filebeat check does not include any service checks.
+`filebeat.can_connect`:
+
+Returns `Critical` if the Agent cannot connect to Filebeat to collect metrics; returns `OK` otherwise.
 
 ## Troubleshooting
+
 
 Need help? Contact [Datadog support][13].
 

--- a/filebeat/assets/service_checks.json
+++ b/filebeat/assets/service_checks.json
@@ -1,1 +1,16 @@
-[]
+[
+    {
+        "agent_version": "6.3.0",
+        "integration": "Filebeat",
+        "check": "filebeat.can_connect",
+        "statuses": [
+            "ok",
+            "critical"
+        ],
+        "groups": [
+            "stats_endpoint"
+        ],
+        "name": "Can Connect",
+        "description": "Returns `Critical` if the Agent cannot connect to Filebeat to collect metrics, returns `OK` otherwise."
+    }
+]

--- a/filebeat/tests/common.py
+++ b/filebeat/tests/common.py
@@ -8,6 +8,7 @@ HOST = get_docker_hostname()
 URL = 'http://{}:5066'.format(HOST)
 ENDPOINT = '{}/stats'.format(URL)
 FIXTURE_DIR = os.path.join(HERE, "fixtures")
+BAD_ENDPOINT = 'http://{}:1234/stats'.format(HOST)
 
 
 def registry_file_path(name):

--- a/filebeat/tests/common.py
+++ b/filebeat/tests/common.py
@@ -5,6 +5,8 @@ from datadog_checks.dev.docker import get_docker_hostname
 HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKER_DIR = os.path.join(HERE, "docker")
 HOST = get_docker_hostname()
+URL = 'http://{}:5066'.format(HOST)
+ENDPOINT = '{}/stats'.format(URL)
 FIXTURE_DIR = os.path.join(HERE, "fixtures")
 
 

--- a/filebeat/tests/conftest.py
+++ b/filebeat/tests/conftest.py
@@ -4,14 +4,21 @@ import pytest
 
 from datadog_checks.dev.docker import docker_run
 
-from .common import DOCKER_DIR, HOST, registry_file_path
+from .common import DOCKER_DIR, ENDPOINT, URL, registry_file_path
+
+INSTANCE = {
+    "stats_endpoint": ENDPOINT,
+    "registry_file_path": registry_file_path("empty"),
+}
 
 
 @pytest.fixture(scope="session")
 def dd_environment():
-    instance = {
-        "stats_endpoint": "http://{}:5066/stats".format(HOST),
-        "registry_file_path": registry_file_path("empty"),
-    }
-    with docker_run(os.path.join(DOCKER_DIR, "docker-compose.yaml"), endpoints="http://{}:5066".format(HOST)):
-        yield instance
+
+    with docker_run(os.path.join(DOCKER_DIR, "docker-compose.yaml"), endpoints=URL):
+        yield INSTANCE
+
+
+@pytest.fixture
+def instance():
+    return INSTANCE.copy()

--- a/filebeat/tests/test_filebeat.py
+++ b/filebeat/tests/test_filebeat.py
@@ -433,11 +433,13 @@ def test_negative_timeout():
     _assert_config_raises({"port": 82, "timeout": -0.5}, "must be a positive number")
 
 
-def test_check(aggregator, dd_environment):
-    check = FilebeatCheck("filebeat", {}, {})
-    check.check(dd_environment)
-    check.check(dd_environment)
-    tags = ["stats_endpoint:{}".format(dd_environment["stats_endpoint"])]
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_check(aggregator, instance):
+    check = FilebeatCheck("filebeat", {}, [instance])
+    check.check(instance)
+    check.check(instance)
+    tags = ["stats_endpoint:{}".format(instance['stats_endpoint'])]
     aggregator.assert_metric("filebeat.harvester.running", metric_type=aggregator.GAUGE, count=2, tags=tags)
     aggregator.assert_metric("libbeat.config.module.starts", metric_type=aggregator.COUNTER, count=1, tags=tags)
 


### PR DESCRIPTION
### What does this PR do?

Add a [service check](https://docs.datadoghq.com/developers/service_checks/) to the Filebeats integration.

* The first commit refactored the integration test setup in what I understand to be the [more current style](https://docs.datadoghq.com/developers/integrations/new_check_howto/#building-an-integration-test).
* Second commit adds
   * the service check
    * a passing testcase to the existing integration test
    * a new failing integration test
    * the relevant documentation bits: changelog, Readme, service_checks.json

### Motivation

We installed the Filebeat integration a while back ; eventually we realised there was no easy way to make sure that every Filebeat was running on a set of hosts. Adding a service check seemed the most correct way to address this.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

* I was not quite sure what to put as `agent_version`.
* the service check does not propagate custom tags ; however custom tags do not appear to be set up for that integration
