### PR TITLE
Change guid

### DIFF
--- a/open_policy_agent/manifest.json
+++ b/open_policy_agent/manifest.json
@@ -7,7 +7,7 @@
   "metric_to_check": "open_policy_agent.policies",
   "creates_events": false,
   "short_description": "OPA integration",
-  "guid": "a68c72bd-a16a-4fcf-8911-43575dd722b9",
+  "guid": "73fdfc40-51ea-11eb-ae93-0242ac130002",
   "support": "contrib",
   "supported_os": [
     "linux"


### PR DESCRIPTION
### What does this PR do?

The `guid` value for the OPA integration is identical to gatekeeper which is failing manifest validation in CI.
### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
