### PR TITLE
Hide sedai from public docs

### DIFF
--- a/sedai/manifest.json
+++ b/sedai/manifest.json
@@ -25,7 +25,7 @@
     "provisioning"
   ],
   "type": "check",
-  "is_public": true,
+  "is_public": false,
   "integration_id": "sedai",
   "assets": {
     "dashboards": {},


### PR DESCRIPTION
### What does this PR do?

Temporarily hide sedai from public docs. 

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
