### PR TITLE
Add instructions to get filebeat integration versions

### DIFF
--- a/filebeat/CHANGELOG.md
+++ b/filebeat/CHANGELOG.md
@@ -1,13 +1,16 @@
 # CHANGELOG - Filebeat Integration
 
-0.3.0
+1.0.0 
+=====
+
+0.3.0 / Unreleased
 =====
 
 ### Add service check
 
 * [FEATURE] Add [Service check](https://docs.datadoghq.com/developers/service_checks/agent_service_checks_submission/)
 
-0.2.0
+0.2.0 / Unreleased
 =====
 
 ### Making the filebeat check compatible with versions > 5.x, and making it able to use the HTTP profiler
@@ -15,7 +18,7 @@
 * [BUG] This patch makes the filebeat check compatible with the new syntax Filebeat started using in versions 5.x and later for its registry file. It still maintains backward compatibility with the syntax from previous versions.
 * [FEATURE] Makes it possible to push to Datadog the metrics Filebeat exposes via its HTTP profiler, when started with the `--httpprof [HOST]:PORT` option (see https://www.elastic.co/guide/en/beats/filebeat/current/command-line-options.html)
 
-0.1.0 
+0.1.0 / Unreleased
 =====
 ### Initial version
 

--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -23,6 +23,8 @@ If you are using Agent v6.8+ follow the instructions below to install the Filebe
    ```
 3. Configure your integration like [any other packaged integration][6].
 
+See the [Changelog](https://github.com/DataDog/integrations-extras/blob/master/filebeat/CHANGELOG.md) for the available integration versions.
+
 ### Configuration
 
 1. Edit the `filebeat.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][7] to start collecting your Filebeat [metrics](#metric-collection). See the [sample filebeat.d/conf.yaml][8] for all available configuration options.


### PR DESCRIPTION
### What does this PR do?

Add instruction to get filebeat integration versions.

### Motivation

I was using the filebeat integration for the first time and found it difficult to know what the integration versions were. Had to do some digging to figure out to check the changelog.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Issue created on the docs repo [here](https://github.com/DataDog/documentation/issues/11379)