### PR TITLE
[documentation] removing the text that is breaking the automation

### DIFF
--- a/statsig/README.md
+++ b/statsig/README.md
@@ -23,7 +23,7 @@ The Statsig integration does not collect any data from Datadog.
 
 ### Metrics
 
-See [metadata.csv][2] for a list of metrics provided by this integration and the description of each.
+See [metadata.csv][2] for a list of metrics provided by this integration.
 
 ### Service Checks
 


### PR DESCRIPTION
### What does this PR do?

Removes the text that is making this show up oddly in the docs. https://docs.datadoghq.com/integrations/statsig/#metrics

The sentence has to be precise.

### Motivation

Better docs for a better world!

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

