### PR TITLE
Update Filebeat to use request wrapper

### DIFF
--- a/filebeat/assets/configuration/spec.yaml
+++ b/filebeat/assets/configuration/spec.yaml
@@ -6,6 +6,9 @@ files:
     options:
     - template: init_config/default
     - template: init_config/http
+      overrides:
+        timeout.value.display_default: 2
+        timeout.value.example: 2
   - template: instances
     options:
     - name: registry_file_path
@@ -50,3 +53,6 @@ files:
           - ^publish\.events$
     - template: instances/default
     - template: instances/http
+      overrides:
+        timeout.value.display_default: 2
+        timeout.value.example: 2

--- a/filebeat/assets/configuration/spec.yaml
+++ b/filebeat/assets/configuration/spec.yaml
@@ -5,6 +5,7 @@ files:
   - template: init_config
     options:
     - template: init_config/default
+    - template: init_config/http
   - template: instances
     options:
     - name: registry_file_path
@@ -33,6 +34,7 @@ files:
       value:
         type: boolean
         example: false
+        display_default: false
     - name: only_metrics
       required: true
       description: |
@@ -46,9 +48,5 @@ files:
         example:
           - ^filebeat
           - ^publish\.events$
-    - name: timeout
-      description: Timeout in seconds for the connection `registry_file_path`.
-      value:
-        type: integer
-        example: 2
     - template: instances/default
+    - template: instances/http

--- a/filebeat/datadog_checks/filebeat/data/conf.yaml.example
+++ b/filebeat/datadog_checks/filebeat/data/conf.yaml.example
@@ -9,6 +9,38 @@ init_config:
     #
     # service: <SERVICE>
 
+    ## @param proxy - mapping - optional
+    ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported like so:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for connecting to services.
+    #
+    # timeout: 10
+
 ## Every instance is scheduled independent of the others.
 #
 instances:
@@ -43,11 +75,6 @@ instances:
       - ^filebeat
       - ^publish\.events$
 
