### PR TITLE
Fix ACME HTTP metrics names

### DIFF
--- a/cert_manager/datadog_checks/cert_manager/metrics.py
+++ b/cert_manager/datadog_checks/cert_manager/metrics.py
@@ -5,7 +5,7 @@
 METRIC_MAP = {
     'certmanager_certificate_ready_status': 'certificate.ready_status',
     'certmanager_certificate_expiration_timestamp_seconds': 'certificate.expiration_timestamp',
-    'certmanager_acme_client_request_count': 'acme_client.request.count',
-    'certmanager_acme_client_request_duration_seconds': 'acme_client.request.duration',
+    'certmanager_http_acme_client_request_count': 'http_acme_client.request.count',
+    'certmanager_http_acme_client_request_duration_seconds': 'http_acme_client.request.duration',
     'certmanager_controller_sync_call_count': 'controller.sync_call.count',
 }

--- a/cert_manager/metadata.csv
+++ b/cert_manager/metadata.csv
@@ -2,8 +2,8 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 cert_manager.prometheus.health,gauge,,,,Whether the check is able to connect to the metrics endpoint,0,cert-manager,cm.health
 cert_manager.certificate.ready_status,gauge,,,,The ready status of the certificate,0,cert-manager,cm.cert_ready_status
 cert_manager.certificate.expiration_timestamp,gauge,,second,,The date after which the certificate expires. Expressed as a Unix Epoch Time,0,cert-manager,cm.cert_exp_time
-cert_manager.acme_client.request.count,count,,,,The number of requests made by the ACME client,1,cert-manager,cm.acme_req_cnt
-cert_manager.acme_client.request.duration.sum,gauge,,,,The sum of the HTTP request latencies in seconds for the ACME client,1,cert-manager,cm.req_duration.sum
-cert_manager.acme_client.request.duration.count,gauge,,,,The count of the HTTP request latencies in seconds for the ACME client,1,cert-manager,cm.req_duration.cnt
-cert_manager.acme_client.request.duration.quantile,gauge,,,,The quantiles of the HTTP request latencies in seconds for the ACME client,1,cert-manager,cm.req_duration.quant
+cert_manager.http_acme_client.request.count,count,,,,The number of requests made by the ACME client,1,cert-manager,cm.acme_req_cnt
+cert_manager.http_acme_client.request.duration.sum,gauge,,,,The sum of the HTTP request latencies in seconds for the ACME client,1,cert-manager,cm.req_duration.sum
+cert_manager.http_acme_client.request.duration.count,gauge,,,,The count of the HTTP request latencies in seconds for the ACME client,1,cert-manager,cm.req_duration.cnt
+cert_manager.http_acme_client.request.duration.quantile,gauge,,,,The quantiles of the HTTP request latencies in seconds for the ACME client,1,cert-manager,cm.req_duration.quant
 cert_manager.controller.sync_call.count,count,,,,The number of sync() calls made by a controller,1,cert-manager,cm.sync_call_cnt

--- a/cert_manager/tests/common.py
+++ b/cert_manager/tests/common.py
@@ -6,10 +6,10 @@ from datadog_checks.base.stubs import aggregator
 EXPECTED_METRICS = {
     'cert_manager.certificate.ready_status': aggregator.GAUGE,
     'cert_manager.certificate.expiration_timestamp': aggregator.GAUGE,
-    'cert_manager.acme_client.request.count': aggregator.MONOTONIC_COUNT,
-    'cert_manager.acme_client.request.duration.sum': aggregator.GAUGE,
-    'cert_manager.acme_client.request.duration.count': aggregator.GAUGE,
-    'cert_manager.acme_client.request.duration.quantile': aggregator.GAUGE,
+    'cert_manager.http_acme_client.request.count': aggregator.MONOTONIC_COUNT,
+    'cert_manager.http_acme_client.request.duration.sum': aggregator.GAUGE,
+    'cert_manager.http_acme_client.request.duration.count': aggregator.GAUGE,
+    'cert_manager.http_acme_client.request.duration.quantile': aggregator.GAUGE,
     'cert_manager.controller.sync_call.count': aggregator.MONOTONIC_COUNT,
     'cert_manager.prometheus.health': aggregator.GAUGE,
 }

