### PR TITLE
Remove metadata for invalid service check

### DIFF
--- a/storm/assets/service_checks.json
+++ b/storm/assets/service_checks.json
@@ -1,14 +1,1 @@
-[
-    {
-        "agent_version": "6.3.0",
-        "integration": "storm",
-        "check": "topology-check.{}",
-        "statuses": [
-            "ok",
-            "critical"
-        ],
-        "groups": [],
-        "name": "Topology Active",
-        "description": "Returns `CRITICAL` if the topology is not active, returns `OK` otherwise."
-    }
-]
+[]


### PR DESCRIPTION
### Motivation

Rather than using a tag the name is dynamic https://github.com/DataDog/integrations-extras/blob/730f68da1c23d06a78fa8ad404b3163e9f62c44a/storm/datadog_checks/storm/storm.py#L899-L904