### PR TITLE
fix riak tests

### DIFF
--- a/riak_repl/tests/conftest.py
+++ b/riak_repl/tests/conftest.py
@@ -11,7 +11,7 @@ from .common import HERE, URL
 @pytest.fixture(scope='session')
 def dd_environment():
     compose_file = os.path.join(HERE, 'docker', 'docker-compose.yml')
-    log_patterns = 'Fullsync complete from riak-west-1 to riak-east-1'
+    log_patterns = 'Fullsync complete from'
 
     with docker_run(
         compose_file=compose_file,

--- a/riak_repl/tests/test_check.py
+++ b/riak_repl/tests/test_check.py
@@ -1,6 +1,7 @@
 import pytest
 
 from datadog_checks.base.errors import CheckException
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.riak_repl import RiakReplCheck
 
 from .common import INSTANCE
@@ -31,7 +32,7 @@ def test_config():
 
 
 @pytest.mark.integration
-def test_service_check(aggregator, dd_environment):
+def test_check(aggregator, dd_environment):
     init_config = {
         'keys': [
             "riak_repl.server_bytes_sent",
@@ -88,7 +89,8 @@ def test_service_check(aggregator, dd_environment):
     c.check(INSTANCE)
 
     for key in init_config['keys']:
-        aggregator.assert_metric(key, tags=[])
+        aggregator.assert_metric(key, tags=[], at_least=0)
 
     # Assert coverage for this check on this instance
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/riak_repl/tests/test_check.py
+++ b/riak_repl/tests/test_check.py
@@ -1,7 +1,6 @@
 import pytest
 
 from datadog_checks.base.errors import CheckException
-from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.riak_repl import RiakReplCheck
 
 from .common import INSTANCE
@@ -94,4 +93,4 @@ def test_check(aggregator, dd_environment):
     # Assert coverage for this check on this instance
     aggregator.assert_all_metrics_covered()
     # TODO: there are metrics missing in metadata.csv
-    #aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+    # aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/riak_repl/tests/test_check.py
+++ b/riak_repl/tests/test_check.py
@@ -1,6 +1,7 @@
 import pytest
 
 from datadog_checks.base.errors import CheckException
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.riak_repl import RiakReplCheck
 
 from .common import INSTANCE
@@ -93,4 +94,15 @@ def test_check(aggregator, dd_environment):
     # Assert coverage for this check on this instance
     aggregator.assert_all_metrics_covered()
     # TODO: there are metrics missing in metadata.csv
-    # aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+    missing_metrics = [
+        'riak_repl.realtime_queue_stats.consumers.drops',
+        'riak_repl.realtime_queue_stats.consumers.errs',
+        'riak_repl.realtime_queue_stats.consumers.pending',
+        'riak_repl.realtime_queue_stats.consumers.unacked',
+        'riak_repl.realtime_sink.connected.deactivated',
+        'riak_repl.realtime_sink.connected.pending',
+        'riak_repl.realtime_sink.connected.source_drops',
+        'riak_repl.realtime_source.connected.hb_rtt',
+        'riak_repl.realtime_source.connected.objects',
+    ]
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=missing_metrics)

--- a/riak_repl/tests/test_check.py
+++ b/riak_repl/tests/test_check.py
@@ -93,4 +93,5 @@ def test_check(aggregator, dd_environment):
 
     # Assert coverage for this check on this instance
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+    # TODO: there are metrics missing in metadata.csv
+    #aggregator.assert_metrics_using_metadata(get_metadata_metrics())


### PR DESCRIPTION
Test setup was sometimes failing because the full sync log entry some times appears east to west and some times west to east. Also some of the metrics like riak_repl.fullsync_coordinator.last_fullsync_duration seems to not be present on every check run.
Tried to add medatata assertion for completeness but there are missing metrics

