### PR TITLE
Add curated_metric column to metadata.csv files

### DIFF
--- a/aqua/metadata.csv
+++ b/aqua/metadata.csv
@@ -1,7 +1,7 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-aqua.images,gauge,,unit,,The number of images seen by Aqua,0,aqua,images
-aqua.vulnerabilities,gauge,,occurrence,,The number and categories of vulnerabilities detected by Aqua,-1,aqua,vulns
-aqua.running_containers,gauge,,container,,The number of running containers seen by Aqua,0,aqua,running containers
-aqua.audit.access,gauge,,event,,The number of audit events per category,0,aqua,audit access
-aqua.scan_queue,gauge,,occurrence,,The number of scan queues per type,0,aqua,scan Q
-aqua.enforcers,gauge,,host,,The number of host enforcers per status,0,aqua,enforcers
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
+aqua.images,gauge,,unit,,The number of images seen by Aqua,0,aqua,images,
+aqua.vulnerabilities,gauge,,occurrence,,The number and categories of vulnerabilities detected by Aqua,-1,aqua,vulns,
+aqua.running_containers,gauge,,container,,The number of running containers seen by Aqua,0,aqua,running containers,
+aqua.audit.access,gauge,,event,,The number of audit events per category,0,aqua,audit access,
+aqua.scan_queue,gauge,,occurrence,,The number of scan queues per type,0,aqua,scan Q,
+aqua.enforcers,gauge,,host,,The number of host enforcers per status,0,aqua,enforcers,

--- a/rbltracker/metadata.csv
+++ b/rbltracker/metadata.csv
@@ -1,1 +1,1 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric

--- a/split/metadata.csv
+++ b/split/metadata.csv
@@ -1,1 +1,1 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric

--- a/uptime/metadata.csv
+++ b/uptime/metadata.csv
@@ -1,2 +1,2 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-uptime.response_time,gauge,,second,,The response time when running the check.,-1,uptime,uptime response
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
+uptime.response_time,gauge,,second,,The response time when running the check.,-1,uptime,uptime response,


### PR DESCRIPTION
### What does this PR do?
We want to allow the definition of metrics for a given integration as a 'curated' metric. A metric selected here can be given a type (starting with either 'cpu' or 'memory') to group metrics by when users are investigating issues based on that type. We will give these metrics more emphasis in the UI of our products (Live Processes to start) relative to other metrics.

Integrations synced to staging using `integration sync`


### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
