### PR TITLE
Remove inaccuracy around API and APP keys

### DIFF
--- a/docontrol/README.md
+++ b/docontrol/README.md
@@ -19,13 +19,13 @@ You must create a Datadog API key and an application key to use as input paramet
 #### Create an API key in Datadog
 
 1. Use Datadog's [Add an API key][2] documentation to create an API key. Give the key a meaningful name such as `DoControl`.
-2. Copy the `Key` and save it. This key is not accessible after exiting the page.
+2. Copy the `Key` and save it.
 
 
 #### Create an application key in Datadog
 
 1. Use Datadog's [Add application keys][3] documentation to create an application key.
-2. Copy and save your application key. This key is not accessible after exiting the page.
+2. Copy and save your application key.
 
 ![Get_DD_Application_Key](https://raw.githubusercontent.com/DataDog/integrations-extras/master/docontrol/images/Get_DD_Application_Key.png)
 


### PR DESCRIPTION

### What does this PR do?

This PR corrects an earlier oversight in the initial approval of the documentation. It removes notes stating that API and APP keys cannot be accessed after being created. Creators of API and APP keys can indeed copy these values again after leaving the page.

### Motivation

DOCS-3564

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
