### PR TITLE
The sendmail integration don't return the correct sendmail queue size

### DIFF
--- a/sendmail/datadog_checks/sendmail/sendmail.py
+++ b/sendmail/datadog_checks/sendmail/sendmail.py
@@ -73,7 +73,7 @@ class SendmailCheck(AgentCheck):
         self.log.debug("Error: %s", err)
         count = mail_queue.splitlines()
         # Retrieve the last total number of requests
-        queue_count = int(count[-1][-1])
+        queue_count = int(count[-1].split()[-1])
         self.log.info("Number of mails in the queue: %s", queue_count)
 
         return queue_count

--- a/sendmail/tests/test_sendmail.py
+++ b/sendmail/tests/test_sendmail.py
@@ -11,7 +11,7 @@ def mailqueue_mock():
 Total requests: 0
 MTA Queue status...
 /var/spool/mqueue is empty
-Total requests: 0"""
+Total requests: 306"""
 
 
 def test_bad_configuration():
@@ -40,5 +40,5 @@ def test_queue_output(aggregator):
             'datadog_checks.sendmail.sendmail.get_subprocess_output', return_value=(mailqueue_mock(), '', 0)
         ):
             check.check({'sendmail_command': '/usr/bin/mailq', 'tags': tags})
-            aggregator.assert_metric('sendmail.queue.size', value=0, tags=tags + ['queue:total'])
+            aggregator.assert_metric('sendmail.queue.size', value=306, tags=tags + ['queue:total'])
             aggregator.assert_service_check('sendmail.returns.output', SendmailCheck.OK)


### PR DESCRIPTION
### What does this PR do?

The sendmail integration did return the queue size as the last digit in the number for total requests

This PR fix that and return all digits from the  number for total requests

### Motivation

I want to use the sendmail integration and our sendmail  queue size can be > 9

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