-    ## @param timeout - integer - optional - default: 2
-    ## Timeout in seconds for the connection `registry_file_path`.
-    #
-    # timeout: 2
-
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##
@@ -76,3 +103,281 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
+
+    ## @param proxy - mapping - optional
+    ## This overrides the `proxy` setting in `init_config`.
+    ##
+    ## Set HTTP or HTTPS proxies for this instance. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported, for example:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## This overrides the `skip_proxy` setting in `init_config`.
+    ##
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param auth_type - string - optional - default: basic
+    ## The type of authentication to use. The available types (and related options) are:
+    ##
+    ##   - basic
+    ##     |__ username
+    ##     |__ password
+    ##     |__ use_legacy_auth_encoding
+    ##   - digest
+    ##     |__ username
+    ##     |__ password
+    ##   - ntlm
+    ##     |__ ntlm_domain
+    ##     |__ password
+    ##   - kerberos
+    ##     |__ kerberos_auth
+    ##     |__ kerberos_cache
+    ##     |__ kerberos_delegate
+    ##     |__ kerberos_force_initiate
+    ##     |__ kerberos_hostname
+    ##     |__ kerberos_keytab
+    ##     |__ kerberos_principal
+    ##   - aws
+    ##     |__ aws_region
+    ##     |__ aws_host
+    ##     |__ aws_service
+    ##
+    ## The `aws` auth type relies on boto3 to automatically gather AWS credentials, for example: from `.aws/credentials`.
+    ## Details: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
+    #
+    # auth_type: basic
+
+    ## @param use_legacy_auth_encoding - boolean - optional - default: true
+    ## When `auth_type` is set to `basic`, this determines whether to encode as `latin1` rather than `utf-8`.
+    #
+    # use_legacy_auth_encoding: true
+
+    ## @param username - string - optional
+    ## The username to use if services are behind basic or digest auth.
+    #
+    # username: <USERNAME>
+
+    ## @param password - string - optional
+    ## The password to use if services are behind basic or NTLM auth.
+    #
+    # password: <PASSWORD>
+
+    ## @param ntlm_domain - string - optional
+    ## If your services use NTLM authentication, specify
+    ## the domain used in the check. For NTLM Auth, append
+    ## the username to domain, not as the `username` parameter.
+    #
+    # ntlm_domain: <NTLM_DOMAIN>\<USERNAME>
+
+    ## @param kerberos_auth - string - optional - default: disabled
+    ## If your services use Kerberos authentication, you can specify the Kerberos
+    ## strategy to use between:
+    ##
+    ##   - required
+    ##   - optional
+    ##   - disabled
+    ##
+    ## See https://github.com/requests/requests-kerberos#mutual-authentication
+    #
+    # kerberos_auth: disabled
+
+    ## @param kerberos_cache - string - optional
+    ## Sets the KRB5CCNAME environment variable.
+    ## It should point to a credential cache with a valid TGT.
+    #
+    # kerberos_cache: <KERBEROS_CACHE>
+
+    ## @param kerberos_delegate - boolean - optional - default: false
+    ## Set to `true` to enable Kerberos delegation of credentials to a server that requests delegation.
+    ##
+    ## See https://github.com/requests/requests-kerberos#delegation
+    #
+    # kerberos_delegate: false
+
+    ## @param kerberos_force_initiate - boolean - optional - default: false
+    ## Set to `true` to preemptively initiate the Kerberos GSS exchange and
+    ## present a Kerberos ticket on the initial request (and all subsequent).
+    ##
+    ## See https://github.com/requests/requests-kerberos#preemptive-authentication
+    #
+    # kerberos_force_initiate: false
+
+    ## @param kerberos_hostname - string - optional
+    ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't
+    ## match its Kerberos hostname, for example: behind a content switch or load balancer.
+    ##
+    ## See https://github.com/requests/requests-kerberos#hostname-override
+    #
+    # kerberos_hostname: <KERBEROS_HOSTNAME>
+
+    ## @param kerberos_principal - string - optional
+    ## Set an explicit principal, to force Kerberos to look for a
+    ## matching credential cache for the named user.
+    ##
+    ## See https://github.com/requests/requests-kerberos#explicit-principal
+    #
+    # kerberos_principal: <KERBEROS_PRINCIPAL>
+
+    ## @param kerberos_keytab - string - optional
+    ## Set the path to your Kerberos key tab file.
+    #
+    # kerberos_keytab: <KEYTAB_FILE_PATH>
+
+    ## @param auth_token - mapping - optional
+    ## This allows for the use of authentication information from dynamic sources.
+    ## Both a reader and writer must be configured.
+    ##
+    ## The available readers are:
+    ##
+    ##   - type: file
+    ##     path (required): The absolute path for the file to read from.
+    ##     pattern: A regular expression pattern with a single capture group used to find the
+    ##              token rather than using the entire file, for example: Your secret is (.+)
+    ##
+    ## The available writers are:
+    ##
+    ##   - type: header
+    ##     name (required): The name of the field, for example: Authorization
+    ##     value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
+    ##     placeholder: The substring in `value` to replace by the token, defaults to: <TOKEN>
+    #
+    # auth_token:
+    #   reader:
+    #     type: <READER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+    #   writer:
+    #     type: <WRITER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+
+    ## @param aws_region - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the region.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_region: <AWS_REGION>
+
+    ## @param aws_host - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the host.
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_host: <AWS_HOST>
+
+    ## @param aws_service - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the service code. For a list
+    ## of available service codes, see https://docs.aws.amazon.com/general/latest/gr/rande.html
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_service: <AWS_SERVICE>
+
+    ## @param tls_verify - boolean - optional - default: true
+    ## Instructs the check to validate the TLS certificate of services.
+    #
+    # tls_verify: true
+
+    ## @param tls_use_host_header - boolean - optional - default: false
+    ## If a `Host` header is set, this enables its use for SNI (matching against the TLS certificate CN or SAN).
+    #
+    # tls_use_host_header: false
+
+    ## @param tls_ignore_warning - boolean - optional - default: false
+    ## If `tls_verify` is disabled, security warnings are logged by the check.
+    ## Disable those by setting `tls_ignore_warning` to true.
+    ##
+    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
+    ## If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
+    ## to true.
+    #
+    # tls_ignore_warning: false
+
+    ## @param tls_cert - string - optional
+    ## The path to a single file in PEM format containing a certificate as well as any
+    ## number of CA certificates needed to establish the certificate's authenticity for
+    ## use when connecting to services. It may also contain an unencrypted private key to use.
+    #
+    # tls_cert: <CERT_PATH>
+
+    ## @param tls_private_key - string - optional
+    ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
+    ## required if `tls_cert` is set and it does not already contain a private key.
+    #
+    # tls_private_key: <PRIVATE_KEY_PATH>
+
+    ## @param tls_ca_cert - string - optional
+    ## The path to a file of concatenated CA certificates in PEM format or a directory
+    ## containing several CA certificates in PEM format. If a directory, the directory
+    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
+    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    #
+    # tls_ca_cert: <CA_CERT_PATH>
+
+    ## @param headers - mapping - optional
+    ## The headers parameter allows you to send specific headers with every request.
+    ## You can use it for explicitly specifying the host header or adding headers for
+    ## authorization purposes.
+    ##
+    ## This overrides any default headers.
+    #
+    # headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param extra_headers - mapping - optional
+    ## Additional headers to send with every request.
+    #
+    # extra_headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for accessing services.
+    ##
+    ## This overrides the `timeout` setting in `init_config`.
+    #
+    # timeout: 10
+
+    ## @param connect_timeout - number - optional
+    ## The connect timeout for accessing services. Defaults to `timeout`.
+    #
+    # connect_timeout: <CONNECT_TIMEOUT>
+
+    ## @param read_timeout - number - optional
+    ## The read timeout for accessing services. Defaults to `timeout`.
+    #
+    # read_timeout: <READ_TIMEOUT>
+
+    ## @param log_requests - boolean - optional - default: false
+    ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
+    #
+    # log_requests: false
+
+    ## @param persist_connections - boolean - optional - default: false
+    ## Whether or not to persist cookies and use connection pooling for increased performance.
+    #
+    # persist_connections: false

