### PR TITLE
Updating the LaunchDarkly "short description"

### DIFF
--- a/launchdarkly/manifest.json
+++ b/launchdarkly/manifest.json
@@ -16,7 +16,7 @@
   "manifest_version": "1.0.1",
   "name": "launchdarkly",
   "public_title": "Datadog-LaunchDarkly Integration",
-  "short_description": "Track metrics from LaunchDarkly's relay proxy",
+  "short_description": "Monitor LaunchDarkly changes in Datadog",
   "support": "contrib",
   "type": "check",
   "metric_prefix": "launchdarkly_relay.",


### PR DESCRIPTION
### What does this PR do?

This pull request updates the "short description" to reflect what the [integration listing](https://docs.datadoghq.com/integrations/launchdarkly/) currently describes. The existing short description describes a former LaunchDarkly integration listing.

### Motivation

One of the LaunchDarkly engineers noticed the outdated tagline when hovering on our card on the search page.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?

How is the `metric_prefix` property used? Is it safe to change that to `launchdarkly.`? Similar to what I said above, the integration listing _used_ to be focused on LaunchDarkly's [Relay Proxy](https://docs.launchdarkly.com/home/advanced/relay-proxy) but that's no longer the case.