### PR TITLE
Fix embedded image link

### DIFF
--- a/nomad/README.md
+++ b/nomad/README.md
@@ -1,6 +1,6 @@
 # Agent Check: Nomad
 
-[!Nomad Dashboard][4]
+![Nomad Dashboard][4]
 
 ## Overview
 


### PR DESCRIPTION
### What does this PR do?
The Nomad doc currently has the image linked at the top with the hyperlink "!Nomad Dashboard". That is a typo as the ! should've gone before the brackets to embed the image like so: `![Nomad Dashboard][4]`

### Motivation

Fix broken embedded image

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
