### PR TITLE
Add curated_metric column to metadata.csv files

### DIFF
--- a/nomad/metadata.csv
+++ b/nomad/metadata.csv
@@ -1,98 +1,98 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-nomad.client.allocated.cpu,gauge,,megahertz,,Amount of CPU allocated for a client.,0,nomad,allocated cpu
-nomad.client.allocated.disk,gauge,,,,Amount of disk allocated for a client.,0,nomad,allocated disk
-nomad.client.allocated.iops,gauge,,operation,,Number of iops allocated for a client.,0,nomad,allocated iops
-nomad.client.allocated.memory,gauge,,,,Amount of memory allocated for a client.,0,nomad,allocated memory
-nomad.client.allocated.network,gauge,,,,Bandwidth allocation for a client.,0,nomad,allocated network
-nomad.client.allocations.blocked,gauge,,job,,Number of allocations blocked for a client.,0,nomad,allocations blocked
-nomad.client.allocations.migrating,gauge,,job,,Number of allocations migrating for a client.,0,nomad,allocations migrating
-nomad.client.allocations.pending,gauge,,job,,Number of allocations pending for a client.,0,nomad,allocations pending
-nomad.client.allocations.running,gauge,,job,,Number of allocations running for a client.,0,nomad,allocations running
-nomad.client.allocations.start,gauge,,job,,Number of allocations starting,0,nomad,allocations start
-nomad.client.allocations.terminal,gauge,,job,,Number of allocations terminated for a client.,0,nomad,allocations terminal
-nomad.client.allocs.cpu.allocated,gauge,,megahertz,,Total CPU resources allocated by the task across all cores.,0,nomad,allocs cpu allocated
-nomad.client.allocs.cpu.system,gauge,,percent,,Total CPU resources consumed by the task in system space.,0,nomad,allocs cpu system
-nomad.client.allocs.cpu.throttled_periods,gauge,,nanosecond,,Total number of CPU periods that the task was throttled.,0,nomad,allocs cpu throttled p
-nomad.client.allocs.cpu.throttled_time,gauge,,nanosecond,,Total time that the task was throttled.,0,nomad,allocs cpu throttled time
-nomad.client.allocs.cpu.total_percent,gauge,,percent,,Total CPU resources consumed by the task across all cores.,0,nomad,allocs cpu tot percent
-nomad.client.allocs.cpu.total_ticks,gauge,,,,CPU ticks consumed by the process in the last collection interval.,0,nomad,allocs cpu tot ticks
-nomad.client.allocs.cpu.user,gauge,,percent,,Total CPU resources consumed by the task in the user space.,0,nomad,allocs cpu user
-nomad.client.allocs.memory.allocated,gauge,,byte,,Amount of memory allocated by the task.,0,nomad,allocs mem allocated
-nomad.client.allocs.memory.cache,gauge,,byte,,Amount of memory cached by the task.,0,nomad,allocs mem cache
-nomad.client.allocs.memory.kernel_max_usage,gauge,,byte,,Maximum amount of memory ever used by the kernel for this task.,0,nomad,allocs mem kernel max
-nomad.client.allocs.memory.kernel_usage,gauge,,byte,,Amount of memory used by the kernel for this task.,0,nomad,allocs mem kernel
-nomad.client.allocs.memory.max_usage,gauge,,byte,,Maximum amount of memory ever used by the task.,0,nomad,allocs mem usage
-nomad.client.allocs.memory.rss,gauge,,byte,,Amount of RSS memory consumed by the task.,0,nomad,allocs mem rss
-nomad.client.allocs.memory.swap,gauge,,byte,,Amount of memory swapped by the task.,0,nomad,allocs mem swap
-nomad.client.allocs.memory.usage,gauge,,byte,,Total amount of memory used by the task.,0,nomad,allocs mem usage
-nomad.client.allocs.oom_killed,gauge,,,,Number of allocations OOM killed.,0,nomad,allocs oom killed
-nomad.client.consul.check_registrations,gauge,,,,Number of consul check registrations.,0,nomad,check registration
-nomad.client.consul.checks,gauge,,,,Number of consul checks.,0,nomad,check consul
-nomad.client.consul.script_checks,gauge,,,,Number of consul script checks.,0,nomad,consul script
-nomad.client.consul.service_registrations,gauge,,,,Number of consul service registration.,0,nomad,service regitration
-nomad.client.consul.services,gauge,,,,Number of consul services.,0,nomad,consul services
-nomad.client.host.cpu.idle,gauge,,percent,,Amount of CPU idle for a client.,0,nomad,cpu idle
-nomad.client.host.cpu.system,gauge,,percent,,Amount of CPU consumed by the system for a client.,0,nomad,cpu system
-nomad.client.host.cpu.total,gauge,,percent,,Amount of CPU total for a client.,0,nomad,total cpu
-nomad.client.host.cpu.user,gauge,,percent,,Amount of CPU total for a user.,0,nomad,cpu user
-nomad.client.host.disk.available,gauge,,byte,,Disk available for a particular client.,0,nomad,disk available
-nomad.client.host.disk.inodes_percent,gauge,,percent,,Disk nodes used as a percentage for a particular client.,0,nomad,percent inodes
-nomad.client.host.disk.size,gauge,,byte,,Disk size for a particular client.,0,nomad,disk size
-nomad.client.host.disk.used,gauge,,byte,,Disk used for a particular client.,0,nomad,disk used
-nomad.client.host.disk.used_percent,gauge,,percent,,Disk used as a percentage for a particular client.,0,nomad,percent disk used
-nomad.client.host.memory.available,gauge,,byte,,Amount of memory available for a client.,0,nomad,available host memory
-nomad.client.host.memory.free,gauge,,byte,,Amount of memory free for a client.,0,nomad,memory free
-nomad.client.host.memory.total,gauge,,byte,,Total amount of memory for a client.,0,nomad,total host memory
-nomad.client.host.memory.used,gauge,,byte,,Amount of memory used for a client.,0,nomad,memory used
-nomad.client.unallocated.cpu,gauge,,megahertz,,Amount of unallocated CPU for a client.,0,nomad,unallocated cpu
-nomad.client.unallocated.disk,gauge,,,,Amount of unallocated disk for a client.,0,nomad,unallocated disk
-nomad.client.unallocated.iops,gauge,,operation,,Number of unallocated iops for a client.,0,nomad,unallocated iops
-nomad.client.unallocated.memory,gauge,,,,Amount of unallocated memory for a client.,0,nomad,unallocted memory
-nomad.client.unallocated.network,gauge,,,,Unallocated bandwidth for a client.,0,nomad,unallocated network
-nomad.client.uptime,gauge,,second,,Uptime of the host running the Nomad client.,0,nomad,client uptime
-nomad.memberlist.gossip.95percentile,gauge,,resource,,95 percentile of members in the gossip pool.,0,nomad,member gossip
-nomad.memberlist.gossip.avg,gauge,,resource,,Average number of members in the gossip pool.,0,nomad,member gossip avg
-nomad.memberlist.gossip.count,rate,10,resource,,Number of members in the gossip pool.,0,nomad,member gossip count
-nomad.memberlist.gossip.max,gauge,,resource,,Maximum number of members in the gossip pool.,0,nomad,gossip max
-nomad.memberlist.gossip.median,gauge,,resource,,Median number of members in the gossip pool.,0,nomad,gossip med
-nomad.memberlist.msg.alive,gauge,,resource,,Number of message from alive members.,0,nomad,member alive
-nomad.memberlist.tcp.accept,gauge,,resource,,Number of accepted TCP connections.,0,nomad,member tcp
-nomad.nomad.blocked_evals.total_blocked,gauge,,job,,Number of blocked evaluation.,0,nomad,bck eval blocked
-nomad.nomad.blocked_evals.total_escaped,gauge,,job,,Number of blocked evaluation that are escaped.,0,nomad,bck eval escaped
-nomad.nomad.blocked_evals.total_quota_limit,gauge,,job,,Limit quota of evaluations.,0,nomad,bck eval quot
-nomad.nomad.broker.total_blocked,gauge,,,,Evaluations that are blocked until an existing evaluation for the same job completes.,0,nomad,broker blocked
-nomad.nomad.broker.total_ready,gauge,,,,Number of evaluations ready to be processed.,0,nomad,broker ready
-nomad.nomad.broker.total_unacked,gauge,,,,Evaluations dispatched for processing but incomplete.,0,nomad,broker unacked
-nomad.nomad.broker.total_waiting,gauge,,,,Number of evaluations waiting to be processed.,0,nomad,broker waiting
-nomad.nomad.client.get_client_allocs.95percentile,gauge,,,,The 95 percentile of nomad client allocated.,0,nomad,client 95p
-nomad.nomad.client.get_client_allocs.avg,gauge,,,,The average number of nomad client allocated.,0,nomad,client avg
-nomad.nomad.client.get_client_allocs.count,gauge,,,,The number of nomad client allocated.,0,nomad,client count
-nomad.nomad.client.get_client_allocs.max,gauge,,,,The maximum number of nomad client allocated.,0,nomad,client max
-nomad.nomad.job_summary.complete,gauge,,,,Total CPU resources consumed by the task in the user space.,0,nomad,job summary complete
-nomad.nomad.job_summary.failed,gauge,,,,Number of failed allocations for a job.,0,nomad,job summary failed
-nomad.nomad.job_summary.lost,gauge,,,,Number of lost allocations for a job.,0,nomad,job summary lost
-nomad.nomad.job_summary.queued,gauge,,,,Number of queued allocations for a job.,0,nomad,job summary queued
-nomad.nomad.job_summary.running,gauge,,,,Number of running allocations for a job.,0,nomad,job summary running
-nomad.nomad.job_summary.starting,gauge,,,,Number of starting allocations for a job.,0,nomad,job summary starting
-nomad.nomad.job_status.dead,gauge,,job,,Number of dead jobs.,0,nomad,job status dead
-nomad.nomad.job_status.pending,gauge,,job,,Number of pending jobs.,0,nomad,job status pending
-nomad.nomad.job_status.running,gauge,,job,,Number of running jobs.,0,nomad,job status running
-nomad.nomad.acl.bootstrap,gauge,,nanosecond,,Time elapsed for ACL.Bootstrap RPC call.,0,nomad,acl bootstrap
-nomad.nomad.acl.delete_policies,gauge,,nanosecond,,Time elapsed for ACL.DeletePolicies RPC call.,0,nomad,acl del policies
-nomad.nomad.acl.delete_tokens,gauge,,nanosecond,,Time elapsed for ACL.DeleteTokens RPC call.,0,nomad,acl del token
-nomad.nomad.acl.get_policies,gauge,,nanosecond,,Time elapsed for ACL.GetPolicies RPC call.,0,nomad,acl get policies
-nomad.nomad.acl.get_policy,gauge,,nanosecond,,Time elapsed for ACL.GetPolicy RPC call.,0,nomad,acl get policy
-nomad.nomad.acl.get_token,gauge,,nanosecond,,Time elapsed for ACL.GetToken RPC call.,0,nomad,acl get token
-nomad.nomad.acl.get_tokens,gauge,,nanosecond,,Time elapsed for ACL.GetTokens RPC call.,0,nomad,acl get tokens
-nomad.nomad.acl.list_policies,gauge,,nanosecond,,Time elapsed for ACL.ListPolicies RPC call.,0,nomad,acl list policies
-nomad.nomad.acl.list_tokens,gauge,,nanosecond,,Time elapsed for ACL.ListTokens RPC call.,0,nomad,acl list tokens
-nomad.nomad.rpc.query,gauge,,,,Number of RPC queries.,0,nomad,rpc query
-nomad.nomad.rpc.request,gauge,,,,Number of RPC requests being handled.,0,nomad,rpc request
-nomad.runtime.alloc_bytes,gauge,,byte,,Memory utilization.,0,nomad,runtime alloc bytes
-nomad.runtime.free_count,gauge,,,,Count of objects freed from heap by go runtime GC.,0,nomad,runtime gc free
-nomad.runtime.gc_pause_ns,gauge,,nanosecond,,Go runtime GC pause times.,0,nomad,runtime gc pause
-nomad.runtime.heap_objects,gauge,,,,Number of objects on the heap. General memory pressure indicator.,0,nomad,runtime heap obj
-nomad.runtime.num_goroutines,gauge,,,,Number of goroutines and general load pressure indicator.,0,nomad,runtime goroutines
-nomad.runtime.sys_bytes,gauge,,byte,,Go runtime GC metadata size.,0,nomad,runtime sys bytes
-nomad.runtime.total_gc_pause_ns,gauge,,nanosecond,,Total elapsed go runtime GC pause times.,0,nomad,runtime total gc pause
-nomad.runtime.total_gc_runs,gauge,,,,Count of go runtime GC runs.,0,nomad,runtime total gc runs
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
+nomad.client.allocated.cpu,gauge,,megahertz,,Amount of CPU allocated for a client.,0,nomad,allocated cpu,
+nomad.client.allocated.disk,gauge,,,,Amount of disk allocated for a client.,0,nomad,allocated disk,
+nomad.client.allocated.iops,gauge,,operation,,Number of iops allocated for a client.,0,nomad,allocated iops,
+nomad.client.allocated.memory,gauge,,,,Amount of memory allocated for a client.,0,nomad,allocated memory,
+nomad.client.allocated.network,gauge,,,,Bandwidth allocation for a client.,0,nomad,allocated network,
+nomad.client.allocations.blocked,gauge,,job,,Number of allocations blocked for a client.,0,nomad,allocations blocked,
+nomad.client.allocations.migrating,gauge,,job,,Number of allocations migrating for a client.,0,nomad,allocations migrating,
+nomad.client.allocations.pending,gauge,,job,,Number of allocations pending for a client.,0,nomad,allocations pending,
+nomad.client.allocations.running,gauge,,job,,Number of allocations running for a client.,0,nomad,allocations running,
+nomad.client.allocations.start,gauge,,job,,Number of allocations starting,0,nomad,allocations start,
+nomad.client.allocations.terminal,gauge,,job,,Number of allocations terminated for a client.,0,nomad,allocations terminal,
+nomad.client.allocs.cpu.allocated,gauge,,megahertz,,Total CPU resources allocated by the task across all cores.,0,nomad,allocs cpu allocated,
+nomad.client.allocs.cpu.system,gauge,,percent,,Total CPU resources consumed by the task in system space.,0,nomad,allocs cpu system,
+nomad.client.allocs.cpu.throttled_periods,gauge,,nanosecond,,Total number of CPU periods that the task was throttled.,0,nomad,allocs cpu throttled p,
+nomad.client.allocs.cpu.throttled_time,gauge,,nanosecond,,Total time that the task was throttled.,0,nomad,allocs cpu throttled time,
+nomad.client.allocs.cpu.total_percent,gauge,,percent,,Total CPU resources consumed by the task across all cores.,0,nomad,allocs cpu tot percent,
+nomad.client.allocs.cpu.total_ticks,gauge,,,,CPU ticks consumed by the process in the last collection interval.,0,nomad,allocs cpu tot ticks,
+nomad.client.allocs.cpu.user,gauge,,percent,,Total CPU resources consumed by the task in the user space.,0,nomad,allocs cpu user,
+nomad.client.allocs.memory.allocated,gauge,,byte,,Amount of memory allocated by the task.,0,nomad,allocs mem allocated,
+nomad.client.allocs.memory.cache,gauge,,byte,,Amount of memory cached by the task.,0,nomad,allocs mem cache,
+nomad.client.allocs.memory.kernel_max_usage,gauge,,byte,,Maximum amount of memory ever used by the kernel for this task.,0,nomad,allocs mem kernel max,
+nomad.client.allocs.memory.kernel_usage,gauge,,byte,,Amount of memory used by the kernel for this task.,0,nomad,allocs mem kernel,
+nomad.client.allocs.memory.max_usage,gauge,,byte,,Maximum amount of memory ever used by the task.,0,nomad,allocs mem usage,
+nomad.client.allocs.memory.rss,gauge,,byte,,Amount of RSS memory consumed by the task.,0,nomad,allocs mem rss,
+nomad.client.allocs.memory.swap,gauge,,byte,,Amount of memory swapped by the task.,0,nomad,allocs mem swap,
+nomad.client.allocs.memory.usage,gauge,,byte,,Total amount of memory used by the task.,0,nomad,allocs mem usage,
+nomad.client.allocs.oom_killed,gauge,,,,Number of allocations OOM killed.,0,nomad,allocs oom killed,
+nomad.client.consul.check_registrations,gauge,,,,Number of consul check registrations.,0,nomad,check registration,
+nomad.client.consul.checks,gauge,,,,Number of consul checks.,0,nomad,check consul,
+nomad.client.consul.script_checks,gauge,,,,Number of consul script checks.,0,nomad,consul script,
+nomad.client.consul.service_registrations,gauge,,,,Number of consul service registration.,0,nomad,service regitration,
+nomad.client.consul.services,gauge,,,,Number of consul services.,0,nomad,consul services,
+nomad.client.host.cpu.idle,gauge,,percent,,Amount of CPU idle for a client.,0,nomad,cpu idle,
+nomad.client.host.cpu.system,gauge,,percent,,Amount of CPU consumed by the system for a client.,0,nomad,cpu system,
+nomad.client.host.cpu.total,gauge,,percent,,Amount of CPU total for a client.,0,nomad,total cpu,
+nomad.client.host.cpu.user,gauge,,percent,,Amount of CPU total for a user.,0,nomad,cpu user,
+nomad.client.host.disk.available,gauge,,byte,,Disk available for a particular client.,0,nomad,disk available,
+nomad.client.host.disk.inodes_percent,gauge,,percent,,Disk nodes used as a percentage for a particular client.,0,nomad,percent inodes,
+nomad.client.host.disk.size,gauge,,byte,,Disk size for a particular client.,0,nomad,disk size,
+nomad.client.host.disk.used,gauge,,byte,,Disk used for a particular client.,0,nomad,disk used,
+nomad.client.host.disk.used_percent,gauge,,percent,,Disk used as a percentage for a particular client.,0,nomad,percent disk used,
+nomad.client.host.memory.available,gauge,,byte,,Amount of memory available for a client.,0,nomad,available host memory,
+nomad.client.host.memory.free,gauge,,byte,,Amount of memory free for a client.,0,nomad,memory free,
+nomad.client.host.memory.total,gauge,,byte,,Total amount of memory for a client.,0,nomad,total host memory,
+nomad.client.host.memory.used,gauge,,byte,,Amount of memory used for a client.,0,nomad,memory used,
+nomad.client.unallocated.cpu,gauge,,megahertz,,Amount of unallocated CPU for a client.,0,nomad,unallocated cpu,
+nomad.client.unallocated.disk,gauge,,,,Amount of unallocated disk for a client.,0,nomad,unallocated disk,
+nomad.client.unallocated.iops,gauge,,operation,,Number of unallocated iops for a client.,0,nomad,unallocated iops,
+nomad.client.unallocated.memory,gauge,,,,Amount of unallocated memory for a client.,0,nomad,unallocted memory,
+nomad.client.unallocated.network,gauge,,,,Unallocated bandwidth for a client.,0,nomad,unallocated network,
+nomad.client.uptime,gauge,,second,,Uptime of the host running the Nomad client.,0,nomad,client uptime,
+nomad.memberlist.gossip.95percentile,gauge,,resource,,95 percentile of members in the gossip pool.,0,nomad,member gossip,
+nomad.memberlist.gossip.avg,gauge,,resource,,Average number of members in the gossip pool.,0,nomad,member gossip avg,
+nomad.memberlist.gossip.count,rate,10,resource,,Number of members in the gossip pool.,0,nomad,member gossip count,
+nomad.memberlist.gossip.max,gauge,,resource,,Maximum number of members in the gossip pool.,0,nomad,gossip max,
+nomad.memberlist.gossip.median,gauge,,resource,,Median number of members in the gossip pool.,0,nomad,gossip med,
+nomad.memberlist.msg.alive,gauge,,resource,,Number of message from alive members.,0,nomad,member alive,
+nomad.memberlist.tcp.accept,gauge,,resource,,Number of accepted TCP connections.,0,nomad,member tcp,
+nomad.nomad.blocked_evals.total_blocked,gauge,,job,,Number of blocked evaluation.,0,nomad,bck eval blocked,
+nomad.nomad.blocked_evals.total_escaped,gauge,,job,,Number of blocked evaluation that are escaped.,0,nomad,bck eval escaped,
+nomad.nomad.blocked_evals.total_quota_limit,gauge,,job,,Limit quota of evaluations.,0,nomad,bck eval quot,
+nomad.nomad.broker.total_blocked,gauge,,,,Evaluations that are blocked until an existing evaluation for the same job completes.,0,nomad,broker blocked,
+nomad.nomad.broker.total_ready,gauge,,,,Number of evaluations ready to be processed.,0,nomad,broker ready,
+nomad.nomad.broker.total_unacked,gauge,,,,Evaluations dispatched for processing but incomplete.,0,nomad,broker unacked,
+nomad.nomad.broker.total_waiting,gauge,,,,Number of evaluations waiting to be processed.,0,nomad,broker waiting,
+nomad.nomad.client.get_client_allocs.95percentile,gauge,,,,The 95 percentile of nomad client allocated.,0,nomad,client 95p,
+nomad.nomad.client.get_client_allocs.avg,gauge,,,,The average number of nomad client allocated.,0,nomad,client avg,
+nomad.nomad.client.get_client_allocs.count,gauge,,,,The number of nomad client allocated.,0,nomad,client count,
+nomad.nomad.client.get_client_allocs.max,gauge,,,,The maximum number of nomad client allocated.,0,nomad,client max,
+nomad.nomad.job_summary.complete,gauge,,,,Total CPU resources consumed by the task in the user space.,0,nomad,job summary complete,
+nomad.nomad.job_summary.failed,gauge,,,,Number of failed allocations for a job.,0,nomad,job summary failed,
+nomad.nomad.job_summary.lost,gauge,,,,Number of lost allocations for a job.,0,nomad,job summary lost,
+nomad.nomad.job_summary.queued,gauge,,,,Number of queued allocations for a job.,0,nomad,job summary queued,
+nomad.nomad.job_summary.running,gauge,,,,Number of running allocations for a job.,0,nomad,job summary running,
+nomad.nomad.job_summary.starting,gauge,,,,Number of starting allocations for a job.,0,nomad,job summary starting,
+nomad.nomad.job_status.dead,gauge,,job,,Number of dead jobs.,0,nomad,job status dead,
+nomad.nomad.job_status.pending,gauge,,job,,Number of pending jobs.,0,nomad,job status pending,
+nomad.nomad.job_status.running,gauge,,job,,Number of running jobs.,0,nomad,job status running,
+nomad.nomad.acl.bootstrap,gauge,,nanosecond,,Time elapsed for ACL.Bootstrap RPC call.,0,nomad,acl bootstrap,
+nomad.nomad.acl.delete_policies,gauge,,nanosecond,,Time elapsed for ACL.DeletePolicies RPC call.,0,nomad,acl del policies,
+nomad.nomad.acl.delete_tokens,gauge,,nanosecond,,Time elapsed for ACL.DeleteTokens RPC call.,0,nomad,acl del token,
+nomad.nomad.acl.get_policies,gauge,,nanosecond,,Time elapsed for ACL.GetPolicies RPC call.,0,nomad,acl get policies,
+nomad.nomad.acl.get_policy,gauge,,nanosecond,,Time elapsed for ACL.GetPolicy RPC call.,0,nomad,acl get policy,
+nomad.nomad.acl.get_token,gauge,,nanosecond,,Time elapsed for ACL.GetToken RPC call.,0,nomad,acl get token,
+nomad.nomad.acl.get_tokens,gauge,,nanosecond,,Time elapsed for ACL.GetTokens RPC call.,0,nomad,acl get tokens,
+nomad.nomad.acl.list_policies,gauge,,nanosecond,,Time elapsed for ACL.ListPolicies RPC call.,0,nomad,acl list policies,
+nomad.nomad.acl.list_tokens,gauge,,nanosecond,,Time elapsed for ACL.ListTokens RPC call.,0,nomad,acl list tokens,
+nomad.nomad.rpc.query,gauge,,,,Number of RPC queries.,0,nomad,rpc query,
+nomad.nomad.rpc.request,gauge,,,,Number of RPC requests being handled.,0,nomad,rpc request,
+nomad.runtime.alloc_bytes,gauge,,byte,,Memory utilization.,0,nomad,runtime alloc bytes,
+nomad.runtime.free_count,gauge,,,,Count of objects freed from heap by go runtime GC.,0,nomad,runtime gc free,
+nomad.runtime.gc_pause_ns,gauge,,nanosecond,,Go runtime GC pause times.,0,nomad,runtime gc pause,
+nomad.runtime.heap_objects,gauge,,,,Number of objects on the heap. General memory pressure indicator.,0,nomad,runtime heap obj,
+nomad.runtime.num_goroutines,gauge,,,,Number of goroutines and general load pressure indicator.,0,nomad,runtime goroutines,
+nomad.runtime.sys_bytes,gauge,,byte,,Go runtime GC metadata size.,0,nomad,runtime sys bytes,
+nomad.runtime.total_gc_pause_ns,gauge,,nanosecond,,Total elapsed go runtime GC pause times.,0,nomad,runtime total gc pause,
+nomad.runtime.total_gc_runs,gauge,,,,Count of go runtime GC runs.,0,nomad,runtime total gc runs,

