### PR TITLE
Fix ping check with bad float conversion

### DIFF
--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -14,7 +14,7 @@ class PingCheck(AgentCheck):
 
     def _load_conf(self, instance):
         # Fetches the conf
-        timeout = float(instance.get("timeout", 4))
+        timeout = int(instance.get("timeout", 4))
         response_time = instance.get("collect_response_time", False)
         custom_tags = instance.get("tags", [])
 


### PR DESCRIPTION
### What does this PR do?

the `ping` check casts the timeout parameter to float.

this result in running an invalid ping command
```
2021-03-04 20:25:47 UTC | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:126 in LogMessage) | ping:4b1a3ca7e11de8de | (ping.py:44) | Running: ping -c 1 -W 4.0 localhost
which yields an error
```
```
$ ping -c 1 -W 4.0 localhost
ping: invalid value (`4.0' near `.0')
```
unfortunately the type casting is hardcoded in the check code.

I have tested on linux (debian), Darwin and Windows and it seams ok to use `int` instead

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
