### PR TITLE
Make nvml check quieter on non-GPU hosts

### DIFF
--- a/nvml/tests/Dockerfile
+++ b/nvml/tests/Dockerfile
@@ -13,7 +13,7 @@ ARG INTEGRATIONS_VERSION
 ARG DD_AGENT_VERSION
 WORKDIR /wheels
 
-RUN pip install "datadog-checks-dev[cli]==3.1.0"
+RUN python -m pip install --upgrade "datadog-checks-dev[cli]"
 RUN git clone https://github.com/datadog/integrations-extras.git && cd integrations-extras && git status && git reset --hard ${INTEGRATIONS_VERSION}
 
 RUN ddev config set extras ./integrations-extras

--- a/nvml/tests/test_nvml.py
+++ b/nvml/tests/test_nvml.py
@@ -11,6 +11,10 @@ from datadog_checks.nvml import NvmlCheck
 
 class MockNvml:
     @staticmethod
+    def is_nvml_library_available(i):
+        return True
+
+    @staticmethod
     def nvmlInit():
         pass
 


### PR DESCRIPTION
Check nvml library once at instantiation time and skip any further check runs if we failed
Also stop pinning datadog-checks-dev to 3.1.0

### What does this PR do?

This PR makes the check attempt to load libnvml just once, so that we don't fail every 15s on machines without a GPU.

### Motivation

See https://github.com/DataDog/integrations-extras/issues/803

We have many machines with GPUs, but at least as many without. We don't need the spam.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
