### PR TITLE
(DOCS-2047) Remove broken images

### DIFF
--- a/stackpulse/README.md
+++ b/stackpulse/README.md
@@ -98,6 +98,6 @@ Need help? Contact [Datadog support][11].
 [3]: https://app.stackpulse.io/integrations/datadog?create=true
 [5]: https://app.datadoghq.com/account/settings#integrations/webhooks
 [7]: https://docs.datadoghq.com/monitors/manage_monitor/
-[8]: https://app.stackpulse.io/integrations/datadog%20api%20keys?create=tru
+[8]: https://app.stackpulse.io/integrations/datadog%20api%20keys?create=true
 [10]: https://github.com/stackpulse/steps/tree/master/steps/datadog/post-event
 [11]: https://docs.datadoghq.com/help/

--- a/stackpulse/README.md
+++ b/stackpulse/README.md
@@ -12,8 +12,6 @@ To set up this integration, you must have an active [StackPulse account][2] and 
 
 1. On the **Integrations** page under **Monitoring**, locate the **Datadog** card and click [**New**][2].
 
-    ![Datadog Card][4]
-
 2. Provide a meaningful name for the integration and click **Add**.
 
 3. **Copy** the newly created webhook endpoint.
@@ -21,8 +19,6 @@ To set up this integration, you must have an active [StackPulse account][2] and 
 ### In Datadog
 
 1. Navigate to **Integrations** and choose the [**Webhooks**][5] card.
-
-    ![Datadog Webhook Card][6]
 
 2. Click on **New** to add a new Webhook integration.
 
@@ -77,8 +73,6 @@ To set up this integration, you must have an active [StackPulse account][2] and 
 
 1. On the **Integrations** page under **Secrets**, locate the **Datadog API Keys** card and click [**Add**][8].
 
-    ![Datadog API Keys Card][9]
-
 2. Provide a meaningful name for the integration and click **Add**.
 
 ## Data Collected
@@ -102,11 +96,8 @@ Need help? Contact [Datadog support][11].
 [1]: https://stackpulse.com
 [2]: https://stackpulse.com/get-started/
 [3]: https://app.stackpulse.io/integrations/datadog?create=true
-[4]: ./images/datadog_card.png
 [5]: https://app.datadoghq.com/account/settings#integrations/webhooks
-[6]: ./images/datadog_app_webhook.png
 [7]: https://docs.datadoghq.com/monitors/manage_monitor/
-[8]: https://app.stackpulse.io/integrations/datadog%20api%20keys?create=true
-[9]: ./images/datadog_api_card.png
+[8]: https://app.stackpulse.io/integrations/datadog%20api%20keys?create=tru
 [10]: https://github.com/stackpulse/steps/tree/master/steps/datadog/post-event
 [11]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

The images are broken on https://docs.datadoghq.com/integrations/stackpulse/ and are not necessary for a user's success anyway, so removing them and the overhead of having to maintain them is the best move.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
