### PR TITLE
Add Doc_Link For Vercel Integration Search

### DIFF
--- a/vercel/manifest.json
+++ b/vercel/manifest.json
@@ -15,7 +15,7 @@
     "windows"
   ],
   "public_title": "Vercel",
-  "categories": ["monitoring"],
+  "categories": ["web"],
   "type": "check",
   "doc_link": "https://docs.datadoghq.com/integrations/vercel/",
   "is_public": true,

--- a/vercel/manifest.json
+++ b/vercel/manifest.json
@@ -6,7 +6,7 @@
   "metric_prefix": "vercel.",
   "metric_to_check": "",
   "creates_events": false,
-  "short_description": "Monitor your serverless applications running on Vercel",
+  "short_description": "Monitor your serverless applications running on Vercel.",
   "guid": "cf0daf64-9c85-43b1-8b6b-7d08f8d31b0f",
   "support": "contrib",
   "supported_os": [
@@ -15,10 +15,9 @@
     "windows"
   ],
   "public_title": "Vercel",
-  "categories": [
-    ""
-  ],
+  "categories": ["monitoring"],
   "type": "check",
+  "doc_link": "https://docs.datadoghq.com/integrations/vercel/",
   "is_public": true,
   "integration_id": "vercel",
   "assets": {


### PR DESCRIPTION
### What does this PR do?

Adds a `doc_link` to the manifest.json of the Vercel integration.

### Motivation

[Slack chat](https://dd.slack.com/archives/C0DESMBQU/p1631049110162100?thread_ts=1631042962.160300&cid=C0DESMBQU) with Stephen P.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
