### PR TITLE
Revert "Pin tagger (#1536)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  TAGGER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:tagger@sha256:5f9cd17c4af0007cf8e9a72dd8880b65a43d3948dec59ccdc87df437b133bd18
+  TAGGER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:tagger
   TAGGER_EMAIL: packages@datadoghq.com
   TAGGER_NAME: ci.integrations-extras
 


### PR DESCRIPTION
### What does this PR do?

This reverts commit c30e3bc5dd81be697c20403798832e6a959411eb.

### Motivation

After https://github.com/DataDog/integrations-core/pull/12956, we can rely on the latest tagger image since we know the dependencies are pinned to the correct ones
### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
