### PR TITLE
Push requests_count metric for Puma running in single mode

### DIFF
--- a/puma/datadog_checks/puma/puma.py
+++ b/puma/datadog_checks/puma/puma.py
@@ -54,6 +54,7 @@ class PumaCheck(AgentCheck):
             metrics['backlog'] = int(response.get('backlog', 0))
             metrics['max_threads'] = int(response.get('max_threads', 0))
             metrics['pool_capacity'] = int(response.get('pool_capacity', 0))
+            metrics['requests_count'] = int(response.get('requests_count', 0))
             metrics['running'] = int(response.get('running', 0))
 
         return metrics


### PR DESCRIPTION
### What does this PR do?

The check was not taking into consideration the requests_count metric when Puma was running in single mode. This PR is just adding this capability.

### Motivation

Gives more visibility to Pumas running in single mode.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