--- a/cert_manager/tests/fixtures/cert_manager.txt
+++ b/cert_manager/tests/fixtures/cert_manager.txt
@@ -1,25 +1,65 @@
 # HELP certmanager_certificate_expiration_timestamp_seconds The date after which the certificate expires. Expressed as a Unix Epoch Time.
 # TYPE certmanager_certificate_expiration_timestamp_seconds gauge
-certmanager_certificate_expiration_timestamp_seconds{name="something",namespace="default"} 2.208988804e+09
+certmanager_certificate_expiration_timestamp_seconds{name="acme-cert",namespace="default"} 1.773579979e+09
+certmanager_certificate_expiration_timestamp_seconds{name="acme-cert2",namespace="default"} 0
+certmanager_certificate_expiration_timestamp_seconds{name="myingress-cert",namespace="cert-manager-test"} 1.622709533e+09
+certmanager_certificate_expiration_timestamp_seconds{name="selfsigned-cert",namespace="cert-manager-test"} 1.622708753e+09
 # HELP certmanager_certificate_ready_status The ready status of the certificate.
 # TYPE certmanager_certificate_ready_status gauge
-certmanager_certificate_ready_status{condition="False",name="something",namespace="default"} 0
-certmanager_certificate_ready_status{condition="True",name="something",namespace="default"} 1
-certmanager_certificate_ready_status{condition="Unknown",name="something",namespace="default"} 0
+certmanager_certificate_ready_status{condition="False",name="acme-cert",namespace="default"} 0
+certmanager_certificate_ready_status{condition="False",name="acme-cert2",namespace="default"} 1
+certmanager_certificate_ready_status{condition="False",name="myingress-cert",namespace="cert-manager-test"} 0
+certmanager_certificate_ready_status{condition="False",name="selfsigned-cert",namespace="cert-manager-test"} 0
+certmanager_certificate_ready_status{condition="True",name="acme-cert",namespace="default"} 1
+certmanager_certificate_ready_status{condition="True",name="acme-cert2",namespace="default"} 0
+certmanager_certificate_ready_status{condition="True",name="myingress-cert",namespace="cert-manager-test"} 1
+certmanager_certificate_ready_status{condition="True",name="selfsigned-cert",namespace="cert-manager-test"} 1
+certmanager_certificate_ready_status{condition="Unknown",name="acme-cert",namespace="default"} 0
+certmanager_certificate_ready_status{condition="Unknown",name="acme-cert2",namespace="default"} 0
+certmanager_certificate_ready_status{condition="Unknown",name="myingress-cert",namespace="cert-manager-test"} 0
+certmanager_certificate_ready_status{condition="Unknown",name="selfsigned-cert",namespace="cert-manager-test"} 0
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter
-certmanager_controller_sync_call_count{controller="certificaterequests"} 5
-certmanager_controller_sync_call_count{controller="challenges"} 48463
+certmanager_controller_sync_call_count{controller="CertificateIssuing"} 20
+certmanager_controller_sync_call_count{controller="CertificateKeyManager"} 16
+certmanager_controller_sync_call_count{controller="CertificateMetrics"} 15
+certmanager_controller_sync_call_count{controller="CertificateReadiness"} 35
+certmanager_controller_sync_call_count{controller="CertificateRequestManager"} 19
+certmanager_controller_sync_call_count{controller="CertificateTrigger"} 19
+certmanager_controller_sync_call_count{controller="certificaterequests-issuer-acme"} 11
+certmanager_controller_sync_call_count{controller="certificaterequests-issuer-ca"} 8
+certmanager_controller_sync_call_count{controller="certificaterequests-issuer-selfsigned"} 8
+certmanager_controller_sync_call_count{controller="certificaterequests-issuer-vault"} 8
+certmanager_controller_sync_call_count{controller="certificaterequests-issuer-venafi"} 8
+certmanager_controller_sync_call_count{controller="clusterissuers"} 1
 certmanager_controller_sync_call_count{controller="ingress-shim"} 1
