### PR TITLE
Add `pyproject.toml` file

### DIFF
--- a/hbase_master/MANIFEST.in
+++ b/hbase_master/MANIFEST.in
@@ -1,7 +1,0 @@
-graft datadog_checks
-
-include MANIFEST.in
-include README.md
-include manifest.json
-
-global-exclude *.py[cod] __pycache__

--- a/hbase_master/pyproject.toml
+++ b/hbase_master/pyproject.toml
@@ -1,0 +1,62 @@
+[build-system]
+requires = [
+    "hatchling>=0.12.0",
+    "setuptools; python_version < '3.0'",
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "datadog-hbase-master"
+description = "The HBase master check"
+readme = "README.md"
+license = "BSD-3-Clause"
+keywords = [
+    "datadog",
+    "datadog agent",
+    "datadog check",
+    "hbase_master",
+]
+authors = [
+    { name = "Datadog", email = "packages@datadoghq.com" },
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: System :: Monitoring",
+]
+dependencies = [
+    "datadog_checks_base>=11.0.0",
+]
+dynamic = [
+    "version",
+]
+
+[project.optional-dependencies]
+deps = []
+
+[project.urls]
+Source = "https://github.com/DataDog/integrations-extras"
+
+[tool.hatch.version]
+path = "datadog_checks/hbase_master/__about__.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/datadog_checks",
+    "/tests",
+    "/manifest.json",
+    "/requirements-dev.txt",
+    "/tox.ini",
+]
+
+[tool.hatch.build.targets.wheel]
+include = [
+    "/datadog_checks/hbase_master",
+]
+dev-mode-dirs = [
+    ".",
+]

--- a/hbase_master/pyproject.toml
+++ b/hbase_master/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     "hbase_master",
 ]
 authors = [
-    { name = "Datadog", email = "packages@datadoghq.com" },
+    { email = "everpeace" },
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/hbase_master/setup.py
+++ b/hbase_master/setup.py
@@ -24,7 +24,22 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+def parse_pyproject_array(name):
+    import os
+    import re
+    from ast import literal_eval
+
+    pattern = r'^{} = (\[.*?\])$'.format(name)
+
+    with open(os.path.join(HERE, 'pyproject.toml'), 'r', encoding='utf-8') as f:
+        # Windows \r\n prevents match
+        contents = '\n'.join(line.rstrip() for line in f.readlines())
+
+    array = re.search(pattern, contents, flags=re.MULTILINE | re.DOTALL).group(1)
+    return literal_eval(array)
+
+
+CHECKS_BASE_REQ = parse_pyproject_array('dependencies')[0]
 
 
 setup(
@@ -61,7 +76,7 @@ setup(
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
-    extras_require={'deps': get_dependencies()},
+    extras_require={'deps': parse_pyproject_array('deps')},
 
     # Extra files to ship with the wheel package
     include_package_data=True,


### PR DESCRIPTION
### Motivation

Modernize packaging, continues https://github.com/DataDog/integrations-core/pull/11233

### Additional Notes

The `setup.py` file will be removed when we drop Python 2 since new-style editable installations require versions of `pip` that are Python 3-only