### PR TITLE
Update Links in Resin Integration Page

### DIFF
--- a/resin/README.md
+++ b/resin/README.md
@@ -65,7 +65,7 @@ Need help? Contact [Datadog support][7].
 
 
 [1]: https://caucho.com/
-[2]: https://github.com/DataDog/integrations-extras/tree/master/resin
+[2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-extras/blob/master/resin/metadata.csv

--- a/resin/README.md
+++ b/resin/README.md
@@ -12,7 +12,7 @@ The Resin check is not included in the [Datadog Agent][2] package, so you need t
 
 ### Configuration
 
-1. Configure the [resin default server](https://www.caucho.com/resin-4.0/admin/cluster-server.xtp#JVMparameters:settingtheJVMcommandline) to enable JMX by adding the following JVM arguments:
+1. Configure the [resin default server][9] to enable JMX by adding the following JVM arguments:
 
 ```
 <server-default>
@@ -65,10 +65,11 @@ Need help? Contact [Datadog support][7].
 
 
 [1]: https://caucho.com/
-[2]: https://github.com/DataDog/integrations-core/blob/master/resin/datadog_checks/resin/data/conf.yaml.example
+[2]: https://github.com/DataDog/integrations-extras/tree/master/resin
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#start-stop-and-restart-the-agent
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-extras/blob/master/resin/metadata.csv
 [6]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/
 [7]: https://docs.datadoghq.com/help/
 [8]: https://github.com/DataDog/integrations-extras/blob/master/resin/assets/service_checks.json
+[9]: https://www.caucho.com/resin-4.0/admin/cluster-server.xtp#JVMparameters:settingtheJVMcommandline


### PR DESCRIPTION
### What does this PR do?

Fixes link to integrations-extras and formats link to "resin default server."

### Motivation

Hotjar

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
