### PR TITLE
Add .kube folder and .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,10 @@ wheelhouse/
 # by default, ignore in-toto metadata from the command line
 .links/
 *.link
+
+## Kind
+.kube
+
+# pyenv versioning
+.python-version
+


### PR DESCRIPTION
### What does this PR do?

Add a couple of entries to .gitignore:

* .kube (this folder gets created for integrations with Kind E2E testing
* .python-version (for pyenv versioning)

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
