### PR TITLE
docs: fix broken links in README files

### DIFF
--- a/apache-apisix/README.md
+++ b/apache-apisix/README.md
@@ -103,7 +103,7 @@ Need help? Contact [Datadog support][6].
 [2]: https://apisix.apache.org/
 [3]: https://docs.datadoghq.com/agent/
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[5]: https://github.com/DataDog/integrations-core/blob/master/apache-apisix/metadata.csv
+[5]: https://github.com/DataDog/integrations-extras/blob/master/apache-apisix/metadata.csv
 [6]: https://docs.datadoghq.com/help/
 [7]: https://apisix.apache.org/blog/2021/11/12/apisix-datadog
 [8]: https://www.datadoghq.com/

--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -130,6 +130,6 @@ Need help? Contact [Datadog support][10].
 [6]: https://github.com/DataDog/integrations-extras/blob/master/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [8]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[9]: https://github.com/DataDog/integrations-core/blob/master/cert_manager/metadata.csv
+[9]: https://github.com/DataDog/integrations-extras/blob/master/cert_manager/metadata.csv
 [10]: https://docs.datadoghq.com/help/
 [11]: https://github.com/DataDog/integrations-extras/blob/master/cert_manager/assets/service_checks.json

--- a/gatekeeper/README.md
+++ b/gatekeeper/README.md
@@ -131,6 +131,6 @@ Need help? Contact [Datadog support][10].
 [6]: https://github.com/DataDog/integrations-extras/blob/master/gatekeeper/datadog_checks/gatekeeper/data/conf.yaml.example
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [8]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[9]: https://github.com/DataDog/integrations-core/blob/master/gatekeeper/metadata.csv
+[9]: https://github.com/DataDog/integrations-extras/blob/master/gatekeeper/metadata.csv
 [10]: https://docs.datadoghq.com/help/
 [11]: https://github.com/DataDog/integrations-extras/blob/master/gatekeeper/assets/service_checks.json

--- a/neutrona/README.md
+++ b/neutrona/README.md
@@ -59,5 +59,5 @@ Need help? Contact [Datadog support][12].
 [8]: https://github.com/DataDog/integrations-extras/blob/master/neutrona/datadog_checks/neutrona/data/conf.yaml.example
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#service-status
-[11]: https://github.com/DataDog/integrations-core/blob/master/neutrona/metadata.csv
+[11]: https://github.com/DataDog/integrations-extras/blob/master/neutrona/metadata.csv
 [12]: https://docs.datadoghq.com/help/

--- a/nvml/README.md
+++ b/nvml/README.md
@@ -70,7 +70,7 @@ Need help? Contact [Datadog support][11].
 [7]: https://github.com/DataDog/integrations-extras/blob/master/nvml/datadog_checks/nvml/data/conf.yaml.example
 [8]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[10]: https://github.com/DataDog/integrations-core/blob/master/nvml/metadata.csv
+[10]: https://github.com/DataDog/integrations-extras/blob/master/nvml/metadata.csv
 [11]: https://docs.datadoghq.com/help
 [12]: https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources
 [13]: https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html

--- a/open_policy_agent/README.md
+++ b/open_policy_agent/README.md
@@ -138,6 +138,6 @@ Need help? Contact [Datadog support][13].
 [9]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/open_policy_agent/images/metric.png
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [11]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[12]: https://github.com/DataDog/integrations-core/blob/master/open_policy_agent/metadata.csv
+[12]: https://github.com/DataDog/integrations-extras/blob/master/open_policy_agent/metadata.csv
 [13]: https://docs.datadoghq.com/help/
 [14]: https://github.com/DataDog/integrations-extras/blob/master/open_policy_agent/assets/service_checks.json

--- a/rigor/README.md
+++ b/rigor/README.md
@@ -143,4 +143,4 @@ Need help? Contact [Rigor support][11].
 [9]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/rigor/images/rigor_add_webhook_to_check.png
 [10]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/rigor/images/rigor_events_example.png
 [11]: mailto:support@rigor.com
-[13]: https://github.com/DataDog/integrations-core/blob/master/rigor/metadata.csv
+[13]: https://github.com/DataDog/integrations-extras/blob/master/rigor/metadata.csv

--- a/superwise/README.md
+++ b/superwise/README.md
@@ -62,6 +62,6 @@ Additional helpful documentation, links, and articles:
 [5]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/superwise/images/6.png
 [6]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/superwise/images/3.png
 [7]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/superwise/images/4.png
-[8]: https://github.com/DataDog/integrations-core/blob/master/check/metadata.csv
+[8]: https://github.com/DataDog/integrations-extras/blob/master/superwise/metadata.csv
 [9]: https://docs.superwise.ai
 [10]: https://www.datadoghq.com/blog/superwise-datadog-marketplace/

--- a/zscaler/README.md
+++ b/zscaler/README.md
@@ -134,6 +134,6 @@ Need help? Contact [Datadog support][7].
 [3]: https://github.com/DataDog/integrations-core/blob/master/zscaler/datadog_checks/zscaler/data/conf.yaml.example
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[6]: https://github.com/DataDog/integrations-core/blob/master/zscaler/metadata.csv
+[6]: https://github.com/DataDog/integrations-extras/blob/master/zscaler/metadata.csv
 [7]: https://docs.datadoghq.com/help/
 [8]: https://help.zscaler.com/zia/about-nanolog-streaming-service


### PR DESCRIPTION
### What does this PR do?

Noticed broken links in some README files pointing to the `core` repository instead of `extras`. Fixing them

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
