### PR TITLE
Change cert_manager.clock_time type to gauge

### DIFF
--- a/cert_manager/datadog_checks/cert_manager/cert_manager.py
+++ b/cert_manager/datadog_checks/cert_manager/cert_manager.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base import OpenMetricsBaseCheck
 
-from .metrics import ACME_METRICS, CERT_METRICS, CONTROLLER_METRICS
+from .metrics import ACME_METRICS, CERT_METRICS, CONTROLLER_METRICS, TYPE_OVERRIDES
 
 
 class CertManagerCheck(OpenMetricsBaseCheck):
@@ -15,7 +15,7 @@ class CertManagerCheck(OpenMetricsBaseCheck):
         METRIC_MAP.update(ACME_METRICS)
         METRIC_MAP.update(CERT_METRICS)
 
-        default_instances = {'cert_manager': {'metrics': [METRIC_MAP]}}
+        default_instances = {'cert_manager': {'metrics': [METRIC_MAP], 'type_overrides': TYPE_OVERRIDES}}
 
         super(CertManagerCheck, self).__init__(
             name, init_config, instances, default_instances=default_instances, default_namespace='cert_manager'

--- a/cert_manager/datadog_checks/cert_manager/metrics.py
+++ b/cert_manager/datadog_checks/cert_manager/metrics.py
@@ -16,3 +16,7 @@ ACME_METRICS = {
     'certmanager_http_acme_client_request_count': 'http_acme_client.request.count',
     'certmanager_http_acme_client_request_duration_seconds': 'http_acme_client.request.duration',
 }
+
+TYPE_OVERRIDES = {
+    'certmanager_clock_time_seconds': 'gauge',
+}

--- a/cert_manager/metadata.csv
+++ b/cert_manager/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-cert_manager.clock_time,count,,second,,The clock time given in seconds (from 1970/01/01 UTC),0,cert-manager,cm.clock_time
+cert_manager.clock_time,gauge,,second,,The clock time given in seconds (from 1970/01/01 UTC),0,cert-manager,cm.clock_time
 cert_manager.prometheus.health,gauge,,,,Whether the check is able to connect to the metrics endpoint,0,cert-manager,cm.health
 cert_manager.certificate.ready_status,gauge,,,,The ready status of the certificate,0,cert-manager,cm.cert_ready_status
 cert_manager.certificate.expiration_timestamp,gauge,,second,,The date after which the certificate expires. Expressed as a Unix Epoch Time,0,cert-manager,cm.cert_exp_time

--- a/cert_manager/tests/common.py
+++ b/cert_manager/tests/common.py
@@ -16,7 +16,7 @@ ACME_METRICS = {
 }
 
 CONTROLLER_METRICS = {
-    'cert_manager.clock_time': aggregator.MONOTONIC_COUNT,
+    'cert_manager.clock_time': aggregator.GAUGE,
     'cert_manager.controller.sync_call.count': aggregator.MONOTONIC_COUNT,
     'cert_manager.prometheus.health': aggregator.GAUGE,
 }


### PR DESCRIPTION
### What does this PR do?

As other people reported upstream (https://github.com/jetstack/cert-manager/pull/4105#issuecomment-930563632) the cert_manager clock metric should be a gauge, not a counter for it to work correctly.

This is also a general view that timestamps should be gauges: https://www.robustperception.io/are-increasing-timestamps-counters-or-gauges

This new cert-manager metric was wrongly created as a counter, but we can override this in our integration to be a gauge. 

I will follow up upstream to fix it there, but for now, we should fix it on our side to make this work correctly.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)


