### PR TITLE
Updates e2e port forwarding

### DIFF
--- a/gatekeeper/tests/conftest.py
+++ b/gatekeeper/tests/conftest.py
@@ -64,7 +64,7 @@ def dd_environment():
             ]
             ip_ports_health = [
                 stack.enter_context(
-                    port_forward(kubeconfig, 'gatekeeper-system', 'gatekeeper-controller-manager', HEALTH_PORT)
+                    port_forward(kubeconfig, 'gatekeeper-system', HEALTH_PORT, 'deployment', 'gatekeeper-controller-manager')
                 )
             ]
 

--- a/gatekeeper/tests/conftest.py
+++ b/gatekeeper/tests/conftest.py
@@ -57,7 +57,9 @@ def dd_environment():
         with ExitStack() as stack:
             ip_ports_metrics = [
                 stack.enter_context(
-                    port_forward(kubeconfig, 'gatekeeper-system', 'gatekeeper-controller-manager', METRICS_PORT)
+                    port_forward(
+                        kubeconfig, 'gatekeeper-system', METRICS_PORT, 'deployment', 'gatekeeper-controller-manager'
+                    )
                 )
             ]
             ip_ports_health = [

--- a/gatekeeper/tests/conftest.py
+++ b/gatekeeper/tests/conftest.py
@@ -64,7 +64,9 @@ def dd_environment():
             ]
             ip_ports_health = [
                 stack.enter_context(
-                    port_forward(kubeconfig, 'gatekeeper-system', HEALTH_PORT, 'deployment', 'gatekeeper-controller-manager')
+                    port_forward(
+                        kubeconfig, 'gatekeeper-system', HEALTH_PORT, 'deployment', 'gatekeeper-controller-manager'
+                    )
                 )
             ]
 


### PR DESCRIPTION
### What does this PR do?

Updates the e2e kind environment to use the new kube port_forwarding arguments: https://github.com/DataDog/integrations-core/pull/10127

### Motivation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
cc @arapulido 

Anything else we should know when reviewing?
