### PR TITLE
Don't spin up agent on prs

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -16,20 +16,10 @@ resources:
       name: Datadog/integrations-core
       ref: master
       endpoint: DataDog
-  containers:
-    - container: dd_agent
-      image: gcr.io/datadoghq/agent:latest
-      ports:
-        - 8127:8126
-      env:
-        DD_API_KEY: $(DD_CI_API_KEY)
-        DD_HOSTNAME: "none"
-        DD_INSIDE_CI: "true"
 
 jobs:
 - template: '.azure-pipelines/templates/test-single-linux.yml@integrations-core'
   parameters:
-    ddtrace_flag: '--ddtrace'
     job_name: Changed
     display: Linux
     validate: true
@@ -39,7 +29,6 @@ jobs:
 
 - template: '.azure-pipelines/templates/test-single-windows.yml@integrations-core'
   parameters:
-    ddtrace_flag: '--ddtrace'
     job_name: Changed
     check: '--changed none_yet'
     validate_changed: changed


### PR DESCRIPTION
Forks can't spin up the agent, so let's remove it completely from PR changes.

Next step is spinning it up only on non-fork PRs
