### PR TITLE
Including tagging for lightstep incident response on Datadog

### DIFF
--- a/lightstep_incident_response/manifest.json
+++ b/lightstep_incident_response/manifest.json
@@ -19,7 +19,7 @@
       "Category::Collaboration",
       "Category::Issue Tracking",
       "Category::Notification",
-      "Category::Incident response"
+      "Category::Incidents"
     ]
   },
   "author": {

--- a/lightstep_incident_response/manifest.json
+++ b/lightstep_incident_response/manifest.json
@@ -29,15 +29,4 @@
     "sales_email": "success@lightstep.com"
   },
   "oauth": {},
-  "assets": {
-      "metrics": {
-        "prefix": "lightstep-incident-response",
-        "check": "",
-        "metadata_path": "metadata.csv"
-      },
-      "service_checks": {
-        "metadata_path": "assets/service_checks.json"
-      }
-    }
-  }
-}
+  "assets": {}

--- a/lightstep_incident_response/manifest.json
+++ b/lightstep_incident_response/manifest.json
@@ -29,4 +29,21 @@
     "sales_email": "success@lightstep.com"
   },
   "oauth": {},
-  "assets": {}
+  "assets": {
+    "integration": {
+      "source_type_name": "Lightstep Incident Response",
+      "configuration": {},
+      "events": {
+        "creates_events": false
+      },
+      "metrics": {
+        "prefix": "lightstep-incident-response",
+        "check": [],
+        "metadata_path": "metadata.csv"
+      },
+      "service_checks": {
+        "metadata_path": "assets/service_checks.json"
+      }
+    }
+  }
+}

--- a/lightstep_incident_response/manifest.json
+++ b/lightstep_incident_response/manifest.json
@@ -30,12 +30,6 @@
   },
   "oauth": {},
   "assets": {
-    "integration": {
-      "source_type_name": "Lightstep Incident Response",
-      "configuration": {},
-      "events": {
-        "creates_events": false
-      },
       "metrics": {
         "prefix": "lightstep-incident-response",
         "check": "",

--- a/lightstep_incident_response/manifest.json
+++ b/lightstep_incident_response/manifest.json
@@ -14,7 +14,12 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::Mac OS",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Category::Alerting",
+      "Category::Collaboration",
+      "Category::Issue Tracking",
+      "Category::Notification",
+      "Category::Incident response"
     ]
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?

Including tags for lightstep Incident response tile on Data dog

### Motivation

Provide the customers with better ability of finding lightstep incident response tile on Datadog 