-certmanager_controller_sync_call_count{controller="issuers"} 2
-certmanager_controller_sync_call_count{controller="orders"} 1
-# HELP certmanager_acme_client_request_count The number of requests made by the ACME client.
-# TYPE certmanager_acme_client_request_count counter
-certmanager_acme_client_request_count 3
-# HELP certmanager_acme_client_request_duration_seconds The HTTP request latencies in seconds for the ACME client.
-# TYPE certmanager_acme_client_request_duration_seconds summary 
-certmanager_acme_client_request_duration_seconds{quantile="0.5"} 6.4853e-05
-certmanager_acme_client_request_duration_seconds{quantile="0.9"} 0.00010102
-certmanager_acme_client_request_duration_seconds{quantile="0.99"} 0.000177367
-certmanager_acme_client_request_duration_seconds_sum 1.623860968846092e+06
-certmanager_acme_client_request_duration_seconds_count 1.112293682e+09
+certmanager_controller_sync_call_count{controller="issuers"} 1
+certmanager_controller_sync_call_count{controller="orders"} 4
+# HELP certmanager_http_acme_client_request_count The number of requests made by the ACME client.
+# TYPE certmanager_http_acme_client_request_count counter
+certmanager_http_acme_client_request_count{host="pebble.default.svc.cluster.local",method="GET",path="/dir",scheme="https",status="200"} 1
+certmanager_http_acme_client_request_count{host="pebble.default.svc.cluster.local",method="HEAD",path="/nonce-plz",scheme="https",status="200"} 1
+certmanager_http_acme_client_request_count{host="pebble.default.svc.cluster.local",method="POST",path="/order-plz",scheme="https",status="400"} 2
+certmanager_http_acme_client_request_count{host="pebble.default.svc.cluster.local",method="POST",path="/sign-me-up",scheme="https",status="400"} 2
+# HELP certmanager_http_acme_client_request_duration_seconds The HTTP request latencies in seconds for the ACME client.
+# TYPE certmanager_http_acme_client_request_duration_seconds summary
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="GET",path="/dir",scheme="https",status="200",quantile="0.5"} 0.044921499
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="GET",path="/dir",scheme="https",status="200",quantile="0.9"} 0.044921499
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="GET",path="/dir",scheme="https",status="200",quantile="0.99"} 0.044921499
+certmanager_http_acme_client_request_duration_seconds_sum{host="pebble.default.svc.cluster.local",method="GET",path="/dir",scheme="https",status="200"} 0.044921499
+certmanager_http_acme_client_request_duration_seconds_count{host="pebble.default.svc.cluster.local",method="GET",path="/dir",scheme="https",status="200"} 1
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="HEAD",path="/nonce-plz",scheme="https",status="200",quantile="0.5"} 0.002433074
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="HEAD",path="/nonce-plz",scheme="https",status="200",quantile="0.9"} 0.002433074
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="HEAD",path="/nonce-plz",scheme="https",status="200",quantile="0.99"} 0.002433074
+certmanager_http_acme_client_request_duration_seconds_sum{host="pebble.default.svc.cluster.local",method="HEAD",path="/nonce-plz",scheme="https",status="200"} 0.002433074
+certmanager_http_acme_client_request_duration_seconds_count{host="pebble.default.svc.cluster.local",method="HEAD",path="/nonce-plz",scheme="https",status="200"} 1
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="POST",path="/order-plz",scheme="https",status="400",quantile="0.5"} 0.002429659
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="POST",path="/order-plz",scheme="https",status="400",quantile="0.9"} 0.004111258
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="POST",path="/order-plz",scheme="https",status="400",quantile="0.99"} 0.004111258
+certmanager_http_acme_client_request_duration_seconds_sum{host="pebble.default.svc.cluster.local",method="POST",path="/order-plz",scheme="https",status="400"} 0.006540916999999999
+certmanager_http_acme_client_request_duration_seconds_count{host="pebble.default.svc.cluster.local",method="POST",path="/order-plz",scheme="https",status="400"} 2
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="POST",path="/sign-me-up",scheme="https",status="400",quantile="0.5"} 0.007592396
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="POST",path="/sign-me-up",scheme="https",status="400",quantile="0.9"} 0.009903988
+certmanager_http_acme_client_request_duration_seconds{host="pebble.default.svc.cluster.local",method="POST",path="/sign-me-up",scheme="https",status="400",quantile="0.99"} 0.009903988
+certmanager_http_acme_client_request_duration_seconds_sum{host="pebble.default.svc.cluster.local",method="POST",path="/sign-me-up",scheme="https",status="400"} 0.017496384
+certmanager_http_acme_client_request_duration_seconds_count{host="pebble.default.svc.cluster.local",method="POST",path="/sign-me-up",scheme="https",status="400"} 2


### PR DESCRIPTION
### What does this PR do?

Cert-Manager ACME related metrics changed their name in the latest versions. This PR uses the new naming convention.

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [X] Feature or bugfix has tests
- [X] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
