### PR TITLE
Update readme example for bind9

### DIFF
--- a/bind9/README.md
+++ b/bind9/README.md
@@ -33,7 +33,7 @@ If you are using Agent v6.8+ follow the instructions below to install the Bind9 
    init_config:
 
    instances:
-     - URL: "<BIND_9_STATS_URL>"
+     - url: "<BIND_9_STATS_URL>"
    ```
 
 2. [Restart the Agent][9]


### PR DESCRIPTION
### What does this PR do?

Update the example in the README for the bind9 integration to `url` instead of `URL` (per https://github.com/DataDog/integrations-extras/blob/master/bind9/datadog_checks/bind9/data/conf.yaml.example#L8)

### Motivation

Tried using `URL` and it didn't work :smile: 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
