### PR TITLE
Update Aqua check to use requests wrapper

### DIFF
--- a/aqua/datadog_checks/aqua/aqua.py
+++ b/aqua/datadog_checks/aqua/aqua.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import requests
 import simplejson as json
 from six.moves.urllib.parse import urljoin
 
@@ -81,7 +80,7 @@ class AquaCheck(AgentCheck):
         """
         headers = {'Content-Type': 'application/json', 'charset': 'UTF-8'}
         data = {"id": str(instance['api_user']), "password": str(instance['password'])}
-        res = requests.post(
+        res = self.http.post(
             instance['url'] + '/api/v1/login',
             data=json.dumps(data),
             headers=headers,
@@ -90,13 +89,12 @@ class AquaCheck(AgentCheck):
         res.raise_for_status()
         return json.loads(res.text)['token']
 
-    @classmethod
-    def _perform_query(cls, instance, route, token):
+    def _perform_query(self, instance, route, token):
         """
         Form queries and interact with the Aqua API.
         """
         headers = {'Content-Type': 'application/json', 'charset': 'UTF-8', 'Authorization': 'Bearer ' + token}
-        res = requests.get(urljoin(instance['url'], route), headers=headers, timeout=60)
+        res = self.http.get(urljoin(instance['url'], route), headers=headers, timeout=60)
         res.raise_for_status()
         return json.loads(res.text)
 


### PR DESCRIPTION
### What does this PR do?
- Updates the Aqua check to use the requests wrapper.
- Removes `requests` import from check

### Motivation

- Standardize http requests

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
