### PR TITLE
(DOCS-2514) Prepend install command with sudo

### DIFF
--- a/pihole/README.md
+++ b/pihole/README.md
@@ -15,7 +15,7 @@ For Agent v7.21+ / v6.21+, follow the instructions below to install the Pi-hole 
 1. Run the following command to install the Agent integration:
 
    ```shell
-   datadog-agent integration install -t datadog-pihole==<INTEGRATION_VERSION>
+   sudo -u dd-agent -- datadog-agent integration install -t datadog-pihole==<INTEGRATION_VERSION>
    ```
 
 2. Configure your integration similar to core [integrations][4].


### PR DESCRIPTION


### What does this PR do?

A user was having issues with install (https://github.com/DataDog/integrations-extras/issues/998) and said docs were out of date/incorrect and that this line needed to be prepended with sudo.

### Motivation

Correcting docs

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
