### PR TITLE
removing AWS from Altostra manifest

### DIFF
--- a/altostra/manifest.json
+++ b/altostra/manifest.json
@@ -17,7 +17,6 @@
   "public_title": "Datadog-Altostra Integration",
   "categories": [
     "automation",
-    "aws",
     "cloud",
     "configuration & deployment",
     "log collection"


### PR DESCRIPTION
### What does this PR do?

Removing AWS because this is not an AWS integration.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

