### PR TITLE
Remove generic tag checking

### DIFF
--- a/filebeat/tox.ini
+++ b/filebeat/tox.ini
@@ -22,3 +22,5 @@ passenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true


### PR DESCRIPTION
### What does this PR do?

Remove generic tag checking that was failing on py2 CI

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

pinging @wk8 as integration maintainer 
