### PR TITLE
Ping on Windows - Set codepage to English

### DIFF
--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -26,7 +26,7 @@ class PingCheck(AgentCheck):
 
     def _exec_ping(self, timeout, target_host):
         if platform.system() == "Windows":  # pragma: nocover
-            precmd = ["cmd", "/c", "chcp 437 &"]   # Set code page to English for non-US Windows
+            precmd = ["cmd", "/c", "chcp 437 &"]  # Set code page to English for non-US Windows
             countOption = "-n"
             timeoutOption = "-w"
             # The timeout option is in ms on Windows
@@ -48,7 +48,8 @@ class PingCheck(AgentCheck):
 
         lines, err, retcode = get_subprocess_output(
             precmd + ["ping", countOption, "1", timeoutOption, str(timeout), target_host],
-            self.log, raise_on_empty_output=True
+            self.log,
+            raise_on_empty_output=True
         )
         self.log.debug("ping returned %s - %s - %s", retcode, lines, err)
         if retcode != 0:

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -49,7 +49,7 @@ class PingCheck(AgentCheck):
         lines, err, retcode = get_subprocess_output(
             precmd + ["ping", countOption, "1", timeoutOption, str(timeout), target_host],
             self.log,
-            raise_on_empty_output=True
+            raise_on_empty_output=True,
         )
         self.log.debug("ping returned %s - %s - %s", retcode, lines, err)
         if retcode != 0:

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -25,6 +25,7 @@ class PingCheck(AgentCheck):
         return host, custom_tags, timeout, response_time
 
     def _exec_ping(self, timeout, target_host):
+        precmd = []
         if platform.system() == "Windows":  # pragma: nocover
             precmd = ["cmd", "/c", "chcp 437 &"]  # Set code page to English for non-US Windows
             countOption = "-n"
@@ -33,14 +34,12 @@ class PingCheck(AgentCheck):
             # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/ping
             timeout = timeout * 1000
         elif platform.system() == "Darwin":
-            precmd = []
             countOption = "-c"
             timeoutOption = "-W"  # Also in ms on Mac
             timeout = timeout * 1000
         else:
             # The timeout option is is seconds on Linux, leaving timeout as is
             # https://linux.die.net/man/8/ping
-            precmd = []
             countOption = "-c"
             timeoutOption = "-W"
 

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -26,25 +26,28 @@ class PingCheck(AgentCheck):
 
     def _exec_ping(self, timeout, target_host):
         if platform.system() == "Windows":  # pragma: nocover
+            precmd = ["cmd", "/c", "chcp 437 &"] # Set code page to English for non-US Windows
             countOption = "-n"
             timeoutOption = "-w"
             # The timeout option is in ms on Windows
             # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/ping
             timeout = timeout * 1000
         elif platform.system() == "Darwin":
+            precmd = []
             countOption = "-c"
             timeoutOption = "-W"  # Also in ms on Mac
             timeout = timeout * 1000
         else:
             # The timeout option is is seconds on Linux, leaving timeout as is
             # https://linux.die.net/man/8/ping
+            precmd = []
             countOption = "-c"
             timeoutOption = "-W"
 
         self.log.debug("Running: ping %s %s %s %s %s", countOption, "1", timeoutOption, timeout, target_host)
 
         lines, err, retcode = get_subprocess_output(
-            ["ping", countOption, "1", timeoutOption, str(timeout), target_host], self.log, raise_on_empty_output=True
+            precmd + ["ping", countOption, "1", timeoutOption, str(timeout), target_host], self.log, raise_on_empty_output=True
         )
         self.log.debug("ping returned %s - %s - %s", retcode, lines, err)
         if retcode != 0:

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -26,7 +26,7 @@ class PingCheck(AgentCheck):
 
     def _exec_ping(self, timeout, target_host):
         if platform.system() == "Windows":  # pragma: nocover
-            precmd = ["cmd", "/c", "chcp 437 &"] # Set code page to English for non-US Windows
+            precmd = ["cmd", "/c", "chcp 437 &"]   # Set code page to English for non-US Windows
             countOption = "-n"
             timeoutOption = "-w"
             # The timeout option is in ms on Windows
@@ -47,7 +47,8 @@ class PingCheck(AgentCheck):
         self.log.debug("Running: ping %s %s %s %s %s", countOption, "1", timeoutOption, timeout, target_host)
 
         lines, err, retcode = get_subprocess_output(
-            precmd + ["ping", countOption, "1", timeoutOption, str(timeout), target_host], self.log, raise_on_empty_output=True
+            precmd + ["ping", countOption, "1", timeoutOption, str(timeout), target_host],
+            self.log, raise_on_empty_output=True
         )
         self.log.debug("ping returned %s - %s - %s", retcode, lines, err)
         if retcode != 0:


### PR DESCRIPTION
### What does this PR do?

On non-US Windows, output of the ping.exe is localized.
It breaks the ping check and results in error.
To avoid this, I added the code to set the code page to English.
chcp and code page: [docs](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/chcp)

### Motivation

Feedback and support tickets from users.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
