### PR TITLE
Link default dashboard for Vercel integration

### DIFF
--- a/vercel/manifest.json
+++ b/vercel/manifest.json
@@ -25,7 +25,9 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "dashboards": {},
+    "dashboards": {
+      "Vercel": "assets/dashboards/vercel_overview.json"
+    },
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",


### PR DESCRIPTION
### What does this PR do?

Links the default dashboard for the Vercel integration. 

### Motivation

This is currently broken, so customers who set up this integration today do not have this dashboard created.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
