### PR TITLE
Fix flagsmith README links

### DIFF
--- a/flagsmith/README.md
+++ b/flagsmith/README.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-[Flagsmith][https://www.flagsmith.com/] facilitates feature management across web, mobile, and server side applications. The Datadog Flagsmith integration enables you to view information about flag changes directly within Datadog.
+[Flagsmith][1] facilitates feature management across web, mobile, and server side applications. The Datadog Flagsmith integration enables you to view information about flag changes directly within Datadog.
 
 All flag change events are sent to Datadog. These events are tagged with the environment they were changed in.
 
 ## Setup
 
-In the [Flagsmith Integration tile][https://app.datadoghq.com/account/settings#integrations/flagsmith], enter your [Datadog API Key][https://app.datadoghq.com/account/settings#api]. For API URL, enter `https://api.datadoghq.com` if you are using the US site, or `https://api.datadoghq.eu` if you are using the EU site.
+In the [Flagsmith Integration tile][2], enter your [Datadog API Key][3]. For API URL, enter `https://api.datadoghq.com` if you are using the US site, or `https://api.datadoghq.eu` if you are using the EU site.
 
 ## Data Collected
 
@@ -28,4 +28,6 @@ All events are sent to the Datadog event stream.
 
 Need help? Check out the [Flagsmith documentation](https://docs.flagsmith.com/integrations/datadog/) or [contact Datadog Support][https://docs.datadoghq.com/help/].
 
-[1]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
+[1]: https://www.flagsmith.com/
+[2]: https://app.datadoghq.com/account/settings#integrations/flagsmith
+[3]: https://app.datadoghq.com/account/settings#api

--- a/flagsmith/README.md
+++ b/flagsmith/README.md
@@ -26,8 +26,9 @@ All events are sent to the Datadog event stream.
 
 ## Troubleshooting
 
-Need help? Check out the [Flagsmith documentation](https://docs.flagsmith.com/integrations/datadog/) or [contact Datadog Support][https://docs.datadoghq.com/help/].
+Need help? Check out the [Flagsmith documentation](https://docs.flagsmith.com/integrations/datadog/) or [contact Datadog Support][4].
 
 [1]: https://www.flagsmith.com/
 [2]: https://app.datadoghq.com/account/settings#integrations/flagsmith
 [3]: https://app.datadoghq.com/account/settings#api
+[4]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
The format should be either:
```
[Text](link)
```
or
```
[Text][Ref]
....
[Ref]: link
```
but not
```
[Text][link]
```