### PR TITLE
Reflect correct metric_prefix

### DIFF
--- a/aws_pricing/manifest.json
+++ b/aws_pricing/manifest.json
@@ -4,7 +4,7 @@
   "maintainer": "tsein@brightcove.com",
   "manifest_version": "1.0.0",
   "name": "aws_pricing",
-  "metric_prefix": "aws_pricing.",
+  "metric_prefix": "aws.",
   "metric_to_check": "",
   "creates_events": false,
   "short_description": "Collect AWS Pricing information for services by rate code.",


### PR DESCRIPTION
### What does this PR do?

All metrics emited are prefixed `aws`
### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