--- a/filebeat/datadog_checks/filebeat/data/conf.yaml.example
+++ b/filebeat/datadog_checks/filebeat/data/conf.yaml.example
@@ -36,10 +36,10 @@ init_config:
     #
     # skip_proxy: false
 
-    ## @param timeout - number - optional - default: 10
+    ## @param timeout - number - optional - default: 2
     ## The timeout for connecting to services.
     #
-    # timeout: 10
+    # timeout: 2
 
 ## Every instance is scheduled independent of the others.
 #
@@ -355,12 +355,12 @@ instances:
     #   Host: <ALTERNATIVE_HOSTNAME>
     #   X-Auth-Token: <AUTH_TOKEN>
 
-    ## @param timeout - number - optional - default: 10
+    ## @param timeout - number - optional - default: 2
     ## The timeout for accessing services.
     ##
     ## This overrides the `timeout` setting in `init_config`.
     #
-    # timeout: 10
+    # timeout: 2
 
     ## @param connect_timeout - number - optional
     ## The connect timeout for accessing services. Defaults to `timeout`.

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -216,6 +216,11 @@ class FilebeatCheck(AgentCheck):
         AgentCheck.__init__(self, *args, **kwargs)
         self.instance_cache = {}
 
+        # preserve backwards compatible default timeouts
+        if self.instance and self.instance.get('timeout') is None:
+            if self.init_config.get('timeout') is None:
+                self.init_config['timeout'] = 2
+
     def check(self, instance):
         normalize_metrics = is_affirmative(instance.get("normalize_metrics", False))
 

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -219,7 +219,7 @@ class FilebeatCheck(AgentCheck):
         # preserve backwards compatible default timeouts
         if self.instance and self.instance.get('timeout') is None:
             if self.init_config.get('timeout') is None:
-                self.init_config['timeout'] = 2
+                self.instance['timeout'] = 2
 
     def check(self, instance):
         normalize_metrics = is_affirmative(instance.get("normalize_metrics", False))

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -208,9 +208,9 @@ class FilebeatCheckInstanceConfig:
 
 class FilebeatCheck(AgentCheck):
 
-    SERVICE_CHECK_NAME = 'filebeat.can_connect'
+    SERVICE_CHECK_NAME = 'can_connect'
 
-    METRIC_PREFIX = "filebeat."
+    __NAMESPACE__ = "filebeat"
 
     def __init__(self, *args, **kwargs):
         AgentCheck.__init__(self, *args, **kwargs)
@@ -265,7 +265,7 @@ class FilebeatCheck(AgentCheck):
             if self._is_same_file(stats, item["FileStateOS"]):
                 unprocessed_bytes = stats.st_size - offset
 
-                self.gauge("filebeat.registry.unprocessed_bytes", unprocessed_bytes, tags=["source:{0}".format(source)])
+                self.gauge("registry.unprocessed_bytes", unprocessed_bytes, tags=["source:{0}".format(source)])
             else:
                 self.log.debug("Filebeat source %s appears to have changed", source)
         except OSError:
@@ -291,7 +291,8 @@ class FilebeatCheck(AgentCheck):
             method = getattr(self, action)
 
             for name, value in iteritems(metrics):
