### PR TITLE
Add `pyproject.toml` file

### DIFF
--- a/bind9/MANIFEST.in
+++ b/bind9/MANIFEST.in
@@ -1,6 +1,0 @@
-include README.md
-include requirements.in
-include requirements.txt
-include requirements-dev.txt
-graft datadog_checks
-graft tests

--- a/bind9/pyproject.toml
+++ b/bind9/pyproject.toml
@@ -1,0 +1,62 @@
+[build-system]
+requires = [
+    "hatchling>=0.12.0",
+    "setuptools; python_version < '3.0'",
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "datadog-bind9"
+description = "The BIND 9 check"
+readme = "README.md"
+license = "BSD-3-Clause"
+keywords = [
+    "datadog",
+    "datadog agent",
+    "datadog check",
+    "bind9",
+]
+authors = [
+    { name = "Datadog", email = "packages@datadoghq.com" },
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: System :: Monitoring",
+]
+dependencies = [
+    "datadog-checks-base",
+]
+dynamic = [
+    "version",
+]
+
+[project.optional-dependencies]
+deps = []
+
+[project.urls]
+Source = "https://github.com/DataDog/integrations-extras"
+
+[tool.hatch.version]
+path = "datadog_checks/bind9/__about__.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/datadog_checks",
+    "/tests",
+    "/manifest.json",
+    "/requirements-dev.txt",
+    "/tox.ini",
+]
+
+[tool.hatch.build.targets.wheel]
+include = [
+    "/datadog_checks/bind9",
+]
+dev-mode-dirs = [
+    ".",
+]

--- a/bind9/pyproject.toml
+++ b/bind9/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     "bind9",
 ]
 authors = [
-    { name = "Datadog", email = "packages@datadoghq.com" },
+    { email = "ashuvyas45@gmail.com" },
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/bind9/setup.py
+++ b/bind9/setup.py
@@ -28,7 +28,22 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base'
+def parse_pyproject_array(name):
+    import os
+    import re
+    from ast import literal_eval
+
+    pattern = r'^{} = (\[.*?\])$'.format(name)
+
+    with open(os.path.join(HERE, 'pyproject.toml'), 'r', encoding='utf-8') as f:
+        # Windows \r\n prevents match
+        contents = '\n'.join(line.rstrip() for line in f.readlines())
+
+    array = re.search(pattern, contents, flags=re.MULTILINE | re.DOTALL).group(1)
+    return literal_eval(array)
+
+
+CHECKS_BASE_REQ = parse_pyproject_array('dependencies')[0]
 
 setup(
     name='datadog-bind9',
@@ -53,7 +68,7 @@ setup(
     packages=['datadog_checks.bind9'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
-    extras_require={'deps': get_dependencies()},
+    extras_require={'deps': parse_pyproject_array('deps')},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/bind9/tox.ini
+++ b/bind9/tox.ini
@@ -12,9 +12,9 @@ envdir =
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
+extras = deps
 deps =
     datadog-checks-base[deps]
     -rrequirements-dev.txt
 commands =
-    pip install -r requirements.in
     pytest -v


### PR DESCRIPTION
### Motivation

Modernize packaging, continues https://github.com/DataDog/integrations-core/pull/11233

### Additional Notes

The `setup.py` file will be removed when we drop Python 2 since new-style editable installations require versions of `pip` that are Python 3-only