### PR TITLE
Bump base check version to 15.0.0

### DIFF
--- a/gatekeeper/pyproject.toml
+++ b/gatekeeper/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=11.0.0",
+    "datadog-checks-base>=15.0.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?

Bump base check version to 15.0.0

### Motivation

py27 tests fail in base check versions < 15.0.0

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