--- a/octoprint/metadata.csv
+++ b/octoprint/metadata.csv
@@ -1,11 +1,11 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-octoprint.rpi_core_temp,gauge,,degree celsius,,Temp (in C) of Raspberry Pi Core,0,octoprint,rpi_core_temp
-octoprint.printer_state,gauge,,operation,,Current state of OctoPrint,0,octoprint,printer_state
-octoprint.est_print_time,gauge,,minute,,Estimated print time of current job,0,octoprint,est_print_time
-octoprint.pct_completed,gauge,,percent,,Percentage of current Print job completed,0,octoprint,pct_completed
-octoprint.print_job_time,gauge,,minute,,Elapsed print time,0,octoprint,print_job_time
-octoprint.print_job_time_left,gauge,,minute,,Estimated remaining print time,0,octoprint,print_job_time_left
-octoprint.current_tool_temp,gauge,,degree celsius,,Temp (in C) of each extruder,0,octoprint,current_tool_temp
-octoprint.target_tool_temp,gauge,,degree celsius,,Target Temp (in C) of each extruder,0,octoprint,target_tool_temp
-octoprint.current_bed_temp,gauge,,degree celsius,,Temp (in C) of each printer bed,0,octoprint,current_bed_temp
-octoprint.target_bed_temp,gauge,,degree celsius,,Target Temp (in C) of each extruder,0,octoprint,target_bed_temp
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
+octoprint.rpi_core_temp,gauge,,degree celsius,,Temp (in C) of Raspberry Pi Core,0,octoprint,rpi_core_temp,
+octoprint.printer_state,gauge,,operation,,Current state of OctoPrint,0,octoprint,printer_state,
+octoprint.est_print_time,gauge,,minute,,Estimated print time of current job,0,octoprint,est_print_time,
+octoprint.pct_completed,gauge,,percent,,Percentage of current Print job completed,0,octoprint,pct_completed,
+octoprint.print_job_time,gauge,,minute,,Elapsed print time,0,octoprint,print_job_time,
+octoprint.print_job_time_left,gauge,,minute,,Estimated remaining print time,0,octoprint,print_job_time_left,
+octoprint.current_tool_temp,gauge,,degree celsius,,Temp (in C) of each extruder,0,octoprint,current_tool_temp,
+octoprint.target_tool_temp,gauge,,degree celsius,,Target Temp (in C) of each extruder,0,octoprint,target_tool_temp,
+octoprint.current_bed_temp,gauge,,degree celsius,,Temp (in C) of each printer bed,0,octoprint,current_bed_temp,
+octoprint.target_bed_temp,gauge,,degree celsius,,Target Temp (in C) of each extruder,0,octoprint,target_bed_temp,

