### PR TITLE
Broken docs build. Only single backticks on inline monospace

### DIFF
--- a/n2ws/README.md
+++ b/n2ws/README.md
@@ -21,7 +21,7 @@ and more by Datadog monitoring service. This integration allows users to monitor
         [external_monitoring]
         enabled=True
         ```
-    - Run ```service apache2 restart```.
+    - Run `service apache2 restart`
 
 3.	##### Install the Datadog Agent on your N2WS Instance.
     Login to Datadog and go to Integrations -> Agent -> Ubuntu


### PR DESCRIPTION
### What does this PR do?

Fixes broken docs build


### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
