### PR TITLE
(DOCS) Add blog link for vercel

### DIFF
--- a/vercel/README.md
+++ b/vercel/README.md
@@ -36,6 +36,9 @@ The Vercel integration does not include any events.
 
 Need help? Contact [Datadog support][8].
 
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/vercel/images/logo-full-black.png
 [2]: https://vercel.com/

--- a/vercel/manifest.json
+++ b/vercel/manifest.json
@@ -31,5 +31,10 @@
     "service_checks": "assets/service_checks.json",
     "logs": {},
     "metrics_metadata": "metadata.csv"
-  }
+  },
+  "further_reading": [
+    {"link": "https://www.datadoghq.com/blog/monitor-vercel-serverless-functions-with-datadog/",
+      "tag": "Blog",
+      "text": "Monitor Vercel Serverless Functions with Datadog"
+    }]
 }


### PR DESCRIPTION
### What does this PR do?

Adds the further reading section to the readme and the new blog link about vercel

### Motivation

Docs on call tasks

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
