### PR TITLE
Fix php APCu rec monitor

### DIFF
--- a/php_apcu/assets/monitors/php-apcu_expunges.json
+++ b/php_apcu/assets/monitors/php-apcu_expunges.json
@@ -1,6 +1,6 @@
 {
     "name": "[php_apcu] Cache Full has been detected.",
-    "type": "metric alert",
+    "type": "query alert",
     "query": "max(last_5m):avg:php_apcu.cache.num_expunges{*} by {host} > 1",
     "message": "APCu Cache Full has been detected. All cache purged.",
     "tags": [

--- a/php_apcu/assets/monitors/php-apcu_high_usage.json
+++ b/php_apcu/assets/monitors/php-apcu_high_usage.json
@@ -1,6 +1,6 @@
 {
     "name": "[php_apcu] Detected High Cache Usage.",
-    "type": "metric alert",
+    "type": "query alert",
     "query": "avg(last_15m):( avg:php_apcu.cache.mem_size{*} / avg:php_apcu.sma.seg_size{*} ) * 100 > 90",
     "message": "APCu Detected High Cache Usage.",
     "tags": [


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with the php APCu recommended monitor that is causing staging to fail.
This changes `metric alert` to `query alert`.

### Motivation

Staging is failing.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
