### PR TITLE
Remove 'Integration' from tiles titles

### DIFF
--- a/algorithmia/manifest.json
+++ b/algorithmia/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Algorithmia Integration",
+  "public_title": "Algorithmia",
   "categories": [
     "monitoring"
   ],

--- a/altostra/manifest.json
+++ b/altostra/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Altostra Integration",
+  "public_title": "Altostra",
   "categories": [
     "automation",
     "cloud",

--- a/ambassador/manifest.json
+++ b/ambassador/manifest.json
@@ -15,7 +15,7 @@
   "metric_prefix": "envoy.",
   "metric_to_check": "envoy.listener.downstream_cx_total",
   "creates_events": false,
-  "public_title": "Ambassador API Gateway Integration",
+  "public_title": "Ambassador API Gateway",
   "type": "check",
   "is_public": true,
   "categories": [

--- a/amixr/manifest.json
+++ b/amixr/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Amixr Integration",
+  "public_title": "Amixr",
   "categories": [
     "monitoring",
     "collaboration",

--- a/apache-apisix/manifest.json
+++ b/apache-apisix/manifest.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Apache APISIX",
-  "public_title": "Apache APISIX Integration",
+  "public_title": "Apache APISIX",
   "integration_id": "apache-apisix",
   "is_public": true,
   "maintainer": "dev@apisix.apache.org",

--- a/apollo/manifest.json
+++ b/apollo/manifest.json
@@ -18,7 +18,7 @@
     "apollo.engine.operations.count"
   ],
   "creates_events": false,
-  "public_title": "Apollo Integration",
+  "public_title": "Apollo",
   "type": "crawler",
   "is_public": true,
   "categories": [

--- a/appkeeper/manifest.json
+++ b/appkeeper/manifest.json
@@ -13,7 +13,7 @@
     "linux",
     "windows"
   ],
-  "public_title": "AppKeeper Integration",
+  "public_title": "AppKeeper",
   "categories": [
     "aws",
     "cloud",

--- a/aqua/manifest.json
+++ b/aqua/manifest.json
@@ -15,7 +15,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Aqua Integration",
+  "public_title": "Aqua",
   "categories": [
     "security",
     "monitoring",

--- a/auth0/manifest.json
+++ b/auth0/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Auth0 Integration",
+  "public_title": "Auth0",
   "categories": [
     "log collection",
     "security"

--- a/aws_pricing/manifest.json
+++ b/aws_pricing/manifest.json
@@ -15,7 +15,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "AWS Pricing Integration",
+  "public_title": "AWS Pricing",
   "categories": [
     "aws",
     "cloud",

--- a/bind9/manifest.json
+++ b/bind9/manifest.json
@@ -10,7 +10,7 @@
   "guid": "bce6961c-4312-11e9-b210-d663bd873d93",
   "is_public": true,
   "maintainer": "ashuvyas45@gmail.com",
-  "public_title": "bind9 Integration",
+  "public_title": "bind9",
   "manifest_version": "1.0.0",
   "name": "bind9",
   "short_description": "A datadog integration to collect bind9 server metrics",

--- a/bluematador/manifest.json
+++ b/bluematador/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Blue Matador Integration",
+  "public_title": "Blue Matador",
   "categories": [
     "monitoring"
   ],

--- a/bonsai/manifest.json
+++ b/bonsai/manifest.json
@@ -10,7 +10,7 @@
   "metric_prefix": "bonsai.",
   "metric_to_check": "bonsai.req.total",
   "creates_events": false,
-  "public_title": "Bonsai Integration",
+  "public_title": "Bonsai",
   "type": "crawler",
   "is_public": true,
   "categories": [

--- a/botprise/manifest.json
+++ b/botprise/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Botprise Integration",
+  "public_title": "Botprise",
   "categories": [
     "monitoring"
   ],

--- a/buddy/manifest.json
+++ b/buddy/manifest.json
@@ -16,7 +16,7 @@
     "windows"
   ],
   "guid": "7b131269-e2ba-4279-b9dd-82e85764d389",
-  "public_title": "Buddy Integration",
+  "public_title": "Buddy",
   "type": "crawler",
   "is_public": true,
   "assets": {

--- a/cert_manager/manifest.json
+++ b/cert_manager/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "cert-manager Integration",
+  "public_title": "cert-manager",
   "categories": [
     "security",
     "configuration & deployment",

--- a/cockroachdb_dedicated/manifest.json
+++ b/cockroachdb_dedicated/manifest.json
@@ -14,7 +14,7 @@
   "short_description": "Send your Cockroach Cloud metrics to DataDog.",
   "metric_prefix": "crdb_dedicated.",
   "metric_to_check": "crdb_dedicated.sys.rss",
-  "public_title": "CockroachDB Dedicated Integration",
+  "public_title": "CockroachDB Dedicated",
   "creates_events": false,
   "assets": {
     "dashboards": {

--- a/concourse_ci/manifest.json
+++ b/concourse_ci/manifest.json
@@ -6,7 +6,7 @@
   "guid": "054cc9fb-01c4-4f05-98b5-fae828746787",
   "is_public": true,
   "maintainer": "help@datadoghq.com",
-  "public_title": "Concourse-CI Integration",
+  "public_title": "Concourse-CI",
   "support": "contrib",
   "supported_os": [
     "linux",

--- a/configcat/manifest.json
+++ b/configcat/manifest.json
@@ -15,7 +15,7 @@
   "maintainer": "developer@configcat.com",
   "manifest_version": "1.0.0",
   "name": "configcat",
-  "public_title": "ConfigCat Integration",
+  "public_title": "ConfigCat",
   "description": "Datadog-ConfigCat integration ensures that all ConfigCat settings changes send to Datadog as an Event. With this feature you can see your system behaviour when changing your settings. You can setup the Datadog integration for a products in the ConfigCat.",
   "short_description": "Setting change events tracked by Datadog",
   "support": "contrib",

--- a/contrastsecurity/manifest.json
+++ b/contrastsecurity/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Contrast Security Integration",
+  "public_title": "Contrast Security",
   "categories": [
     "log collection"
   ],

--- a/convox/manifest.json
+++ b/convox/manifest.json
@@ -16,7 +16,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Convox Integration",
+  "public_title": "Convox",
   "type": "crawler",
   "is_public": true,
   "assets": {

--- a/datazoom/manifest.json
+++ b/datazoom/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datazoom Integration",
+  "public_title": "Datazoom",
   "categories": [
     ""
   ],

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -11,7 +11,7 @@
     "windows"
   ],
   "guid": "4BEB8E51-E7DA-4145-B780-E3B3A6A8CD60",
-  "public_title": "Eventstore Integration",
+  "public_title": "Eventstore",
   "categories": [
     "data store"
   ],

--- a/federatorai/manifest.json
+++ b/federatorai/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Federator.ai Integration",
+  "public_title": "Federator.ai",
   "categories": [
     "containers",
     "orchestration"

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -12,7 +12,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Filebeat Integration",
+  "public_title": "Filebeat",
   "categories": [
     "os & system"
   ],

--- a/fluentbit/manifest.json
+++ b/fluentbit/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Fluent Bit (Agent) Integration",
+  "public_title": "Fluent Bit (Agent)",
   "categories": [
     "metrics"
   ],

--- a/gnatsd/manifest.json
+++ b/gnatsd/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": "1.0.0",
   "name": "gnatsd",
   "display_name": "Gnatsd",
-  "public_title": "Gnatsd Integration",
+  "public_title": "Gnatsd",
   "short_description": "Monitor gnatsd cluster with Datadog.",
   "guid": "7edcf450-d9cf-44aa-9053-ece04ac7c21d",
   "support": "contrib",

--- a/gnatsd_streaming/manifest.json
+++ b/gnatsd_streaming/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": "1.0.0",
   "name": "gnatsd_streaming",
   "display_name": "Gnatsd streaming",
-  "public_title": "Gnatsd Streaming Integration",
+  "public_title": "Gnatsd Streaming",
   "short_description": "NATS server streaming",
   "guid": "0a849512-5823-4d9b-b378-aa9d8fb06231",
   "support": "contrib",

--- a/gremlin/manifest.json
+++ b/gremlin/manifest.json
@@ -11,7 +11,7 @@
   "maintainer": "support@gremlin.com",
   "manifest_version": "1.0.0",
   "name": "gremlin",
-  "public_title": "Gremlin Integration",
+  "public_title": "Gremlin",
   "short_description": "Send events occurring in Gremlin to Datadog",
   "support": "contrib",
   "supported_os": [

--- a/hasura_cloud/manifest.json
+++ b/hasura_cloud/manifest.json
@@ -18,7 +18,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Hasura Cloud Integration",
+  "public_title": "Hasura Cloud",
   "categories": [
     "monitoring",
     "log collection",

--- a/hbase_master/manifest.json
+++ b/hbase_master/manifest.json
@@ -13,7 +13,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Hbase Master Integration",
+  "public_title": "Hbase Master",
   "categories": [
     "data store",
     "log collection"

--- a/hbase_regionserver/manifest.json
+++ b/hbase_regionserver/manifest.json
@@ -13,7 +13,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Hbase region server Integration",
+  "public_title": "Hbase region server",
   "categories": [
     "data store",
     "log collection"

--- a/hcp_vault/manifest.json
+++ b/hcp_vault/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "HCP Vault Integration",
+  "public_title": "HCP Vault",
   "categories": [
     ""
   ],

--- a/ilert/manifest.json
+++ b/ilert/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "iLert Integration",
+  "public_title": "iLert",
   "categories": [
     "issue tracking",
     "collaboration",

--- a/k6/manifest.json
+++ b/k6/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "k6 Integration",
+  "public_title": "k6",
   "categories": [
     "monitoring",
     "notification"

--- a/kernelcare/manifest.json
+++ b/kernelcare/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Kernelcare Integration",
+  "public_title": "Kernelcare",
   "categories": [
     "security",
     "os & system"

--- a/lacework/manifest.json
+++ b/lacework/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Lacework Integration",
+  "public_title": "Lacework",
   "categories": [
     "security",
     "log collection"

--- a/lambdatest/manifest.json
+++ b/lambdatest/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "LambdaTest Integration",
+  "public_title": "LambdaTest",
   "categories": [
     "Issue Tracking",
     "Automation",

--- a/lighthouse/manifest.json
+++ b/lighthouse/manifest.json
@@ -13,7 +13,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Lighthouse Integration",
+  "public_title": "Lighthouse",
   "categories": [
     "web"
   ],

--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Logstash Integration",
+  "public_title": "Logstash",
   "categories": [
     "log collection"
   ],

--- a/logzio/manifest.json
+++ b/logzio/manifest.json
@@ -5,7 +5,7 @@
   "display_name": "Logz.io",
   "short_description": "AI-Powered ELK as a Service",
   "creates_events": false,
-  "public_title": "Logz.io Integration",
+  "public_title": "Logz.io",
   "type": "crawler",
   "is_public": true,
   "support": "contrib",

--- a/n2ws/manifest.json
+++ b/n2ws/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "N2WS Integration",
+  "public_title": "N2WS",
   "categories": [
     "cloud"
   ],

--- a/neo4j/manifest.json
+++ b/neo4j/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Neo4j Integration",
+  "public_title": "Neo4j",
   "categories": [
     "data store"
   ],

--- a/neutrona/manifest.json
+++ b/neutrona/manifest.json
@@ -15,7 +15,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Neutrona Integration",
+  "public_title": "Neutrona",
   "categories": [
     "AZURE",
     "CLOUD",

--- a/nextcloud/manifest.json
+++ b/nextcloud/manifest.json
@@ -15,7 +15,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Nextcloud Integration",
+  "public_title": "Nextcloud",
   "categories": [
     "collaboration"
   ],

--- a/nomad/manifest.json
+++ b/nomad/manifest.json
@@ -9,7 +9,7 @@
   "metric_prefix": "nomad",
   "metric_to_check": "nomad.client.host.cpu.user",
   "creates_events": true,
-  "public_title": "Nomad Integration",
+  "public_title": "Nomad",
   "supported_os": [
     "linux",
     "mac_os",

--- a/octoprint/manifest.json
+++ b/octoprint/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Datadog OctoPrint Integration",
+  "public_title": "Datadog OctoPrint",
   "categories": [
     "web",
     "orchestration",

--- a/perimeterx/manifest.json
+++ b/perimeterx/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "PerimeterX Integration",
+  "public_title": "PerimeterX",
   "categories": [
     "security"
   ],

--- a/php_apcu/manifest.json
+++ b/php_apcu/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "PHP APCu Integration",
+  "public_title": "PHP APCu",
   "categories": [
     ""
   ],

--- a/php_opcache/manifest.json
+++ b/php_opcache/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "PHP OPcache Integration",
+  "public_title": "PHP OPcache",
   "categories": [
     ""
   ],

--- a/pihole/manifest.json
+++ b/pihole/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Pi-hole Integration",
+  "public_title": "Pi-hole",
   "categories": [
     "network",
     "log collection"

--- a/ping/manifest.json
+++ b/ping/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "network.",
   "metric_to_check": "network.ping.response_time",
   "name": "ping",
-  "public_title": "Ping Integration",
+  "public_title": "Ping",
   "short_description": "Monitor connectivity to remote hosts.",
   "support": "contrib",
   "supported_os": [

--- a/pliant/manifest.json
+++ b/pliant/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Pliant Integration",
+  "public_title": "Pliant",
   "categories": [
     "orchestration",
     "notification",

--- a/portworx/manifest.json
+++ b/portworx/manifest.json
@@ -7,7 +7,7 @@
   "short_description": "Collect runtime metrics from a Portworx Instance.",
   "metric_prefix": "portworx.",
   "metric_to_check": "portworx.cluster.cpu_percent",
-  "public_title": "Portworx Integration",
+  "public_title": "Portworx",
   "guid": "858a4b03-3f75-4019-8ba8-46b00d5aeb46",
   "support": "contrib",
   "type": "check",

--- a/puma/manifest.json
+++ b/puma/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Puma Integration",
+  "public_title": "Puma",
   "categories": [
     "web"
   ],

--- a/rbltracker/manifest.json
+++ b/rbltracker/manifest.json
@@ -7,7 +7,7 @@
   "metric_prefix": "",
   "metric_to_check": "",
   "creates_events": true,
-  "public_title": "RBLTracker Integration",
+  "public_title": "RBLTracker",
   "maintainer": "help@datadoghq.com",
   "guid": "94218bd0-8cc3-4686-8b67-ea9110b77092",
   "categories": [

--- a/reboot_required/manifest.json
+++ b/reboot_required/manifest.json
@@ -10,7 +10,7 @@
     "linux"
   ],
   "guid": "e7eed0e7-0acd-47c9-b684-3190828517ce",
-  "public_title": "Reboot Required Integration",
+  "public_title": "Reboot Required",
   "categories": [
     "os & system"
   ],

--- a/redis_sentinel/manifest.json
+++ b/redis_sentinel/manifest.json
@@ -13,7 +13,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Redis Sentinel Integration",
+  "public_title": "Redis Sentinel",
   "categories": [
     "os & system"
   ],

--- a/redisenterprise/manifest.json
+++ b/redisenterprise/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "RedisEnterprise Integration",
+  "public_title": "RedisEnterprise",
   "categories": [
     "data store",
     "caching"

--- a/resin/manifest.json
+++ b/resin/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Resin Integration",
+  "public_title": "Resin",
   "categories": [
     "web",
     "log collection"

--- a/riak_repl/manifest.json
+++ b/riak_repl/manifest.json
@@ -15,7 +15,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Riak MDC Replication Integration",
+  "public_title": "Riak MDC Replication",
   "categories": [
     "data store"
   ],

--- a/rigor/manifest.json
+++ b/rigor/manifest.json
@@ -10,7 +10,7 @@
   "maintainer": "support@rigor.com",
   "manifest_version": "1.0.0",
   "name": "rigor",
-  "public_title": "Rigor Integration",
+  "public_title": "Rigor",
   "short_description": "Rigor provides synthetic monitoring and optimization throughout dev lifecycle",
   "support": "contrib",
   "supported_os": [

--- a/rundeck/manifest.json
+++ b/rundeck/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Rundeck Integration",
+  "public_title": "Rundeck",
   "categories": [
     "orchestration",
     "notification"

--- a/sedai/manifest.json
+++ b/sedai/manifest.json
@@ -15,7 +15,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Sedai Integration",
+  "public_title": "Sedai",
   "categories": [
     "automation",
     "cloud",

--- a/sendmail/manifest.json
+++ b/sendmail/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Sendmail Integration",
+  "public_title": "Sendmail",
   "categories": [
     "Collaboration"
   ],

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -9,7 +9,7 @@
   "metric_prefix": "sigsci.",
   "metric_to_check": "sigsci.agent.signal",
   "creates_events": true,
-  "public_title": "Signal Sciences Integration",
+  "public_title": "Signal Sciences",
   "type": "crawler",
   "support": "contrib",
   "supported_os": [

--- a/sleuth/manifest.json
+++ b/sleuth/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Sleuth Integration",
+  "public_title": "Sleuth",
   "categories": [
     "orchestration",
     "issue tracking",

--- a/snmpwalk/manifest.json
+++ b/snmpwalk/manifest.json
@@ -12,7 +12,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "SNMP walk Integration",
+  "public_title": "SNMP walk",
   "categories": [
     "monitoring",
     "notification",

--- a/sortdb/manifest.json
+++ b/sortdb/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": "1.0.0",
   "name": "sortdb",
   "display_name": "Sortdb",
-  "public_title": "Sortdb Integration",
+  "public_title": "Sortdb",
   "short_description": "Datadog support for sortdb monitoring",
   "guid": "806dcbd7-3686-4472-9435-2049729847c1",
   "support": "contrib",

--- a/speedtest/manifest.json
+++ b/speedtest/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "speedtest Integration",
+  "public_title": "speedtest",
   "categories": [
     "isp",
     "network"

--- a/split/manifest.json
+++ b/split/manifest.json
@@ -16,7 +16,7 @@
   ],
   "short_description": "Feature Experimentation Platform for Engineering and Product Teams.",
   "creates_events": true,
-  "public_title": "Split Integration",
+  "public_title": "Split",
   "type": "crawler",
   "is_public": true,
   "assets": {

--- a/sqreen/manifest.json
+++ b/sqreen/manifest.json
@@ -8,7 +8,7 @@
   "short_description": "Review AppSec activity detected by Sqreen",
   "metric_prefix": "sqreen.",
   "creates_events": false,
-  "public_title": "Sqreen integration",
+  "public_title": "Sqreen",
   "type": "crawler",
   "support": "contrib",
   "supported_os": [

--- a/squadcast/manifest.json
+++ b/squadcast/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Squadcast Integration",
+  "public_title": "Squadcast",
   "categories": [
     "issue tracking",
     "collaboration",

--- a/stackpulse/manifest.json
+++ b/stackpulse/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "StackPulse Integration",
+  "public_title": "StackPulse",
   "categories": [
     "automation",
     "orchestration",

--- a/stardog/manifest.json
+++ b/stardog/manifest.json
@@ -11,7 +11,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Stardog Integration",
+  "public_title": "Stardog",
   "categories": [
     "data store"
   ],

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -12,7 +12,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Storm Integration",
+  "public_title": "Storm",
   "categories": [
     "processing"
   ],

--- a/superwise/manifest.json
+++ b/superwise/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Superwise Integration",
+  "public_title": "Superwise",
   "categories": [
     "monitoring",
     "MLOps"

--- a/syncthing/manifest.json
+++ b/syncthing/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Syncthing Integration",
+  "public_title": "Syncthing",
   "categories": [
     "collaboration"
   ],

--- a/torq/manifest.json
+++ b/torq/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Torq Integration",
+  "public_title": "Torq",
   "categories": [
     "automation",
     "orchestration",

--- a/traefik/manifest.json
+++ b/traefik/manifest.json
@@ -12,7 +12,7 @@
     "windows"
   ],
   "guid": "322c0b9d-3ec6-434e-918c-5740f2a114bf",
-  "public_title": "Traefik Integration",
+  "public_title": "Traefik",
   "categories": [
     "web",
     "log collection"

--- a/tyk/manifest.json
+++ b/tyk/manifest.json
@@ -1,6 +1,6 @@
 {
   "display_name": "Tyk",
-  "public_title": "Tyk Integration",
+  "public_title": "Tyk",
   "integration_id": "tyk",
   "is_public": true,
   "maintainer": "yaara@tyk.io",

--- a/unbound/manifest.json
+++ b/unbound/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Unbound Integration",
+  "public_title": "Unbound",
   "categories": [
     "network"
   ],

--- a/upsc/manifest.json
+++ b/upsc/manifest.json
@@ -13,7 +13,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "UPSC Integration",
+  "public_title": "UPSC",
   "type": "check",
   "is_public": true,
   "metric_prefix": "upsc.",

--- a/uptime/manifest.json
+++ b/uptime/manifest.json
@@ -15,7 +15,7 @@
   "metric_prefix": "uptime",
   "metric_to_check": "uptime.response_time",
   "creates_events": true,
-  "public_title": "Uptime Integration",
+  "public_title": "Uptime",
   "categories": [
     "os & system"
   ],

--- a/vespa/manifest.json
+++ b/vespa/manifest.json
@@ -10,7 +10,7 @@
   "maintainer": "dd@vespa.ai",
   "manifest_version": "1.0.0",
   "name": "vespa",
-  "public_title": "Vespa Integration",
+  "public_title": "Vespa",
   "short_description": "Health and performance monitoring for the big data serving engine Vespa",
   "support": "contrib",
   "supported_os": [

--- a/vns3/manifest.json
+++ b/vns3/manifest.json
@@ -18,7 +18,7 @@
   "metric_prefix": "vns3.",
   "metric_to_check": "vns3.peering",
   "creates_events": false,
-  "public_title": "VNS3 Integration",
+  "public_title": "VNS3",
   "type": "crawler",
   "is_public": true,
   "assets": {

--- a/zscaler/manifest.json
+++ b/zscaler/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Zscaler Integration",
+  "public_title": "Zscaler",
   "categories": [
     ""
   ],


### PR DESCRIPTION
It is redundant that integrations are called "Integrations"
Relates to https://github.com/DataDog/integrations-core/pull/12414