### PR TITLE
Fix tests for gnatsd streaming

### DIFF
--- a/gnatsd_streaming/tests/docker/config/Dockerfile
+++ b/gnatsd_streaming/tests/docker/config/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.15
 
 COPY script.sh /opt/local/script.sh
 


### PR DESCRIPTION
### What does this PR do?

Fixes tests for gnatsd_streaming. Fixes #812

Golang 1.16 changed dramatically how modules are handled, and thus made [this Docker image](https://github.com/DataDog/integrations-extras/blob/master/gnatsd_streaming/tests/docker/config/Dockerfile) not work anymore. Pinning to 1.15 workarounds the issue.

