### PR TITLE
Bump nvml version to 1.0.1

### DIFF
--- a/nvml/CHANGELOG.md
+++ b/nvml/CHANGELOG.md
@@ -1,2 +1,5 @@
 # CHANGELOG - nvml
 
+## 1.0.1
+
+* [FIXED] Make nvml check quieter on non-GPU hosts (https://github.com/DataDog/integrations-extras/pull/817)

--- a/nvml/datadog_checks/nvml/__about__.py
+++ b/nvml/datadog_checks/nvml/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/nvml/manifest.json
+++ b/nvml/manifest.json
@@ -1,7 +1,7 @@
 {
   "display_name": "nvml",
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "1.0.0",
+  "manifest_version": "1.0.1",
   "name": "nvml",
   "metric_prefix": "nvml.",
   "metric_to_check": "nvml.device_count",


### PR DESCRIPTION
### What does this PR do?

A change was done in nvml (https://github.com/DataDog/integrations-extras/pull/817) that make nvml check quieter on non-gpu hosts. Updating version to 1.0.1 so that change can be consumed.

### Motivation

Unless the version is bumped up, I think we cannot utilize the update. Or am I missing something here?

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

