### PR TITLE
Fix hbase_master integration typo on `metrics.yaml` file

### DIFF
--- a/hbase_master/datadog_checks/hbase_master/data/metrics.yaml
+++ b/hbase_master/datadog_checks/hbase_master/data/metrics.yaml
@@ -6,7 +6,7 @@ jmx_metrics:
   - include:
       domain: Hadoop
       bean:
-       - Hadoop:service=HBase,name=Master,sub=AssignmentManger
+       - Hadoop:service=HBase,name=Master,sub=AssignmentManager
       attribute:
         # The age of the longest region in transition, in milliseconds
         ritOldestAge:


### PR DESCRIPTION

### What does this PR do?

Fix a typo on the `Hadoop:service=HBase,name=Master,sub=AssignmentManager` bean on hbase_master module

### Motivation

Found a bug

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [-] Feature or bugfix has tests
- [X] Git history is clean
- [-] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

