### PR TITLE
Add missing MANIFEST.in to nvml

### DIFF
--- a/nvml/MANIFEST.in
+++ b/nvml/MANIFEST.in
@@ -1,0 +1,11 @@
+graft datadog_checks
+graft tests
+
+include MANIFEST.in
+include README.md
+include requirements.in
+include requirements.txt
+include requirements-dev.txt
+include manifest.json
+
+global-exclude *.py[cod] __pycache__

--- a/nvml/pyproject.toml
+++ b/nvml/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-nvml"
 description = "The nvml check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = { text = "BSD-3-Clause" }
 keywords = [
     "datadog",
     "datadog agent",


### PR DESCRIPTION
Docker builds fail without this

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
