### PR TITLE
Add GPU temperature

### DIFF
--- a/nvml/CHANGELOG.md
+++ b/nvml/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - nvml
 
+## 1.0.2
+
+* Add GPU temperature metric. 
+
 ## 1.0.1
 
 * [FIXED] Make nvml check quieter on non-GPU hosts (https://github.com/DataDog/integrations-extras/pull/817)

--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -159,6 +159,11 @@ class NvmlCheck(AgentCheck):
             self.monotonic_count('pcie_tx_throughput', tx_bytes, tags=tags)
             self.monotonic_count('pcie_rx_throughput', rx_bytes, tags=tags)
 
+        # https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g92d1c5182a14dd4be7090e3c1480b121
+        with NvmlCall("temperature", self.log):
+            temp = NvmlCheck.N.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
+            self.monotonic_count('temperature', temp, tags=tags)
+
     def _start_discovery(self):
         """Start daemon thread to discover which k8s pod is assigned to a GPU"""
         # type: () -> None

--- a/nvml/metadata.csv
+++ b/nvml/metadata.csv
@@ -11,3 +11,4 @@ nvml.enc_utilization,gauge,,percent,,The current utilization for the Encoder,0,n
 nvml.dec_utilization,gauge,,percent,,The current utilization for the Decoder,0,nvml,decoder_utilization,
 nvml.pcie_tx_throughput,gauge,,kibibyte,second,PCIe TX utilization,0,nvml,TX_utilization,
 nvml.pcie_rx_throughput,gauge,,kibibyte,second,PCIe RX utilization,0,nvml,RX_utilization,
+nvml.temperature,gauge,,,,Current temperature for this GPU in degrees celsius,0,nvml,temperature,

--- a/nvml/tests/test_nvml.py
+++ b/nvml/tests/test_nvml.py
@@ -66,6 +66,10 @@ class MockNvml:
     def nvmlDeviceGetPowerUsage(h):
         return 12
 
+    @staticmethod
+    def nvmlDeviceGetTemperature(h, b):
+        return 13
+
 
 @pytest.mark.unit
 def test_check(aggregator, instance):
@@ -85,5 +89,6 @@ def test_check(aggregator, instance):
     aggregator.assert_metric('nvml.pcie_rx_throughput', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.pcie_tx_throughput', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.power_usage', tags=expected_tags, count=1)
+    aggregator.assert_metric('nvml.temperature', tags=expected_tags, count=1)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
This implementation gathers the temperature metric collection based on the NVML API syntax (https://docs.nvidia.com/deploy/nvml-api/index.html).

### What does this PR do?

Adds GPU temperature to the monitored metrics.

### Motivation

GPU temperature is a very important metric to monitor when working with GPUs under heavy workloads.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
