### PR TITLE
Remove message from OK service checks

### DIFF
--- a/bind9/datadog_checks/bind9/bind9.py
+++ b/bind9/datadog_checks/bind9/bind9.py
@@ -19,7 +19,7 @@ class Bind9Check(AgentCheck):
         if not dns_url:
             raise ConfigurationError('The statistic channel URL must be specified in the configuration')
 
-        self.service_check(self.BIND_SERVICE_CHECK, AgentCheck.OK, message='Connection to %s was successful' % dns_url)
+        self.service_check(self.BIND_SERVICE_CHECK, AgentCheck.OK)
 
         root = self.getStatsFromUrl(dns_url)
         self.collectTimeMetric(root, 'boot-time')

--- a/cloudsmith/datadog_checks/cloudsmith/check.py
+++ b/cloudsmith/datadog_checks/cloudsmith/check.py
@@ -230,11 +230,15 @@ class CloudsmithCheck(AgentCheck):
         self.service_check(
             'storage',
             usage_info['storage_mark'],
-            message="Percentage storage used: {}%".format(usage_info['storage_used']),
+            message="Percentage storage used: {}%".format(usage_info['storage_used'])
+            if usage_info['storage_used'] != AgentCheck.OK
+            else "",
         )
 
         self.service_check(
             'bandwidth',
             usage_info['bandwidth_mark'],
-            message="Percentage bandwidth used: {}%".format(usage_info['bandwidth_used']),
+            message="Percentage bandwidth used: {}%".format(usage_info['bandwidth_used'])
+            if usage_info['bandwidth_mark'] != AgentCheck.OK
+            else "",
         )

--- a/cloudsmith/datadog_checks/cloudsmith/check.py
+++ b/cloudsmith/datadog_checks/cloudsmith/check.py
@@ -227,18 +227,16 @@ class CloudsmithCheck(AgentCheck):
         self.gauge("token_bandwidth_total", entitlement_info['token_bandwidth_total'], tags=self.tags)
         self.gauge("token_download_total", entitlement_info['token_download_total'], tags=self.tags)
 
+        storage_msg = "Percentage storage used: {}%".format(usage_info['storage_used'])
         self.service_check(
             'storage',
             usage_info['storage_mark'],
-            message="Percentage storage used: {}%".format(usage_info['storage_used'])
-            if usage_info['storage_used'] != AgentCheck.OK
-            else "",
+            message=storage_msg if usage_info['storage_mark'] != AgentCheck.OK else "",
         )
 
+        bandwith_msg = "Percentage bandwidth used: {}%".format(usage_info['bandwidth_used'])
         self.service_check(
             'bandwidth',
             usage_info['bandwidth_mark'],
-            message="Percentage bandwidth used: {}%".format(usage_info['bandwidth_used'])
-            if usage_info['bandwidth_mark'] != AgentCheck.OK
-            else "",
+            message=bandwith_msg if usage_info['bandwidth_mark'] != AgentCheck.OK else "",
         )

--- a/sendmail/datadog_checks/sendmail/sendmail.py
+++ b/sendmail/datadog_checks/sendmail/sendmail.py
@@ -24,7 +24,7 @@ class SendmailCheck(AgentCheck):
             self.gauge('sendmail.queue.size', queue_size, tags=tags + ['queue:total'])
             self.log.debug("Sendmail queue size: %s mails", queue_size)
             # Send an OK service check as well
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags, message='Sendmail OK')
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags)
         except OSError as e:
             self.log.info("Cannot get sendmail queue info: %s", e)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags, message=str(e))

--- a/sortdb/datadog_checks/sortdb/check.py
+++ b/sortdb/datadog_checks/sortdb/check.py
@@ -63,7 +63,6 @@ class SortdbCheck(AgentCheck):
             self.SORTDB_SERVICE_CHECK,
             AgentCheck.OK,
             tags=instance_tags,
-            message='Connection to %s was successful' % sortdb_url,
         )
 
         # get and set metrics

