### PR TITLE
fixing issue that is breaking the documentation pipeline

### DIFF
--- a/octoprint/README.md
+++ b/octoprint/README.md
@@ -33,12 +33,6 @@ To install the OctoPrint check on your host:
 
 [Run the Agent's status subcommand][7] and look for `octoprint` under the Checks section.
 
-## Data Collected
-
-### Metrics
-
-See [metadata.csv][8] for a list of metrics provided by this integration.
-
 ### Logs
 
 By default this integration assumes that you are using the [OctoPi][8] image that is pre-configured to run OctoPrint from a Raspberry Pi.
@@ -64,6 +58,12 @@ OctoPrint uses its own log format (not an object format), so making better use o
             - `General_OctoPrint_Log %{date("yyyy-MM-dd HH:mm:ss,SSS"):date}\s+-\s+%{notSpace:source}\s+-\s+%{word:level}\s+-\s+%{data:message}`
 
 For more information, see the [Datadog Log Processing documentation][9].
+
+## Data Collected
+
+### Metrics
+
+See [metadata.csv][8] for a list of metrics provided by this integration.
 
 ### Service Checks
 


### PR DESCRIPTION
### What does this PR do?

The Logs section can't be in the Data Collected because that section has to follow the template for our build. I checked it locally and moving the content above the Data Collected section fixes the build

### Motivation

The documentation pipeline is broken. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

