### PR TITLE
Update README to clarify integration version

### DIFF
--- a/purefa/README.md
+++ b/purefa/README.md
@@ -24,7 +24,7 @@ Follow the instructions below to install and configure this check for an Agent r
 2. Manually install the Pure FlashArray integration. See [Use Community Integrations][10] for more details based on your environment.
 
 
-#### Agent Host
+#### Host
 
 To configure this check for an Agent running on a host, run `datadog-agent integration install -t datadog-purefa==<INTEGRATION_VERSION>`.
 

--- a/purefa/README.md
+++ b/purefa/README.md
@@ -28,7 +28,7 @@ Follow the instructions below to install and configure this check for an Agent r
 
 To configure this check for an Agent running on a host, run `datadog-agent integration install -t datadog-purefa==<INTEGRATION_VERSION>`.
 
-Note:  `<INTEGRATION_VERSION>` can be found within the [CHANGELOG.md](https://github.com/DataDog/integrations-extras/blob/master/purefa/CHANGELOG.md) for Datadog Integration Extras. 
+Note:  `<INTEGRATION_VERSION>` can be found within the [CHANGELOG.md][13] for Datadog Integration Extras. 
   * e.g. `datadog-agent integration install -t datadog-purefa==1.0.0`
 
 ### Configuration
@@ -139,3 +139,4 @@ For support or feature requests, contact Pure Storage through the following meth
 [10]: https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent
 [11]: https://code-purestorage.slack.com/messages/C0357KLR1EU
 [12]: https://github.com/DataDog/integrations-extras/blob/master/purefa/assets/service_checks.json
+[13]: https://github.com/DataDog/integrations-extras/blob/master/purefa/CHANGELOG.md

--- a/purefa/README.md
+++ b/purefa/README.md
@@ -24,9 +24,12 @@ Follow the instructions below to install and configure this check for an Agent r
 2. Manually install the Pure FlashArray integration. See [Use Community Integrations][10] for more details based on your environment.
 
 
-#### Host
+#### Agent Host
 
 To configure this check for an Agent running on a host, run `datadog-agent integration install -t datadog-purefa==<INTEGRATION_VERSION>`.
+
+Note:  `<INTEGRATION_VERSION>` can be found within the [CHANGELOG.md](https://github.com/DataDog/integrations-extras/blob/master/purefa/CHANGELOG.md) for Datadog Integration Extras. 
+  * e.g. `datadog-agent integration install -t datadog-purefa==1.0.0`
 
 ### Configuration
 


### PR DESCRIPTION
Clarifying how to find the `<INTEGRATION_VERSION>` for PureStorage through the CHANGELOG.md (https://github.com/DataDog/integrations-extras/blob/master/purefa/CHANGELOG.md).  

This may apply for all the integration-extras which doesn't specify in the main documentation (https://docs.datadoghq.com/agent/guide/use-community-integrations/?tab=agentv721v621).

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
