### PR TITLE
Disable docs

### DIFF
--- a/calico/datadog_checks/calico/data/conf.yaml.example
+++ b/calico/datadog_checks/calico/data/conf.yaml.example
@@ -124,8 +124,16 @@ instances:
 
     ## @param exclude_labels - list of strings - optional
     ## A list of labels to exclude, useful for high cardinality values like timestamps or UUIDs.
+    ## May be used in conjunction with `include_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
     #
     # exclude_labels: []
+
+    ## @param include_labels - list of strings - optional
+    ## A list of labels to include. May be used in conjunction with `exclude_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    #
+    # include_labels: []
 
     ## @param rename_labels - mapping - optional
     ## A mapping of label names to how they should be renamed.
@@ -176,6 +184,14 @@ instances:
     ## `histogram_buckets_as_distributions` option.
     #
     # collect_counters_with_distributions: false
+
+    ## @param use_process_start_time - boolean - optional - default: false
+    ## Whether to enable a heuristic for reporting counter values on the first scrape. When true,
+    ## the first time an endpoint is scraped, check `process_start_time_seconds` to decide whether zero
+    ## initial value can be assumed for counters. This requires keeping metrics in memory until the entire
+    ## response is received.
+    #
+    # use_process_start_time: false
 
     ## @param share_labels - mapping - optional
     ## This mapping allows for the sharing of labels across multiple metrics. The keys represent the

--- a/calico/manifest.json
+++ b/calico/manifest.json
@@ -13,7 +13,7 @@
   "public_title": "calico",
   "categories": ["metrics", "network", "security"],
   "type": "check",
-  "is_public": true,
+  "is_public": false,
   "integration_id": "calico",
   "assets": {
     "configuration": {


### PR DESCRIPTION
### What does this PR do?
Disable documentation on the Datadog docs site. 

### Motivation


### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
