### PR TITLE
Update install instructions

### DIFF
--- a/aqua/README.md
+++ b/aqua/README.md
@@ -15,35 +15,17 @@ need to install it yourself.
 
 If you are using Agent v6.8+ follow the instructions below to install the Aqua check on your host. See our dedicated Agent guide for [installing community integrations][3] to install checks with the [Agent prior to version 6.8][4] or the [Docker Agent][5]:
 
-1. Install the [developer toolkit][6].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][7].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `aqua` package, run:
-
-   ```shell
-   ddev -e release build aqua
-   ```
-
-5. [Download and launch the Datadog Agent][7].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_AQUA_ARTIFACT>/<AQUA_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][8].
 
 ### Configuration
+
+1. Configure your integration like [any other packaged integration][8].
+2. [Restart the Agent][10]
 
 #### Metric Collection
 

--- a/bind9/README.md
+++ b/bind9/README.md
@@ -16,33 +16,14 @@ The Bind9 check is **NOT** included in the [Datadog Agent][2] package.
 
 If you are using Agent v6.8+ follow the instructions below to install the Bind9 check on your host. See our dedicated Agent guide for [installing community integrations][3] to install checks with the [Agent prior v6.8][4] or the [Docker Agent][5]:
 
-1. Install the [developer toolkit][6].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][2].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `bind9` package, run:
-
-   ```shell
-   ddev -e release build bind9
-   ```
-
-5. [Download and launch the Datadog Agent][2].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_BIND9_ARTIFACT>/<BIND9_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][7].
+   
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -12,14 +12,7 @@ Follow the instructions below to install and configure this check for an Agent r
 
 To install the cert_manager check on your host:
 
-1. Install the [developer toolkit][3].
-2. Clone the `integrations-extras` repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+2. Clone the `integrations-extras` repository: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras

--- a/cyral/README.md
+++ b/cyral/README.md
@@ -12,7 +12,6 @@ Follow the instructions below to install and configure this check for an Agent r
 
 To install the Cyral check on your host:
 
-1. Install the [developer toolkit][8] on any machine.
 2. Run `ddev release build cyral` to build the package.
 3. [Download the Datadog Agent][9].
 4. Upload the build artifact to any host with an Agent and run `datadog-agent integration install -w path/to/cyral/dist/<ARTIFACT_NAME>.whl`.

--- a/eventstore/README.md
+++ b/eventstore/README.md
@@ -13,33 +13,14 @@ Get metrics from EventStore in real time to:
 
 If you are using Agent v6.8+ follow the instructions below to install the EventStore check on your host. See our dedicated Agent guide for [installing community integrations][1] to install checks with the [Agent prior to version 6.8][2] or the [Docker Agent][3]:
 
-1. Install the [developer toolkit][4].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][5].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
 
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `eventstore` package, run:
-
-   ```shell
-   ddev -e release build eventstore
-   ```
-
-5. [Download and launch the Datadog Agent][5].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_EVENTSTORE_ARTIFACT_>/<EVENTSTORE_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][6].
+3. Configure your integration like [any other packaged integration][6].
 
 ### Configuration
 

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -15,33 +15,12 @@ The Filebeat check is **NOT** included in the [Datadog Agent][1] package.
 
 If you are using Agent v6.8+ follow the instructions below to install the Filebeat check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior to version 6.8][3] or the [Docker Agent][4]:
 
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `filebeat` package, run:
-
-   ```shell
-   ddev -e release build filebeat
-   ```
-
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_FILEBEAT_ARTIFACT_>/<FILEBEAT_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/flume/README.md
+++ b/flume/README.md
@@ -10,8 +10,6 @@ This check monitors [Apache Flume][1].
 
 To install the Flume check on your host:
 
-1. Install the [developer toolkit][2].
-
 2. Run `ddev release build flume` to build the package.
 
 3. [Download the Datadog Agent][3].

--- a/gnatsd/README.md
+++ b/gnatsd/README.md
@@ -13,33 +13,14 @@ Get metrics from Gnatsd service in real time to:
 
 If you are using Agent v6.8+ follow the instructions below to install the Gnatsd check on your host. See our dedicated Agent guide for [installing community integrations][1] to install checks with the [Agent prior to version 6.8][2] or the [Docker Agent][3]:
 
