### PR TITLE
Use requests wrappers and new check signature

### DIFF
--- a/stardog/tests/test_stardog.py
+++ b/stardog/tests/test_stardog.py
@@ -38,8 +38,8 @@ def test_check_all_metrics(aggregator):
     """
     Testing Stardog check.
     """
-    check = StardogCheck('stardog', {}, {})
-    check.check(copy.deepcopy(INSTANCE))
+    check = StardogCheck('stardog', {}, [copy.deepcopy(INSTANCE)])
+    check.check({})
     tags = copy.deepcopy(INSTANCE['tags'])
     tags.append("stardog_url:http://localhost:%d" % HTTP.port)
     for metric_key in DATA:


### PR DESCRIPTION
Changes the usage of requests to the httpwrapper
More information in https://datadoghq.dev/integrations-core/base/http/

It also changes the `check` signature to the new, recommended one.