### PR TITLE
[Release] Bumped redpanda to 1.1.0

### DIFF
--- a/redpanda/CHANGELOG.md
+++ b/redpanda/CHANGELOG.md
@@ -9,4 +9,4 @@
 
 ## 1.0.0 / 2021-11-10
 
-* [Added] Add Redpanda integration. See[#1020](https://github.com/DataDog/integrations-extras/pull/1020).
+* [Added] Add Redpanda integration. See [#1020](https://github.com/DataDog/integrations-extras/pull/1020).


### PR DESCRIPTION
### What does this PR do?

Release redpanda 1.1.0 again. Integration release pipeline for this PR failed: https://github.com/DataDog/integrations-extras/pull/1245

### Motivation


### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
