### PR TITLE
Don't run validations on CI

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -34,7 +34,7 @@ jobs:
       ddtrace_flag: '--ddtrace'
     job_name: Changed
     display: Linux
-    validate: true
+    validate: false
     validate_changed: changed
     validate_codeowners: true
     repo: 'extras'


### PR DESCRIPTION
### What does this PR do?

Stop running validations on CI

### Motivation

We already run them on github actions

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
