### PR TITLE
Make all manifest versions 1.0.0

### DIFF
--- a/apollo/manifest.json
+++ b/apollo/manifest.json
@@ -8,7 +8,7 @@
     "mac_os",
     "windows"
   ],
-  "manifest_version": "1.2.0",
+  "manifest_version": "1.0.0",
   "maintainer": "sachin@apollographql.com",
   "display_name": "Apollo Engine",
   "short_description": "Monitor the performance of your GraphQL infrastructure",

--- a/buddy/manifest.json
+++ b/buddy/manifest.json
@@ -1,7 +1,7 @@
 {
   "integration_id": "buddy",
   "name": "buddy",
-  "manifest_version": "1.0.2",
+  "manifest_version": "1.0.0",
   "maintainer": "support@buddy.works",
   "display_name": "Buddy",
   "short_description": "One-click delivery automation with working website previews for web developers.",

--- a/convox/manifest.json
+++ b/convox/manifest.json
@@ -1,7 +1,7 @@
 {
   "integration_id": "convox",
   "name": "convox",
-  "manifest_version": "1.0.1",
+  "manifest_version": "1.0.0",
   "display_name": "Convox",
   "short_description": "Convox is an open-source PaaS designed for total privacy and zero upkeep.",
   "creates_events": false,

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -1,7 +1,7 @@
 {
   "integration_id": "eventstore",
   "maintainer": "@xorima",
-  "manifest_version": "1.1.0",
+  "manifest_version": "1.0.0",
   "name": "eventstore",
   "display_name": "Eventstore",
   "short_description": "Collects Eventstore Metrics",

--- a/jfrog_platform/manifest.json
+++ b/jfrog_platform/manifest.json
@@ -1,7 +1,7 @@
 {
   "display_name": "JFrog Platform",
   "maintainer": "integrations@jfrog.com",
-  "manifest_version": "2.0.0",
+  "manifest_version": "1.0.0",
   "name": "jfrog_platform",
   "metric_prefix": "jfrog.",
   "metric_to_check": "jfrog.artifactory.app_disk_free_bytes",

--- a/launchdarkly/manifest.json
+++ b/launchdarkly/manifest.json
@@ -13,7 +13,7 @@
   "guid": "a1441ba8-be33-4123-8808-5a87cd696b64",
   "is_public": true,
   "maintainer": "support@launchdarkly",
-  "manifest_version": "1.0.1",
+  "manifest_version": "1.0.0",
   "name": "launchdarkly",
   "public_title": "Datadog-LaunchDarkly Integration",
   "short_description": "Monitor LaunchDarkly changes in Datadog",

--- a/lighthouse/manifest.json
+++ b/lighthouse/manifest.json
@@ -2,7 +2,7 @@
   "integration_id": "lighthouse",
   "display_name": "Lighthouse",
   "maintainer": "mustin.eric@gmail.com",
-  "manifest_version": "2.0.0",
+  "manifest_version": "1.0.0",
   "name": "lighthouse",
   "metric_prefix": "lighthouse.",
   "metric_to_check": "lighthouse.performance",

--- a/logzio/manifest.json
+++ b/logzio/manifest.json
@@ -1,7 +1,7 @@
 {
   "integration_id": "logz-io",
   "name": "logzio",
-  "manifest_version": "1.0.2",
+  "manifest_version": "1.0.0",
   "display_name": "Logz.io",
   "short_description": "AI-Powered ELK as a Service",
   "creates_events": false,

--- a/nvml/manifest.json
+++ b/nvml/manifest.json
@@ -1,7 +1,7 @@
 {
   "display_name": "nvml",
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "1.0.1",
+  "manifest_version": "1.0.0",
   "name": "nvml",
   "metric_prefix": "nvml.",
   "metric_to_check": "nvml.device_count",

--- a/rbltracker/manifest.json
+++ b/rbltracker/manifest.json
@@ -1,7 +1,7 @@
 {
   "integration_id": "rbltracker",
   "name": "rbltracker",
-  "manifest_version": "1.0.1",
+  "manifest_version": "1.0.0",
   "display_name": "RBLTracker",
   "short_description": "RBLTracker provides easy-to-use, real-time blacklist monitoring.",
   "metric_prefix": "",

--- a/redis_sentinel/manifest.json
+++ b/redis_sentinel/manifest.json
@@ -1,7 +1,7 @@
 {
   "integration_id": "redis-sentinel",
   "maintainer": "@krasnoukhov",
-  "manifest_version": "1.1.0",
+  "manifest_version": "1.0.0",
   "name": "redis_sentinel",
   "display_name": "Redis Sentinel",
   "guid": "8efe0a8c-88c6-4a2f-aa04-60d92051c458",

--- a/split/manifest.json
+++ b/split/manifest.json
@@ -1,7 +1,7 @@
 {
   "integration_id": "split",
   "maintainer": "jeremy-lq",
-  "manifest_version": "1.0.1",
+  "manifest_version": "1.0.0",
   "name": "split",
   "display_name": "Split",
   "guid": "2c48dd0b-418f-4ca7-9b8d-54c857587db4",

--- a/traefik/manifest.json
+++ b/traefik/manifest.json
@@ -2,7 +2,7 @@
   "integration_id": "traefik",
   "display_name": "Traefik",
   "maintainer": "@renaudhager",
-  "manifest_version": "1.1.0",
+  "manifest_version": "1.0.0",
   "name": "traefik",
   "short_description": "collects traefik metrics",
   "support": "contrib",

--- a/vns3/manifest.json
+++ b/vns3/manifest.json
@@ -12,7 +12,7 @@
     "mac_os",
     "windows"
   ],
-  "manifest_version": "1.0.2",
+  "manifest_version": "1.0.0",
   "display_name": "VNS3",
   "short_description": "Cloud network appliance for application connectivity and security.",
   "metric_prefix": "vns3.",


### PR DESCRIPTION
### What does this PR do?

Updates all manifest versions to be 1.0.0

### Motivation

No other manifest versions are supported at this time. Fixing this is a pre-requisite to allowing other manifest versions to be implemented. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
