### PR TITLE
Add average_response_time_sec to traefik integration

### DIFF
--- a/traefik/datadog_checks/traefik/traefik.py
+++ b/traefik/datadog_checks/traefik/traefik.py
@@ -42,6 +42,11 @@ class TraefikCheck(AgentCheck):
                 else:
                     self.log.warning('Field total_count not found in response.')
 
+                if 'average_response_time_sec' in payload:
+                    self.gauge('traefik.average_response_time_sec', payload['average_response_time_sec'])
+                else:
+                    self.log.warning('Field average_response_time_sec not found in response.')
+
             else:
                 self.service_check(
                     'traefik.health', self.CRITICAL, message='Traefik health check return code is not 200'

--- a/traefik/datadog_checks/traefik/traefik.py
+++ b/traefik/datadog_checks/traefik/traefik.py
@@ -35,17 +35,17 @@ class TraefikCheck(AgentCheck):
                         self.gauge('traefik.total_status_code_count', count, ['status_code:{}'.format(status_code)])
 
                 else:
-                    self.log.warning('Field total_status_code_count not found in response.')
+                    self.log.debug('Field total_status_code_count not found in response.')
 
                 if 'total_count' in payload:
                     self.gauge('traefik.total_count', payload['total_count'])
                 else:
-                    self.log.warning('Field total_count not found in response.')
+                    self.log.debug('Field total_count not found in response.')
 
                 if 'average_response_time_sec' in payload:
                     self.gauge('traefik.average_response_time_sec', payload['average_response_time_sec'])
                 else:
-                    self.log.warning('Field average_response_time_sec not found in response.')
+                    self.log.debug('Field average_response_time_sec not found in response.')
 
             else:
                 self.service_check(


### PR DESCRIPTION
### What does this PR do?

Adds `average_response_time_sec` metric to the traefik integration.

### Motivation

The current traefik integration only tracks limited number of metrics; only two. The `average_response_time_sec` can help us set alerts based on the latency increases on the request served.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