--- a/pihole/metadata.csv
+++ b/pihole/metadata.csv
@@ -1,15 +1,15 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-pihole.queries_forwarded,gauge,,query,,Queries not blocked,0,pihole,queries_forwarded
-pihole.domains_being_blocked,gauge,,,,Domains that are currently being blocked,0,pihole,domains_being_blocked
-pihole.ads_percent_blocked,gauge,,percent,,Percentage of ads blocked today,0,pihole,ads_percent_blocked
-pihole.ads_blocked_today,gauge,,,,Number of ads blocked today,0,pihole,ads_blocked_today
-pihole.dns_queries_today,gauge,,,,Amount of queries made to Pi-hole,0,pihole,dns_queries_today
-pihole.clients_ever_seen,gauge,,,,Total clients,0,pihole,clients_ever_seen
-pihole.unique_clients,gauge,,,,Total number of unique clients,0,pihole,unique_clients
-pihole.queries_cached,gauge,,query,,Number of cached queries,0,pihole,queries_cached
-pihole.unique_domains,gauge,,,,Number of unique domains seen,0,pihole,unique_domains
-pihole.reply_nodata,gauge,,,,Number of no data replies,0,pihole,reply_NODATA
-pihole.reply_cname,gauge,,,,Number of cname replies,0,pihole,reply_cname
-pihole.reply_ip,gauge,,,,Number of ip replies,0,pihole,reply_ip
-pihole.reply_nxdomain,gauge,,,,Number of nxdomain replies,0,pihole,reply_NXDOMAIN
-pihole.dns_queries_all_types,gauge,,,,Amount of queries made to Pi-hole of all types,0,pihole,dns_queries_all_types
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
+pihole.queries_forwarded,gauge,,query,,Queries not blocked,0,pihole,queries_forwarded,
+pihole.domains_being_blocked,gauge,,,,Domains that are currently being blocked,0,pihole,domains_being_blocked,
+pihole.ads_percent_blocked,gauge,,percent,,Percentage of ads blocked today,0,pihole,ads_percent_blocked,
+pihole.ads_blocked_today,gauge,,,,Number of ads blocked today,0,pihole,ads_blocked_today,
+pihole.dns_queries_today,gauge,,,,Amount of queries made to Pi-hole,0,pihole,dns_queries_today,
+pihole.clients_ever_seen,gauge,,,,Total clients,0,pihole,clients_ever_seen,
+pihole.unique_clients,gauge,,,,Total number of unique clients,0,pihole,unique_clients,
+pihole.queries_cached,gauge,,query,,Number of cached queries,0,pihole,queries_cached,
+pihole.unique_domains,gauge,,,,Number of unique domains seen,0,pihole,unique_domains,
+pihole.reply_nodata,gauge,,,,Number of no data replies,0,pihole,reply_NODATA,
+pihole.reply_cname,gauge,,,,Number of cname replies,0,pihole,reply_cname,
+pihole.reply_ip,gauge,,,,Number of ip replies,0,pihole,reply_ip,
+pihole.reply_nxdomain,gauge,,,,Number of nxdomain replies,0,pihole,reply_NXDOMAIN,
+pihole.dns_queries_all_types,gauge,,,,Amount of queries made to Pi-hole of all types,0,pihole,dns_queries_all_types,

--- a/ping/metadata.csv
+++ b/ping/metadata.csv
@@ -1,3 +1,3 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-network.ping.response_time,gauge,,millisecond,,"The response time of a given host and ping port, tagged with url, e.g. 'host:192.168.1.100'.",-1,ping,ping resp time
-network.ping.can_connect,gauge,,,,"Value of 1 if the agent can successfully communicate with the target host, 0 otherwise",1,ping,ping can connect
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
+network.ping.response_time,gauge,,millisecond,,"The response time of a given host and ping port, tagged with url, e.g. 'host:192.168.1.100'.",-1,ping,ping resp time,
+network.ping.can_connect,gauge,,,,"Value of 1 if the agent can successfully communicate with the target host, 0 otherwise",1,ping,ping can connect,


### PR DESCRIPTION
### What does this PR do?
We want to allow the definition of metrics for a given integration as a 'curated' metric. A metric selected here can be given a type (starting with either 'cpu' or 'memory') to group metrics by when users are investigating issues based on that type. We will give these metrics more emphasis in the UI of our products (Live Processes to start) relative to other metrics.

Integrations synced to staging using `integration sync`

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