-1. Install the [developer toolkit][4].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][5].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
 
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `gnatsd` package, run:
-
-   ```shell
-   ddev -e release build gnatsd
-   ```
-
-5. [Download and launch the Datadog Agent][5].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_GNATSD_ARTIFACT_>/<GNATSD_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][6].
+3. Configure your integration like [any other packaged integration][6].
 
 ### Configuration
 

--- a/gnatsd_streaming/README.md
+++ b/gnatsd_streaming/README.md
@@ -13,33 +13,14 @@ Get metrics from gnatsd_streaming service in real time to:
 
 If you are using Agent v6.8+ follow the instructions below to install the gnatsd_streaming check on your host. See our dedicated Agent guide for [installing community integrations][1] to install checks with the [Agent prior v6.8][2] or the [Docker Agent][3]:
 
-1. Install the [developer toolkit][4].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][5].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
 
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `gnatsd_streaming` package, run:
-
-   ```shell
-   ddev -e release build gnatsd_streaming
-   ```
-
-5. [Download and launch the Datadog Agent][5].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_GNATSD_STREAMING_ARTIFACT_>/<GNATSD_STREAMING_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][6].
+3. Configure your integration like [any other packaged integration][6].
 
 ### Configuration
 

--- a/hbase_master/README.md
+++ b/hbase_master/README.md
@@ -13,33 +13,14 @@ Get metrics from Hbase_master service in real time to:
 
 If you are using Agent v6.8+ follow the instructions below to install the Hbase_master check on your host. See our dedicated Agent guide for [installing community integrations][1] to install checks with the [Agent prior v6.8][2] or the [Docker Agent][3]:
 
-1. Install the [developer toolkit][4].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][5].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
 
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `hbase_master` package, run:
-
-   ```shell
-   ddev -e release build hbase_master
-   ```
-
-5. [Download and launch the Datadog Agent][5].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_HBASE_MASTER_ARTIFACT_>/<HBASE_MASTER_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][6].
+3. Configure your integration like [any other packaged integration][6].
 
 ### Configuration
 

--- a/hbase_regionserver/README.md
+++ b/hbase_regionserver/README.md
@@ -15,33 +15,14 @@ The HBase RegionServer check is **NOT** included in the [Datadog Agent][1] packa
 
 If you are using Agent v6.8+ follow the instructions below to install the HBase RegionServer check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
 
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
 
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `hbase_regionserver` package, run:
-
-   ```shell
-   ddev -e release build hbase_regionserver
-   ```
-
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_HBASE_REGIONSERVER_ARTIFACT_>/<HBASE_REGIONSERVER_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/lighthouse/README.md
+++ b/lighthouse/README.md
@@ -15,33 +15,14 @@ The Lighthouse check is not included in the [Datadog Agent][2] package, so you w
 
 If you are using Agent v6.8+ follow the instructions below to install the Google Chrome Lighthouse check on your host. See our dedicated Agent guide for [installing community integrations][3] to install checks with the [Agent prior to version 6.8][4] or the [Docker Agent][5]:
 
-1. Install the [developer toolkit][6].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][7].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
 
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `lighthouse` package, run:
-
-   ```shell
-   ddev -e release build lighthouse
-   ```
-
-5. [Download and launch the Datadog Agent][7].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_LIGHTHOUSE_ARTIFACT>/<LIGHTHOUSE_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][8].
+3. Configure your integration like [any other packaged integration][8].
 
 ### Configuration
 

--- a/logstash/README.md
+++ b/logstash/README.md
@@ -15,33 +15,14 @@ The Logstash check is **NOT** included in the [Datadog Agent][1] package.
 
 If you are using Agent v6.8+ follow the instructions below to install the Logstash check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
 
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
 
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `logstash` package, run:
-
-   ```shell
-   ddev -e release build logstash
-   ```
-
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_LOGSTASH_ARTIFACT_>/<LOGSTASH_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -15,33 +15,14 @@ The Neo4j check is **NOT** included in the [Datadog Agent][1] package.
 
 If you are using Agent v6.8+ follow the instructions below to install the Neo4j check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
 
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
 
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `neo4j` package, run:
-
-   ```shell
-   ddev -e release build neo4j
-   ```
-
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_NEO4J_ARTIFACT_>/<NEO4J_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/neutrona/README.md
+++ b/neutrona/README.md
@@ -12,33 +12,14 @@ This check monitors [Neutrona][1] cloud connectivity services to:
 
 If you are using Agent v6.8+ follow the instructions below to install the Neutrona check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
 
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `neutrona` package, run:
-
-   ```shell
-   ddev -e release build neutrona
-   ```
-
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_NEUTRONA_ARTIFACT_>/<NEUTRONA_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -8,16 +8,7 @@ This check monitors [Nextcloud][1].
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the Nextcloud check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
-
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the Nextcloud check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -29,14 +20,14 @@ If you are using Agent v6.8+ follow the instructions below to install the Nextcl
    ddev -e release build nextcloud
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_NEXTCLOUD_ARTIFACT_>/<NEXTCLOUD_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/nvml/README.md
+++ b/nvml/README.md
@@ -13,14 +13,7 @@ This package is **NOT** included in the [Datadog Agent][1] package.
 
 If you are using Agent v6.8+ follow the instructions below to install the check on your host. See the dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
 
