### PR TITLE
Add kube pod tags to nvml reported metrics

### DIFF
--- a/nvml/requirements.in
+++ b/nvml/requirements.in
@@ -1,2 +1,2 @@
-pynvml==8.0.4
+pynvml==11.4.1
 grpcio==1.27.2


### PR DESCRIPTION
### What does this PR do?

Currently when the nvml plugin submits GPU metrics (`nvml.*`), they only include 3 tags that were available from the kubelet pod resources socket (pod name/namespace/container name).

This change uses the [tagger](https://github.com/DataDog/datadog-agent/blob/main/pkg/tagger/README.md) python API to look up datadog tags that apply to the individual pod, which allows people using the nvml integration to slice metrics across additional dimensions.

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [X] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
