### PR TITLE
Update rookout manifest to adhere to full manifest V2 schemas

### DIFF
--- a/rookout/CHANGELOG.md
+++ b/rookout/CHANGELOG.md
@@ -1,0 +1,1 @@
+# CHANGELOG - Embrace Mobile

--- a/rookout/manifest.json
+++ b/rookout/manifest.json
@@ -7,6 +7,7 @@
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
     "support": "README.md#Support",
+    "changelog": "CHANGELOG.md",
     "description": "Collect metrics from your code running in production using Rookout",
     "title": "Rookout Live Debugging",
     "media": [
@@ -37,7 +38,8 @@
   "author": {
     "homepage": "https://rookout.com",
     "name": "Rookout",
-    "support_email": "support@rookout.com"
+    "support_email": "support@rookout.com",
+    "sales_email": "support@rookout.com"
   },
   "oauth": {},
   "assets": {
@@ -49,7 +51,7 @@
       },
       "metrics": {
         "prefix": "rookout.",
-        "check": "",
+        "check": [],
         "metadata_path": "metadata.csv"
       },
       "service_checks": {


### PR DESCRIPTION
### What does this PR do?

Rookouts manifest was created before the V2 schema was completely finalized. Now that we're migrated all integrations to use V2, there were a couple small tweaks (nothing changing functionality) that needed to be made. 

### Motivation

Complete the V2 manifest migration

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
