### PR TITLE
fix auth header formatting error in stardog integration

### DIFF
--- a/stardog/datadog_checks/stardog/stardog.py
+++ b/stardog/datadog_checks/stardog/stardog.py
@@ -123,7 +123,7 @@ class StardogCheck(AgentCheck):
 
     def check(self, instance):
         try:
-            auth_token = base64.b64encode(ensure_bytes(instance['username'] + ":" + instance['password']))
+            auth_token = base64.b64encode(ensure_bytes(instance["username"] + ":" + instance["password"])).decode()
             response = requests.get(
                 instance['stardog_url'] + '/admin/status', headers={'Authorization': 'Basic {}'.format(auth_token)}
             )

--- a/stardog/tests/test_stardog.py
+++ b/stardog/tests/test_stardog.py
@@ -60,6 +60,9 @@ class HttpServerThread(threading.Thread):
                 if self.path != '/admin/status':
                     self.send_response(404)
                     return
+                if self.headers["Authorization"] != "Basic YWRtaW46YWRtaW4=":
+                    self.send_response(401)
+                    return
                 self.send_response(200)
                 self.send_header('Content-type', 'application/json')
                 self.end_headers()


### PR DESCRIPTION
The stardog integration doesn't currently work with python 3, because of a formatting error with the auth header. The `auth_token` is a bytestring, and so `format` wraps it in `b'...'`. It needs a `decode` to get back to a string. Without it you get

    >>> "Basic {}".format(base64.b64encode(b"admin:admin"))
    "Basic b'YWRtaW46YWRtaW4='"

resulting in a 401 from stardog.

With the `decode`

    >>> "Basic {}".format(base64.b64encode(b"admin:admin").decode())
    'Basic YWRtaW46YWRtaW4='

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
