### PR TITLE
Migrate manifest to V2

### DIFF
--- a/fluxcd/manifest.json
+++ b/fluxcd/manifest.json
@@ -1,35 +1,46 @@
 {
-  "display_name": "fluxcd",
-  "maintainer": "melchior.moulin@blablacar.com",
-  "manifest_version": "1.0.0",
-  "name": "fluxcd",
-  "metric_prefix": "fluxcd.",
-  "metric_to_check": "fluxcd.gotk.suspend.status",
-  "creates_events": false,
-  "short_description": "Fluxcd integration with openmetric v2",
-  "guid": "23df9683-a49e-462e-8fa7-b04e2bfb8361",
-  "support": "contrib",
-  "supported_os": [
-    "linux",
-    "mac_os",
-    "windows"
-  ],
-  "public_title": "fluxcd",
-  "categories": [
-    ""
-  ],
-  "type": "check",
-  "is_public": true,
-  "integration_id": "fluxcd",
+  "manifest_version": "2.0.0",
+  "app_uuid": "11cc5047-83aa-44df-b7ca-9c6e1c32b723",
+  "app_id": "fluxcd",
+  "display_on_public_website": true,
+  "tile": {
+    "overview": "README.md#Overview",
+    "configuration": "README.md#Setup",
+    "support": "README.md#Support",
+    "changelog": "CHANGELOG.md",
+    "description": "Fluxcd integration with openmetric v2",
+    "title": "fluxcd",
+    "media": [],
+    "classifier_tags": [
+      "Supported OS::Linux",
+      "Supported OS::macOS",
+      "Supported OS::Windows"
+    ]
+  },
+  "author": {
+    "support_email": "melchior.moulin@blablacar.com",
+    "homepage": "https://github.com/DataDog/integrations-extras",
+    "sales_email": "melchior.moulin@blablacar.com",
+    "name": "unknown"
+  },
+  "oauth": {},
   "assets": {
-    "configuration": {
-      "spec": "assets/configuration/spec.yaml"
-    },
-    "dashboards": {},
-    "monitors": {},
-    "saved_views": {},
-    "service_checks": "assets/service_checks.json",
-    "logs": {},
-    "metrics_metadata": "metadata.csv"
+    "integration": {
+      "source_type_name": "fluxcd",
+      "configuration": {
+        "spec": "assets/configuration/spec.yaml"
+      },
+      "events": {
+        "creates_events": false
+      },
+      "metrics": {
+        "prefix": "fluxcd.",
+        "check": "fluxcd.gotk.suspend.status",
+        "metadata_path": "metadata.csv"
+      },
+      "service_checks": {
+        "metadata_path": "assets/service_checks.json"
+      }
+    }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Migrates the newly merged integration to manifest V2

### Motivation

All integrations should be on manifest V2 at this point, as V1 is deprecated. This won't functionally impact the integration itself, just is an architectural update. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