--- a/storm/datadog_checks/storm/storm.py
+++ b/storm/datadog_checks/storm/storm.py
@@ -896,10 +896,11 @@ class StormCheck(AgentCheck):
                         if topology_status is None:
                             topology_status = _get_string(stats, 'unknown', 'status').upper()
                             check_status = AgentCheck.CRITICAL if topology_status != 'ACTIVE' else AgentCheck.OK
+                            topology_message = '{} topology status marked as: {}'.format(topology_name, topology_status)
                             self.service_check(
                                 'topology_check.{}'.format(topology_name),
                                 status=check_status,
-                                message='{} topology status marked as: {}'.format(topology_name, topology_status),
+                                message=topology_message if check_status != AgentCheck.OK else "",
                                 tags=['stormEnvironment:{}'.format(self.environment_name)] + self.additional_tags,
                             )
                     except Exception:  # noqa

--- a/vespa/datadog_checks/vespa/vespa.py
+++ b/vespa/datadog_checks/vespa/vespa.py
@@ -40,8 +40,7 @@ class VespaCheck(AgentCheck):
                     self._emit_metrics(service_name, metrics, instance_tags)
 
             self.log.info("Forwarded %s metrics to hq for %s services", self.metric_count, self.services_up)
-            self.service_check(self.METRICS_SERVICE_CHECK, AgentCheck.OK, tags=instance_tags,
-                               message="Metrics collected successfully for consumer {}".format(consumer))
+            self.service_check(self.METRICS_SERVICE_CHECK, AgentCheck.OK, tags=instance_tags)
         except Timeout as e:
             self._report_metrics_error("Timed out connecting to Vespa's node metrics api: {}".format(e),
                                        AgentCheck.CRITICAL, instance_tags)
@@ -58,7 +57,7 @@ class VespaCheck(AgentCheck):
     def _report_metrics_error(self, msg, level, instance_tags):
         self.log.warning(msg)
         self.service_check(self.METRICS_SERVICE_CHECK, level, tags=instance_tags,
-                           message=msg)
+                           message=msg if level != self.OK else "")
         self.service_check(self.PROCESS_SERVICE_CHECK, AgentCheck.WARNING, tags=instance_tags,
                            message="Problem getting metrics from Vespa's node metrics api")
         self.log.warning("Issued a warning to " + self.PROCESS_SERVICE_CHECK +
@@ -111,8 +110,7 @@ class VespaCheck(AgentCheck):
 
         tags = tags + instance_tags
         if code == "up":
-            self.service_check(self.PROCESS_SERVICE_CHECK, AgentCheck.OK, tags=tags,
-                               message="Service {} returns up".format(service_name))
+            self.service_check(self.PROCESS_SERVICE_CHECK, AgentCheck.OK, tags=tags)
             self.services_up += 1
         elif code == "down":
             self.service_check(self.PROCESS_SERVICE_CHECK, AgentCheck.CRITICAL, tags=tags,

--- a/vespa/tests/test_vespa.py
+++ b/vespa/tests/test_vespa.py
@@ -80,7 +80,6 @@ def test_down_service_does_not_raise(aggregator):
     aggregator.assert_service_check(check.PROCESS_SERVICE_CHECK,
                                     VespaCheck.OK,
                                     count=1,
-                                    message='Service vespa.up-service returns up',
                                     tags=['instance:up-service', 'vespaVersion:7.0.0',
                                           'vespa-service:vespa.up-service', 'tag1:val1'])
     assert 3 == check.metric_count


### PR DESCRIPTION
### What does this PR do?

Service check returning OK should no longer send a message

### Motivation

https://github.com/DataDog/integrations-core/pull/9898

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Pinging integrations maintainers:
* bind9: @ashuvyas45 
* cloudsmith: @cloudsmith
* sendmail: @dabcoder
* sortdb: @namrata4
* storm: @platinummonkey 
* vespa: @gjoranv 
