### PR TITLE
Add sales email to manifest

### DIFF
--- a/purefa/manifest.json
+++ b/purefa/manifest.json
@@ -39,7 +39,8 @@
   "author": {
     "homepage": "https://purestorage.com",
     "name": "Pure Storage",
-    "support_email": "pure-observability@purestorage.com"
+    "support_email": "pure-observability@purestorage.com",
+    "sales_email": "sales@purestorage.com"
   },
   "oauth": {},
   "assets": {


### PR DESCRIPTION
### What does this PR do?

Updates the manifest to have a `sales_email`. I am using the sales email from https://github.com/DataDog/integrations-extras/pull/1273 since it's another PureStorage integration.

### Motivation

Failing validation.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
