### PR TITLE
Correct the spelling of Log Explorer

### DIFF
--- a/datazoom/README.md
+++ b/datazoom/README.md
@@ -16,7 +16,7 @@ The Datazoom integration emits logs to Datadog. No installation is required on t
 
 ### Configuration
 
-- Visit Datazoom's integation [documentation][1] for details on how to configure the Datazoom Datadog Connector.
+- Visit Datazoom's integration [documentation][1] for details on how to configure the Datazoom Datadog Connector.
 
 ### Dashboard
 

--- a/datazoom/manifest.json
+++ b/datazoom/manifest.json
@@ -6,7 +6,7 @@
   "metric_prefix": "datazoom.",
   "metric_to_check": "",
   "creates_events": false,
-  "short_description": "View Datazoom Collector data in Logs Explorer.",
+  "short_description": "View Datazoom Collector data in Log Explorer.",
   "guid": "eef8335b-ae57-4bbf-82a7-41f9b8a704e9",
   "support": "contrib",
   "supported_os": [


### PR DESCRIPTION
### What does this PR do?

Correct the spellings of Log Explorer and integration in the Datazoom integration docs.

### Motivation

The French translator noticed the errors

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
