### PR TITLE
[documentation] fixing the documentation build

### DIFF
--- a/tidb/README.md
+++ b/tidb/README.md
@@ -170,9 +170,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 | -------------- | ------------------------------------------------------ |
 | `<LOG_CONFIG>` | `{"source": "tidb", "service": "tidb_cluster"}` |
 
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
-
 ### Validation
 
 [Run the Agent's status subcommand][5] and look for `tidb` under the Checks section.


### PR DESCRIPTION
### What does this PR do?

Removing spare shortcode that is breaking the documentation build.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
