### PR TITLE
Fix categories

### DIFF
--- a/sleuth/manifest.json
+++ b/sleuth/manifest.json
@@ -17,9 +17,9 @@
   "public_title": "Datadog-Sleuth Integration",
   "categories": [
     "orchestration",
-    "issue-tracking",
+    "issue tracking",
     "collaboration",
-    "source-control"
+    "source control"
   ],
   "type": "crawler",
   "is_public": true,


### PR DESCRIPTION

### What does this PR do?

The hyphenated categories are creating duplicate filters on the docs website, converting these to spaces.

### Motivation

Someone mentioned the duplicates in slack #documentation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