-                if not name.startswith(self.METRIC_PREFIX) and normalize_metrics:
-                    name = self.METRIC_PREFIX + name
-                method(name, value, tags)
+                if not name.startswith(self.__NAMESPACE__) and normalize_metrics:
+                    method(name, value, tags)
+                else:
+                    method(name, value, tags, raw=True)
         self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=tags)

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -5,12 +5,10 @@
 # stdlib
 import errno
 import json
-import numbers
 import os
 import re
 import sre_constants
 
-import requests
 import six
 from six import iteritems
 
@@ -88,8 +86,9 @@ class FilebeatCheckHttpProfiler:
 
     VARS_ROUTE = "debug/vars"
 
-    def __init__(self, config):
+    def __init__(self, config, http):
         self._config = config
+        self._http = http
         self._previous_increment_values = {}
         # regex matching ain't free, let's cache this
         self._should_keep_metrics = {}
@@ -104,7 +103,7 @@ class FilebeatCheckHttpProfiler:
 
     def _make_request(self):
 
-        response = requests.get(self._config.stats_endpoint, timeout=self._config.timeout)
+        response = self._http.get(self._config.stats_endpoint)
         response.raise_for_status()
 
         return self.flatten(response.json())
@@ -175,10 +174,6 @@ class FilebeatCheckInstanceConfig:
                 "If given, filebeat's only_metrics must be a list of regexes, got %s" % (self._only_metrics,)
             )
 
-        self._timeout = instance.get("timeout", 2)
-        if not isinstance(self._timeout, numbers.Real) or self._timeout <= 0:
-            raise Exception("If given, filebeats timeout must be a positive number, got %s" % (self._timeout,))
-
     @property
     def registry_file_path(self):
         return self._registry_file_path
@@ -186,10 +181,6 @@ class FilebeatCheckInstanceConfig:
     @property
     def stats_endpoint(self):
         return self._stats_endpoint
-
-    @property
-    def timeout(self):
-        return self._timeout
 
     def should_keep_metric(self, metric_name):
 
@@ -234,7 +225,7 @@ class FilebeatCheck(AgentCheck):
             profiler = self.instance_cache[instance_key]["profiler"]
         else:
             config = FilebeatCheckInstanceConfig(instance)
-            profiler = FilebeatCheckHttpProfiler(config)
+            profiler = FilebeatCheckHttpProfiler(config, self.http)
             self.instance_cache[instance_key] = {"config": config, "profiler": profiler}
 
         self._process_registry(config)

--- a/filebeat/tests/test_filebeat.py
+++ b/filebeat/tests/test_filebeat.py
@@ -438,6 +438,7 @@ def test_negative_timeout():
     _assert_config_raises({"port": 82, "timeout": 0}, "must be a positive number")
     _assert_config_raises({"port": 82, "timeout": -0.5}, "must be a positive number")
 
+
 @pytest.mark.parametrize(
     'init_config, instance, expected_timeout',
     [
@@ -449,6 +450,7 @@ def test_negative_timeout():
 def test_default_timeout(init_config, instance, expected_timeout):
     check = FilebeatCheck("filebeat", init_config, [instance])
     assert check.http.options['timeout'] == expected_timeout
+
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')

--- a/filebeat/tests/test_filebeat.py
+++ b/filebeat/tests/test_filebeat.py
@@ -438,6 +438,17 @@ def test_negative_timeout():
     _assert_config_raises({"port": 82, "timeout": 0}, "must be a positive number")
     _assert_config_raises({"port": 82, "timeout": -0.5}, "must be a positive number")
 
+@pytest.mark.parametrize(
+    'init_config, instance, expected_timeout',
+    [
+        pytest.param({}, _build_instance("empty", stats_endpoint="http://localhost:9999", timeout=8), (8.0, 8.0)),
+        pytest.param({'timeout': 8}, _build_instance("empty", stats_endpoint="http://localhost:9999"), (8.0, 8.0)),
+        pytest.param({}, _build_instance("empty", stats_endpoint="http://localhost:9999"), (2.0, 2.0)),
+    ],
+)
+def test_default_timeout(init_config, instance, expected_timeout):
+    check = FilebeatCheck("filebeat", init_config, [instance])
+    assert check.http.options['timeout'] == expected_timeout
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')


### PR DESCRIPTION
### What does this PR do?
- Updates Filebeat to use RequestsWrapper
- Modifies `normalize_metrics` logic to use base class namespace formatting
- Updates tests to use instance when instantiating check

### Motivation
- Standardize behavior for HTTP requests
- Leverage standard functionality of base class for formatting metric names

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
