### PR TITLE
Add support for Filebeat file registry post version 7.x

### DIFF
--- a/filebeat/datadog_checks/filebeat/data/conf.yaml.example
+++ b/filebeat/datadog_checks/filebeat/data/conf.yaml.example
@@ -270,6 +270,12 @@ instances:
     ##     path (required): The absolute path for the file to read from.
     ##     pattern: A regular expression pattern with a single capture group used to find the
     ##              token rather than using the entire file, for example: Your secret is (.+)
+    ##   - type: oauth
+    ##     url (required): The token endpoint.
+    ##     client_id (required): The client identifier.
+    ##     client_secret (required): The client secret.
+    ##     basic_auth: Whether the provider expects credentials to be transmitted in
+    ##                 an HTTP Basic Auth header. The default is: false
     ##
     ## The available writers are:
     ##

--- a/filebeat/datadog_checks/filebeat/filebeat.py
+++ b/filebeat/datadog_checks/filebeat/filebeat.py
@@ -261,6 +261,16 @@ class FilebeatCheck(AgentCheck):
         try:
             with open(registry_file_path) as registry_file:
                 return json.load(registry_file)
+
+        except ValueError:
+            contents = []
+            with open(registry_file_path) as registry_file:
+                for line in registry_file:
+                    content = json.loads(line)
+                    if 'op' not in content.keys():
+                        contents.append(content['v'])
+            return contents
+
         except IOError as ex:
             self.log.error("Cannot read the registry log file at %s: %s", registry_file_path, ex)
 

--- a/filebeat/tests/fixtures/malformed_json_registry.json
+++ b/filebeat/tests/fixtures/malformed_json_registry.json
@@ -1,2 +1,1 @@
-{"op":"set","id":1}
-{"k":"filebeat::logs::native::396268-66306","v":{"id":"native::396268-66306","timestamp":[612296462,1629212377],"ttl":-1,"FileStateOS":{"inode":396268,"device":66306},"identifier_name":"native","prev_id":"","source":"/test_dd_agent/var/log/nginx/access.log","offset":0,"type":"log"}}
+malformed_json

--- a/filebeat/tests/fixtures/new_style_json_registry.json
+++ b/filebeat/tests/fixtures/new_style_json_registry.json
@@ -1,0 +1,4 @@
+{"op":"set","id":1}
+{"k":"filebeat::logs::native::396268-66306","v":{"id":"native::396268-66306","timestamp":[612296462,1629212377],"ttl":-1,"FileStateOS":{"inode":277025,"device":51713},"identifier_name":"native","prev_id":"","source":"/test_dd_agent/var/log/nginx/access.log","offset":391747,"type":"log"}}
+{"op":"set","id":2}
+{"k":"filebeat::logs::native::396268-66306","v":{"id":"native::396268-66306","timestamp":[612296461,1629212378],"ttl":-1,"FileStateOS":{"inode":152172,"device":51713},"identifier_name":"native","prev_id":"","source":"/test_dd_agent/var/log/syslog","offset":1024917,"type":"log"}}


### PR DESCRIPTION
### What does this PR do?

Since filebeat version 7.x, the registry file format changed.

- Add fixtures for the new-style format
- Update `_parse_registry_file` to process it correctly

### Motivation

After upgrade to Filebeat 7.x, the datadog-agent Filebeat check did not fully work anymore, as described in #915.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
