### PR TITLE
Run validations on master

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -8,6 +8,9 @@ on:
     branches:
     - master
 
+env:
+  CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -46,39 +49,39 @@ jobs:
 
     - name: Run configuration validation
       run: |
-        ddev validate config changed
+        ddev validate config $CHANGED
 
     - name: Run dashboard validation
       run: |
-        ddev validate dashboards changed
+        ddev validate dashboards $CHANGED
 
 #    - name: Run HTTP wrapper validation
 #      run: |
-#        ddev validate http changed
+#        ddev validate http $CHANGED
 
     - name: Run imports validation
       run: |
-        ddev validate imports changed
+        ddev validate imports $CHANGED
         
     - name: Run JMX metrics validation
       run: |
-        ddev validate jmx-metrics changed
+        ddev validate jmx-metrics $CHANGED
 
     - name: Run manifest validation
       run: |
-        ddev validate manifest changed
+        ddev validate manifest $CHANGED
         
     - name: Run metadata validation
       run: |
-        ddev validate metadata changed
+        ddev validate metadata $CHANGED
 
     - name: Run models validation
       run: |
-        ddev validate models changed
+        ddev validate models $CHANGED
   
     - name: Run legacy signature validation
       run: |
-        ddev validate legacy-signature changed
+        ddev validate legacy-signature $CHANGED
 
     - name: Run licenses validation
       run: |
@@ -86,23 +89,23 @@ jobs:
 
     - name: Run readmes validation
       run: |
-        ddev validate readmes changed
+        ddev validate readmes $CHANGED
 
     - name: Run recommended monitors validation
       run: |
-        ddev validate recommended-monitors changed
+        ddev validate recommended-monitors $CHANGED
 
     - name: Run package validation
       run: |
-        ddev validate package changed
+        ddev validate package $CHANGED
 
     - name: Run saved views validation
       run: |
-        ddev validate saved-views changed
+        ddev validate saved-views $CHANGED
         
     - name: Run service checks validation
       run: |
-        ddev validate service-checks changed
+        ddev validate service-checks $CHANGED
 
     - name: Comment PR on failure
       if: failure()


### PR DESCRIPTION
### What does this PR do?

Implements https://github.com/DataDog/integrations-core/pull/11888 on integrations-extras

### Motivation

We want all validations to run on master
### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
