### PR TITLE
Fix flaky resin

### DIFF
--- a/resin/tests/conftest.py
+++ b/resin/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import pytest
 
@@ -15,5 +14,4 @@ def dd_environment():
     compose_file = os.path.join(HERE, 'docker', 'docker-compose.yml')
     with docker_run(compose_file, conditions=[CheckDockerLogs(compose_file, 'Resin/4.0.62 started -server')]):
         instance = load_jmx_config()
-        time.sleep(15)  # There are no more logs to check
         yield instance, {'use_jmx': True}


### PR DESCRIPTION
Some times resin takes a while to start emitting metrics but there is no proper way to check (there are no more logs beyond starting).
This change moves the sleep from conftest into a loop in the test itself to wait for metrics to be sent.