### PR TITLE
Fix typo in statsig integrations link

### DIFF
--- a/statsig/README.md
+++ b/statsig/README.md
@@ -37,6 +37,6 @@ The Statsig integration sends configuration change events on Statsig to Datadog.
 
 Need help? Contact Statsig Support at support@statsig.com or [contact us here][3]
 
-[1]: https://console.statsig.com/integration
+[1]: https://console.statsig.com/integrations
 [2]: https://github.com/DataDog/integrations-extras/blob/master/statsig/metadata.csv
 [3]: https://www.statsig.com/contact


### PR DESCRIPTION
### What does this PR do?

Fix a typo in the Statsig Integrations link (go to /integrations instead of /integration)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
