### PR TITLE
Updating the only DATABASE integration to live in DATA-STORE

### DIFF
--- a/neo4j/manifest.json
+++ b/neo4j/manifest.json
@@ -16,7 +16,7 @@
   ],
   "public_title": "Datadog-Neo4j Integration",
   "categories": [
-    "data-store"
+    "data store"
   ],
   "type": "check",
   "is_public": true,

--- a/neo4j/manifest.json
+++ b/neo4j/manifest.json
@@ -16,7 +16,7 @@
   ],
   "public_title": "Datadog-Neo4j Integration",
   "categories": [
-    "database"
+    "data-store"
   ],
   "type": "check",
   "is_public": true,


### PR DESCRIPTION
The database category for integrations https://www.datadoghq.com/product/platform/integrations/#cat-database only has one neo4j integration. If one were to go there, it looks like something must be wrong. If one went to the data-store integration and found all the actual database-related integrations there, one would figure out that we need to fix this. :)

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

I clicked on DATABASE integrations while preparing for a demo and was very confused.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

I don't know if there are additional changes that need to be made todo away with database integration category.
