### PR TITLE
Set Algorithmia integration to public

### DIFF
--- a/algorithmia/manifest.json
+++ b/algorithmia/manifest.json
@@ -17,7 +17,7 @@
     "monitoring"
   ],
   "type": "check",
-  "is_public": false,
+  "is_public": true,
   "integration_id": "algorithmia",
   "assets": {
     "dashboards": {


### PR DESCRIPTION
### What does this PR do?

Set `"is_public": true` in the manifest for the Datadog-Algorithmia integration developed in https://github.com/DataDog/integrations-extras/pull/727. 

### Motivation

Setting this integration to publicly visible per our product release this week.