### PR TITLE
encoded link for ping integration

### DIFF
--- a/ping/README.md
+++ b/ping/README.md
@@ -56,7 +56,7 @@ The Ping check does not include any events.
 
 Need help? Contact [Datadog support][11].
 
-[1]: https://en.wikipedia.org/wiki/Ping_(networking_utility)
+[1]: https://en.wikipedia.org/wiki/Ping_(networking_utility%29
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/
 [4]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentpriorto68


### PR DESCRIPTION
### What does this PR do?

Encodes the wikipedia link so it doesn't populate `)` in the docs

### Motivation

🙃 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [X] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)