### PR TITLE
Update bind9 to use requests wrapper

### DIFF
--- a/bind9/datadog_checks/bind9/bind9.py
+++ b/bind9/datadog_checks/bind9/bind9.py
@@ -4,8 +4,6 @@
 import xml.etree.ElementTree as ET
 from datetime import datetime
 
-import requests
-
 from datadog_checks.base import AgentCheck, ConfigurationError
 
 EPOCH = datetime(1970, 1, 1)
@@ -33,7 +31,7 @@ class Bind9Check(AgentCheck):
 
     def getStatsFromUrl(self, dns_url):
         try:
-            response = requests.get(dns_url)
+            response = self.http.get(dns_url)
             response.raise_for_status()
         except Exception:
             self.service_check(self.BIND_SERVICE_CHECK, AgentCheck.CRITICAL, message="stats cannot be taken")


### PR DESCRIPTION
### What does this PR do?
- Updates bind9 to use requests wrapper
- Removes `requests` import

### Motivation
- Standardize http requests

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
