### PR TITLE
Update e2e port forwarding

### DIFF
--- a/cert_manager/tests/conftest.py
+++ b/cert_manager/tests/conftest.py
@@ -83,7 +83,7 @@ def setup_cert_manager():
 def dd_environment():
     with kind_run(conditions=[setup_cert_manager]) as kubeconfig:
         with ExitStack() as stack:
-            ip_ports = [stack.enter_context(port_forward(kubeconfig, 'cert-manager', 'cert-manager', PORT))]
+            ip_ports = [stack.enter_context(port_forward(kubeconfig, 'cert-manager', PORT, 'deployment', 'cert-manager'))]
         instances = {
             'instances': [
                 {'prometheus_url': 'http://{}:{}/metrics'.format(*ip_ports[0])},

--- a/cert_manager/tests/conftest.py
+++ b/cert_manager/tests/conftest.py
@@ -83,7 +83,9 @@ def setup_cert_manager():
 def dd_environment():
     with kind_run(conditions=[setup_cert_manager]) as kubeconfig:
         with ExitStack() as stack:
-            ip_ports = [stack.enter_context(port_forward(kubeconfig, 'cert-manager', PORT, 'deployment', 'cert-manager'))]
+            ip_ports = [
+                stack.enter_context(port_forward(kubeconfig, 'cert-manager', PORT, 'deployment', 'cert-manager'))
+            ]
         instances = {
             'instances': [
                 {'prometheus_url': 'http://{}:{}/metrics'.format(*ip_ports[0])},


### PR DESCRIPTION
### What does this PR do?

Updates the e2e kind environment to use the new kube port_forwarding arguments: DataDog/integrations-core#10127

### Motivation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
cc @arapulido 

Anything else we should know when reviewing?
