### PR TITLE
Use https for downloading

### DIFF
--- a/resin/tests/docker/Dockerfile
+++ b/resin/tests/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --update \
     && rm -rf /var/cache/apk/*
 
 RUN CHK_SUM=05461c51fa94ab1a304481d0d9cbab64f5772eb9119289db696b868e4adba57d && \
-  curl -Lo /tmp/resin.tar.gz 'http://caucho.com/download/resin-4.0.62.tar.gz' && \
+  curl -Lo /tmp/resin.tar.gz 'https://caucho.com/download/resin-4.0.62.tar.gz' && \
   sha256sum /tmp/resin.tar.gz && \
   echo "${CHK_SUM}  /tmp/resin.tar.gz" | sha256sum -c - && \
   mkdir -p /opt/resin && \


### PR DESCRIPTION
Fix url for downloading resin tar