### PR TITLE
Remove incorrect per_unit_name

### DIFF
--- a/upsc/metadata.csv
+++ b/upsc/metadata.csv
@@ -3,8 +3,8 @@ upsc.status,gauge,,sample,,UPS Status,1,upsc,status
 upsc.battery.charge,gauge,,sample,percent,UPS Charge,1,upsc,charge %
 upsc.battery.charge.low,gauge,,sample,percent,UPS Charge Low Threshold,1,upsc,low charge %
 upsc.battery.charge.warning,gauge,,sample,percent,UPS Charge Warn Threshold,1,upsc,warn charge %
-upsc.battery.runtime,gauge,,minute,minute,UPS Runtime Remaining,1,upsc,runtime min
-upsc.battery.runtime.low,gauge,,minute,minute,UPS Runtime Low Threshold,1,upsc,runtime low min threshold
+upsc.battery.runtime,gauge,,minute,,UPS Runtime Remaining,1,upsc,runtime min
+upsc.battery.runtime.low,gauge,,minute,,UPS Runtime Low Threshold,1,upsc,runtime low min threshold
 upsc.battery.voltage,gauge,,sample,,UPS Battery Voltage,1,upsc,V
 upsc.battery.voltage.nominal,gauge,,sample,,UPS Battery Nominal Voltage,1,upsc,V
 upsc.input.voltage,gauge,,sample,,UPS Input Voltage,1,upsc,V


### PR DESCRIPTION
### What does this PR do?

The per_unit_name is invalid and unable to be synced. For `upsc.battery.runtime` and `upsc.battery.runtime.low` metrics, the unit/per_unit_name is minute/minute which is invalid.

### Motivation
https://docs.datadoghq.com/developers/integrations/legacy/#metadatacsv
> per_unit_name: If you are gathering a per unit metric, you may provide an additional unit name here and it’s combined with the unit_name. For example, providing a unit_name of “request” and a per_unit_name of “second” results in a metric of “requests per second”. If provided, this must be a value from the available units listed above.


@platinummonkey, removing per_unit_name for `upsc.battery.runtime` and `upsc.battery.runtime.low` for now to sync upsc integration. The `per_unit_name` field is optional, you can open a follow up PR to fix if the per_unit_name is required.
### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
