### PR TITLE
Update ping.py

### DIFF
--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -74,7 +74,7 @@ class PingCheck(AgentCheck):
             raise_on_empty_output=False, #set this to false so that the check doesn't seems to have failed just because the host is unreachable
         )
         self.log.debug("ping returned %s - %s - %s", retcode, lines, err)
-        if retcode == 0 #if ping successful
+        if retcode == 0: #if ping successful
             return lines #return the output.
         return "" #if ping not successful, return an empty string without raising an error.
 

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -71,38 +71,33 @@ class PingCheck(AgentCheck):
         lines, err, retcode = get_subprocess_output(
             precmd + [cmd, countOption, "1", timeoutOption, str(timeout), target_host],
             self.log,
-            raise_on_empty_output=True,
+            raise_on_empty_output=False, #set this to false so that the check doesn't seems to have failed just because the host is unreachable
         )
         self.log.debug("ping returned %s - %s - %s", retcode, lines, err)
-        if retcode != 0:
-            raise CheckException("ping returned {}: {}".format(retcode, err))
-
-        return lines
+        if retcode == 0 #if ping successful
+            return lines #return the output.
+        return "" #if ping not successful, return an empty string without raising an error.
 
     def check(self, instance):
         host, custom_tags, timeout, response_time = self._load_conf(instance)
-
+        length = -1 #initialize length to -1 in case ping unsuccessful
         custom_tags.append("target_host:{}".format(host))
 
-        try:
-            lines = self._exec_ping(timeout, host)
-            regex = re.compile(r"time[<=]((\d|\.)*)")
-            result = regex.findall(lines)
-            if result:
-                length = result[0][0]
-            else:
-                raise CheckException("No time= found ({})".format(lines))
+        lines = self._exec_ping(timeout, host)
+        regex = re.compile(r"time[<=]((\d|\.)*)")
+        result = regex.findall(lines)
+        if result: #if ping successful, get the length value
+            length = result[0][0]
 
-        except CheckException as e:
-            self.log.info("%s is DOWN (%s)", host, e)
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, custom_tags, message=str(e))
-            self.gauge(self.SERVICE_CHECK_NAME, 0, custom_tags)
+        if lines == "": # if ping unsuccessful 
+            self.log.info("%s is DOWN or UNREACHABLE", host) #log the fact that the host in either down or unreachable with out raising an error
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.WARNING, custom_tags) #raise a warning status only when ping unsuccessful
+            self.gauge(self.SERVICE_CHECK_NAME, 0, custom_tags) #set the "network.ping.can_connect" metric to zero to indicate an unsuccessful ping
+            
+        else:
+            if response_time: # if ping successful 
+                self.gauge("network.ping.response_time", length, custom_tags) #set the "network.ping.response_time" metric to the value of "length"
 
-            raise e
-
-        if response_time:
-            self.gauge("network.ping.response_time", length, custom_tags)
-
-        self.log.debug("%s is UP", host)
-        self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, custom_tags)
-        self.gauge(self.SERVICE_CHECK_NAME, 1, custom_tags)
+            self.log.debug("%s is UP", host) #log the fact that the host is up
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, custom_tags) #set the service check to OK if since ping is successful
+            self.gauge(self.SERVICE_CHECK_NAME, 1, custom_tags) #set the "network.ping.can_connect" metric to one to indicate a successful ping


### PR DESCRIPTION
### What does this PR do?
This PR changes how the check handles unsuccessful pings (host unreachable/down)
If the ping is successful:
    Then this code will:
        - Submit the response time.
        - Add a log entry stating that the host is up.
        - Returns OK for the "network.ping.can_connect" service check.
        - Submit the value 1 for the "network.ping.can_connect" metric indicating a successful ping.
Else (ping unsuccessful):
    Then this code will:
        - Add a log entry stating that the host is DOWN or UNREACHABLE.
        - Returns WARNING for the "network.ping.can_connect" service check (instead of CRITICAL).
        - Submit the value 0 for the "network.ping.can_connect" metric indicating an unsuccessful ping.


### Motivation
- A customer reached out for support with the ping integration. 
- They got confused when they ran the "datadog-agent status" command and the ping integration section was showing [ERROR] for a certain instance.
- The customer got confused and thought that the check it self has actually failed to determine the state of the host.
- I myself got confused at first, and now aI think that displaying a WARNING would be more appropriate to indicate that the check was ran successfully but the host was unreachable.
- Link to support ticket: https://datadog.zendesk.com/agent/tickets/893536

### Review checklist
- [ * ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached

### Additional Notes
While this PR will affect the documentation if added (by adding the WARNING service check), the documentation team was not notified. 