### PR TITLE
Add fan speed

### DIFF
--- a/nvml/CHANGELOG.md
+++ b/nvml/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG - nvml
 
+## 1.0.5
+
+* Add fan speed to monitored metrics.
+
 ## 1.0.4
+
 * Change monotonic_count to gauge for temperature. 
 
 ## 1.0.3

--- a/nvml/datadog_checks/nvml/__about__.py
+++ b/nvml/datadog_checks/nvml/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.4'
+__version__ = '1.0.5'

--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -164,6 +164,11 @@ class NvmlCheck(AgentCheck):
             temp = NvmlCheck.N.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
             self.gauge('temperature', temp, tags=tags)
 
+        # https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1ge8e3e5b5b9dcf436e4537982cf647d4e
+        with NvmlCall("fan_speed", self.log):
+            fan_speed = NvmlCheck.N.nvmlDeviceGetFanSpeed(handle)
+            self.gauge('fan_speed', fan_speed, tags=tags)
+
     def _start_discovery(self):
         """Start daemon thread to discover which k8s pod is assigned to a GPU"""
         # type: () -> None

--- a/nvml/metadata.csv
+++ b/nvml/metadata.csv
@@ -12,3 +12,4 @@ nvml.dec_utilization,gauge,,percent,,The current utilization for the Decoder,0,n
 nvml.pcie_tx_throughput,gauge,,kibibyte,second,PCIe TX utilization,0,nvml,TX_utilization,
 nvml.pcie_rx_throughput,gauge,,kibibyte,second,PCIe RX utilization,0,nvml,RX_utilization,
 nvml.temperature,gauge,,,,Current temperature for this GPU in degrees celsius,0,nvml,temperature,
+nvml.fan_speed,gauge,,percent,,The current utilization for the fan,0,nvml,fan_speed,

--- a/nvml/tests/test_nvml.py
+++ b/nvml/tests/test_nvml.py
@@ -70,6 +70,10 @@ class MockNvml:
     def nvmlDeviceGetTemperature(h, b):
         return 13
 
+    @staticmethod
+    def nvmlDeviceGetFanSpeed(h):
+        return 14
+
 
 @pytest.mark.unit
 def test_check(aggregator, instance):
@@ -90,5 +94,6 @@ def test_check(aggregator, instance):
     aggregator.assert_metric('nvml.pcie_tx_throughput', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.power_usage', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.temperature', tags=expected_tags, count=1)
+    aggregator.assert_metric('nvml.fan_speed', tags=expected_tags, count=1)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Adds fan speed to the stack of monitored metrics.
For reference: [NVML api nvmlDeviceGetFanSpeed](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1ge8e3e5b5b9dcf436e4537982cf647d4e).

### Motivation

Fan speed is a common metric of interest for GPUs. 

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
