### PR TITLE
Adds a description to AlertNow

### DIFF
--- a/alertnow/manifest.json
+++ b/alertnow/manifest.json
@@ -8,7 +8,7 @@
     "configuration": "README.md#Setup",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
-    "description": "",
+    "description": "Sync Datadog alerts with those in AlertNow",
     "title": "AlertNow",
     "media": [],
     "classifier_tags": [


### PR DESCRIPTION
### What does this PR do?

Adds a description to AlertNow manifest.json so that the tile on https://docs.datadoghq.com/integrations/?q=alert isn't blank

### Motivation

Noticing the blank tile

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