-1. Install the [developer toolkit][5].
-2. Clone the `integrations-extras` repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+2. Clone the `integrations-extras` repository: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -32,8 +25,8 @@ If you are using Agent v6.8+ follow the instructions below to install the check 
    ddev -e release build nvml
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_NVML_ARTIFACT_>/<NVML_ARTIFACT_NAME>.whl
@@ -47,7 +40,7 @@ If you are using Docker, there is an example Dockerfile in the NVML repository.
    docker build --build-arg=DD_AGENT_VERSION=7.18.0 .
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 8. If you're using Docker and Kubernetes, you will need to expose the environment variables `NVIDIA_VISIBLE_DEVICES` and `NVIDIA_DRIVER_CAPABILITIES`. See the included Dockerfile for an example.
 

--- a/php_apcu/README.md
+++ b/php_apcu/README.md
@@ -13,8 +13,7 @@ Follow the instructions below to install and configure this check for an Agent r
 To install the `php_apcu` check on your host:
 
 
-1. Install the [developer toolkit][3].
- on any machine.
+on any machine.
 
 2. Run `ddev release build php_apcu` to build the package.
 

--- a/pihole/README.md
+++ b/pihole/README.md
@@ -12,7 +12,6 @@ Follow the instructions below to install and configure this check for an Agent r
 
 To install the Pi-hole check on your host:
 
-1. Install the [developer toolkit][3] on any machine.
 2. Run `ddev release build pihole` to build the package.
 3. [Download the Datadog Agent][4].
 4. Upload the build artifact to any host with an Agent and run `datadog-agent integration install -w path/to/pihole/dist/<ARTIFACT_NAME>.whl`.

--- a/ping/README.md
+++ b/ping/README.md
@@ -17,14 +17,9 @@ The Ping check is **NOT** included in the [Datadog Agent][2] package.
 
 If you are using Agent v6.8+ follow the instructions below to install the Ping check on your host. See our dedicated Agent guide for [installing community integrations][3] to install checks with the [Agent prior to version 6.8][4] or the [Docker Agent][5]:
 
-1. Install the [developer toolkit][6].
-2. Clone the integrations-extras repository:
-
-   ```shell
+```shell
    git clone https://github.com/DataDog/integrations-extras.git
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+   ``` your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -36,14 +31,14 @@ If you are using Agent v6.8+ follow the instructions below to install the Ping c
    ddev -e release build ping
    ```
 
-5. [Download and launch the Datadog Agent][7].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][7].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    sudo -u dd-agent datadog-agent integration install -w <PATH_OF_PING_ARTIFACT_>/<PING_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][8].
+3. Configure your integration like [any other packaged integration][8].
 
 ### Configuration
 

