### PR TITLE
Fix to remove unsupported link icons in the Shoreline README

### DIFF
--- a/shoreline/README.md
+++ b/shoreline/README.md
@@ -65,4 +65,4 @@ For more information, see the [Shoreline documentation][9].
 [7]: https://docs.shoreline.io/installation/virtual-machines
 [8]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/shoreline/images/link_icon.svg
 [9]: https://docs.shoreline.io/
-[10]: https://app.datadoghq.com/account/settings#integrations/shoreline
+[10]: /account/settings#integrations/shoreline


### PR DESCRIPTION
### What does this PR do?

Removes unsupported link icons in the Shoreline README

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
