### PR TITLE
Fix redpanda readme

### DIFF
--- a/redpanda/README.md
+++ b/redpanda/README.md
@@ -84,7 +84,7 @@ By default, collecting logs is disabled in the Datadog Agent. Log collection is 
    logs_enabled: true
    ```
 
-2. Make sure `dd-agent` user is member of `systemd-journal` group, if not following command as root:
+2. Make sure `dd-agent` user is member of `systemd-journal` group, if not, run following command as root:
    ```
    usermod -a -G systemd-journal dd-agent
    ```

--- a/redpanda/README.md
+++ b/redpanda/README.md
@@ -84,7 +84,12 @@ By default, collecting logs is disabled in the Datadog Agent. Log collection is 
    logs_enabled: true
    ```
 
-2. Add the following in your `redpanda.d/conf.yaml` file to start collecting your Redpanda logs:
+2. Make sure `dd-agent` user is member of `systemd-journal` group, if not following command as root:
+   ```
+   usermod -a -G systemd-journal dd-agent
+   ```
+
+3. Add the following in your `redpanda.d/conf.yaml` file to start collecting your Redpanda logs:
 
    ```yaml
     logs:


### PR DESCRIPTION
Added missing step when configuring redpanda logs collection in host section.

### What does this PR do?

Adds instruction in redpanda readme to ensure log collection will work when host method is used.

### Motivation

Logs were not collected when I followed readme.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

No.
