### PR TITLE
Change monotonic_count to guage for temperature

### DIFF
--- a/nvml/CHANGELOG.md
+++ b/nvml/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG - nvml
 
+## 1.0.4
+* Change monotonic_count to gauge for temperature. 
+
 ## 1.0.3
 
 * Fix version.

--- a/nvml/datadog_checks/nvml/__about__.py
+++ b/nvml/datadog_checks/nvml/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.3'
+__version__ = '1.0.4'

--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -162,7 +162,7 @@ class NvmlCheck(AgentCheck):
         # https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g92d1c5182a14dd4be7090e3c1480b121
         with NvmlCall("temperature", self.log):
             temp = NvmlCheck.N.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
-            self.monotonic_count('temperature', temp, tags=tags)
+            self.gauge('temperature', temp, tags=tags)
 
     def _start_discovery(self):
         """Start daemon thread to discover which k8s pod is assigned to a GPU"""


### PR DESCRIPTION
### What does this PR do?

Implements a gauge metric rather than a monotonic_count for temperature. 

### Motivation

When first adding the temperature metric, I used monotonic_count by default and later realised (thanks to [this docs](https://docs.datadoghq.com/metrics/custom_metrics/agent_metrics_submission/?tabs=gauge) that for this metric, gauge is the correct option.

I took notice of this issue while setting up my new dashboard, and the metrics were nonsense.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