--- a/portworx/README.md
+++ b/portworx/README.md
@@ -11,16 +11,7 @@ Get metrics from Portworx service in real time to:
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the Portworx check on your host. See our dedicated Agent guide for [installing community integrations][1] to install checks with the [Agent prior to version 6.8][2] or the [Docker Agent][3]:
-
-1. Install the [developer toolkit][4].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the Portworx check on your host. See our dedicated Agent guide for [installing community integrations][1] to install checks with the [Agent prior to version 6.8][2] or the [Docker Agent][3]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -32,14 +23,14 @@ If you are using Agent v6.8+ follow the instructions below to install the Portwo
    ddev -e release build portworx
    ```
 
-5. [Download and launch the Datadog Agent][5].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][5].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_PORTWORX_ARTIFACT_>/<PORTWORX_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][6].
+3. Configure your integration like [any other packaged integration][6].
 
 ### Configuration
 

--- a/puma/README.md
+++ b/puma/README.md
@@ -12,7 +12,6 @@ Follow the instructions below to install and configure this check for an Agent r
 
 To install the Puma check on your host:
 
-1. Install the [developer toolkit][4] on any machine.
 2. Run `ddev release build puma` to build the package.
 3. [Download the Datadog Agent][5].
 4. Upload the build artifact to any host with an Agent and run `datadog-agent integration install -w path/to/puma/dist/<ARTIFACT_NAME>.whl`.

--- a/reboot_required/README.md
+++ b/reboot_required/README.md
@@ -8,35 +8,16 @@ Linux systems that are configured to autoinstall packages may not be configured 
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the Reboot Required check on your host. See our dedicated Agent guide for [installing community integrations][1] to install checks with the [Agent prior to version 6.8][2] or the [Docker Agent][3]:
+If you are using Agent v6.8+ follow the instructions below to install the Reboot Required check on your host. See our dedicated Agent guide for [installing community integrations][1] to install checks with the [Agent prior to version 6.8][2] or the [Docker Agent][3]: your `ddev` config with the `integrations-extras/` path:
 
-1. Install the [developer toolkit][4].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+1. [Download and launch the Datadog Agent][5].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
-   ddev config set extras ./integrations-extras
+   datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
    ```
 
-4. To build the `reboot_required` package, run:
-
-   ```shell
-   ddev -e release build reboot_required
-   ```
-
-5. [Download and launch the Datadog Agent][5].
-6. Run the following command to install the integrations wheel with the Agent:
-
-   ```shell
-   datadog-agent integration install -w <PATH_OF_REBOOT_REQUIRED_ARTIFACT_>/<REBOOT_REQUIRED_ARTIFACT_NAME>.whl
-   ```
-
-7. Configure your integration like [any other packaged integration][6].
+3. Configure your integration like [any other packaged integration][6].
 
 ### Configuration
 

--- a/redis_sentinel/README.md
+++ b/redis_sentinel/README.md
@@ -15,33 +15,14 @@ The Redis's Sentinel check is **NOT** included in the [Datadog Agent][1] package
 
 If you are using Agent v6.8+ follow the instructions below to install the Redis's Sentinel check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
 
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
-
-   ```shell
-   ddev config set extras ./integrations-extras
-   ```
-
-4. To build the `redis_sentinel` package, run:
-
-   ```shell
-   ddev -e release build redis_sentinel
-   ```
-
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_REDIS_SENTINEL_ARTIFACT_>/<REDIS_SENTINEL_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/riak_repl/README.md
+++ b/riak_repl/README.md
@@ -8,16 +8,7 @@ This check monitors Riak replication [riak-repl][1].
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the Riak-Repl check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
-
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the Riak-Repl check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -29,14 +20,14 @@ If you are using Agent v6.8+ follow the instructions below to install the Riak-R
    ddev -e release build riak_repl
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_RIAK_REPL_ARTIFACT_>/<RIAK_REPL_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/sendmail/README.md
+++ b/sendmail/README.md
@@ -8,16 +8,7 @@ This check monitors [Sendmail][1] through the Datadog Agent.
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the Sendmail check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
-
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the Sendmail check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -29,14 +20,14 @@ If you are using Agent v6.8+ follow the instructions below to install the Sendma
    ddev -e release build sendmail
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_SENDMAIL_ARTIFACT_>/<SENDMAIL_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/snmpwalk/README.md
+++ b/snmpwalk/README.md
@@ -13,16 +13,7 @@ The SNMP walk check is **NOT** included in the [Datadog Agent][1] package.
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the SNMP walk check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
-
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the SNMP walk check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -34,14 +25,14 @@ If you are using Agent v6.8+ follow the instructions below to install the SNMP w
    ddev -e release build snmpwalk
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_SNMPWALK_ARTIFACT_>/<SNMPWALK_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/sortdb/README.md
+++ b/sortdb/README.md
@@ -12,16 +12,7 @@ Get metrics from [Sortdb][1] service in real time to:
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the Sortdb check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
-
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the Sortdb check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -33,14 +24,14 @@ If you are using Agent v6.8+ follow the instructions below to install the Sortdb
    ddev -e release build sortdb
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_SORTDB_ARTIFACT_>/<SORTDB_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/stardog/README.md
+++ b/stardog/README.md
@@ -13,16 +13,7 @@ The Stardog check is **NOT** included in the [Datadog Agent][1] package.
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the Stardog check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
-
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the Stardog check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -34,14 +25,14 @@ If you are using Agent v6.8+ follow the instructions below to install the Stardo
    ddev -e release build stardog
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_STARDOG_ARTIFACT_>/<STARDOG_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/storm/README.md
+++ b/storm/README.md
@@ -13,16 +13,7 @@ The Storm check is **NOT** included in the [Datadog Agent][1] package.
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the Storm check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
-
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the Storm check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -34,14 +25,14 @@ If you are using Agent v6.8+ follow the instructions below to install the Storm 
    ddev -e release build storm
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_STORM_ARTIFACT_>/<STORM_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -12,16 +12,7 @@ This integration collects data from [Traefik][1] in order to check its health an
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the Traefik check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
-
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the Traefik check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -33,14 +24,14 @@ If you are using Agent v6.8+ follow the instructions below to install the Traefi
    ddev -e release build traefik
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_TRAEFIK_ARTIFACT_>/<TRAEFIK_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/unbound/README.md
+++ b/unbound/README.md
@@ -16,7 +16,6 @@ The Unbound check is **NOT** included in the [Datadog Agent][2] package.
 
 To install the Unbound check on your host:
 
