### PR TITLE
[skip ci] fix ns1 footer link duplicate

### DIFF
--- a/ns1/README.md
+++ b/ns1/README.md
@@ -66,7 +66,6 @@ For more details about this integration, see the [NS1 + Datadog Integration][9] 
 [3]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=agentabovev68
 [4]: https://docs.datadoghq.com/getting_started/integrations/#configuring-agent-integrations
 [5]: https://github.com/DataDog/integrations-extras/blob/master/ns1/datadog_checks/ns1/data/conf.yaml.example
-[7]: hhttps://github.com/DataDog/integrations-extras/blob/master/ns1/metadata.csv
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [7]: https://github.com/DataDog/integrations-extras/blob/master/ns1/metadata.csv
 [8]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?

This PR removes a duplicate link `[7]` from the ns1 readme.

### Motivation

To fix a build issue

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
