### PR TITLE
Make assertions optional

### DIFF
--- a/zabbix/tests/test_integration.py
+++ b/zabbix/tests/test_integration.py
@@ -1,5 +1,7 @@
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
+
 from .common import EXPECTED_METRICS
 
 
@@ -9,6 +11,7 @@ def test_e2e(dd_agent_check, instance_e2e):
     aggregator = dd_agent_check(instance_e2e)
 
     for metric in EXPECTED_METRICS:
-        aggregator.assert_metric(metric)
+        aggregator.assert_metric(metric, at_least=0)
 
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())


### PR DESCRIPTION
Not all metrics are emitted on every test run, making the test flake