### PR TITLE
Adding date to Firefly's changelog

### DIFF
--- a/firefly/CHANGELOG.md
+++ b/firefly/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Firefly
 
-## 1.0.0
+## 1.0.0 / 2022-07-15
 
 ### Changes
 


### PR DESCRIPTION
### What does this PR do?

Firefly's integration tile is missing a date in their changelog section, so I added the release date of the integration. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