-1. Install the [developer toolkit][3] on any machine.
 2. Run `ddev release build unbound` to build the package.
 3. [Install the Datadog Agent][4].
 4. Upload the build artifact to any host with an Agent and run `datadog-agent integration install -w path/to/unbound/dist/<ARTIFACT_NAshellME>.whl`.

--- a/upsc/README.md
+++ b/upsc/README.md
@@ -13,16 +13,7 @@ The UPSC check is **NOT** included in the [Datadog Agent][1] package.
 
 ### Installation
 
-If you are using Agent v6.8+ follow the instructions below to install the UPSD check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]:
-
-1. Install the [developer toolkit][5].
-2. Clone the integrations-extras repository:
-
-   ```shell
-   git clone https://github.com/DataDog/integrations-extras.git.
-   ```
-
-3. Update your `ddev` config with the `integrations-extras/` path:
+If you are using Agent v6.8+ follow the instructions below to install the UPSD check on your host. See our dedicated Agent guide for [installing community integrations][2] to install checks with the [Agent prior v6.8][3] or the [Docker Agent][4]: your `ddev` config with the `integrations-extras/` path:
 
    ```shell
    ddev config set extras ./integrations-extras
@@ -34,14 +25,14 @@ If you are using Agent v6.8+ follow the instructions below to install the UPSD c
    ddev -e release build upsc
    ```
 
-5. [Download and launch the Datadog Agent][6].
-6. Run the following command to install the integrations wheel with the Agent:
+1. [Download and launch the Datadog Agent][6].
+2. Run the following command to install the integrations wheel with the Agent:
 
    ```shell
    datadog-agent integration install -w <PATH_OF_UPSC_ARTIFACT_>/<UPSC_ARTIFACT_NAME>.whl
    ```
 
-7. Configure your integration like [any other packaged integration][7].
+3. Configure your integration like [any other packaged integration][7].
 
 ### Configuration
 

--- a/vespa/README.md
+++ b/vespa/README.md
@@ -15,7 +15,6 @@ The Vespa check is not included in the [Datadog Agent][2] package.
 
 To install the check on your host:
 
-1. Install the [developer toolkit][7] on any machine.
 2. Run `ddev release build vespa` to build the package.
 3. [Download the Datadog Agent][2].
 4. Upload the build artifact to any host with an Agent and run:

--- a/zabbix/README.md
+++ b/zabbix/README.md
@@ -12,7 +12,6 @@ Follow the instructions below to install and configure this check for an Agent r
 
 To install the Zabbix check on your host:
 
-1. Install the [developer toolkit][2] on any machine.
 2. Run `ddev release build zabbix` to build the package.
 3. [Download the Datadog Agent][3].
 4. Upload the build artifact to any host with an Agent and run `datadog-agent integration install -w path/to/zabbix/dist/<ARTIFACT_NAME>.whl`.


### PR DESCRIPTION
Update install instructions to use the `integration install` command instead of building the wheel