### PR TITLE
Update ui-apps team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 /convox/                                 @DataDog/agent-integrations
 /cortex/                                 @cortexapps/engineering support@getcortexapp.com
 /cyral/                                  @tyrannosaurus-becks product@cyral.com
-/data_runner/                            @DataDog/ui-apps
+/data_runner/                            @DataDog/apps-sdk
 /datazoom/                               @DataDog/web-integrations
 /embrace_mobile/                         @jpmunz @joage
 /eventstore/                             @Xorima
@@ -123,7 +123,7 @@
 /tidb_cloud/                             @SabaPing xuyifan02@pingcap.com
 /torq/                                   @torqio/rnd support@torq.io
 /traefik/                                @renaudhager
-/twenty_forty_eight/                     @DataDog/ui-apps
+/twenty_forty_eight/                     @DataDog/apps-sdk
 /tyk/                                    @letzya
 /unbound/                                @dbyron0 david.byron@avast.com
 /upsc/                                   @platinummonkey


### PR DESCRIPTION
### What does this PR do?

Change ui-apps team name to apps-sdk. Official github team name will be updated shortly before merging