### PR TITLE
Move dashboard to proper location inside assets

### DIFF
--- a/launchdarkly/manifest.json
+++ b/launchdarkly/manifest.json
@@ -58,9 +58,9 @@
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       }
+    },
+    "dashboards": {
+      "launchdarkly": "dashboards/launchdarkly.json"
     }
-  },
-  "dashboards": {
-    "launchdarkly": "dashboards/launchdarkly.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?

Moves the launchdarkly dashboard into the proper section of the manifest (under assets)

### Motivation

This dashboard was at the root of the manifest, and not being registered properly.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
