### PR TITLE
fix tab comment

### DIFF
--- a/redpanda/README.md
+++ b/redpanda/README.md
@@ -13,7 +13,7 @@ Connect Datadog with [Redpanda][1] to view key metrics and add additional metric
 2. Manually install the Redpanda integration. See [Use Community Integrations][10] for more details based on the environment.
 
 <!-- xxx tabs xxx -->
-<!-- xx tab "Host" xxx -->
+<!-- xxx tab "Host" xxx -->
 
 #### Host
 


### PR DESCRIPTION
### What does this PR do?

Redpanda readme tab comment is missing an additional `x`

### Motivation

Some issues with the documentation build processing this

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
