### PR TITLE
Updating k6 command

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -48,7 +48,7 @@ For the detailed instructions, follow the [k6 documentation][2].
     Once the Datadog Agent service is running, run the k6 test and send the metrics to the Agent with:
 
     ```shell
-    k6 run --out datadog script.js
+    K6_STATSD_ENABLE_TAGS=true k6 run --out statsd script.js
     ```
 
 4. Visualize the k6 metrics in Datadog.


### PR DESCRIPTION
### What does this PR do?

Launching `k6 run --out datadog script.js` returns `deprecated(ERRO[0000] could not create the 'datadog' output: the datadog output was deprecated in k6 v0.32.0 and removed in k6 v0.34.0, please use the statsd output with env. variable K6_STATSD_ENABLE_TAGS=true instead`. The good command is `K6_STATSD_ENABLE_TAGS=true k6 run --out statsd script.js`.

### Motivation

Enabling k6