### PR TITLE
Add the Do Not Upload classifier to all integrations

### DIFF
--- a/aqua/pyproject.toml
+++ b/aqua/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base",

--- a/aws_pricing/pyproject.toml
+++ b/aws_pricing/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/bind9/pyproject.toml
+++ b/bind9/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base",

--- a/cert_manager/pyproject.toml
+++ b/cert_manager/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/cfssl/pyproject.toml
+++ b/cfssl/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=25.1.0",

--- a/cloudsmith/pyproject.toml
+++ b/cloudsmith/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.2.0",

--- a/cyral/pyproject.toml
+++ b/cyral/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",

--- a/eventstore/pyproject.toml
+++ b/eventstore/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=5.1.0",

--- a/exim/pyproject.toml
+++ b/exim/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=25.1.0",

--- a/filebeat/pyproject.toml
+++ b/filebeat/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/fluentbit/pyproject.toml
+++ b/fluentbit/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=25.1.0",

--- a/flume/pyproject.toml
+++ b/flume/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base",

--- a/fluxcd/pyproject.toml
+++ b/fluxcd/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=25.1.0",

--- a/gatekeeper/pyproject.toml
+++ b/gatekeeper/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=15.0.0",

--- a/gitea/pyproject.toml
+++ b/gitea/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=25.3.1",

--- a/gnatsd/pyproject.toml
+++ b/gnatsd/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/gnatsd_streaming/pyproject.toml
+++ b/gnatsd_streaming/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/grpc_check/pyproject.toml
+++ b/grpc_check/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=25.1.0",

--- a/hbase_master/pyproject.toml
+++ b/hbase_master/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog_checks_base>=11.0.0",

--- a/hbase_regionserver/pyproject.toml
+++ b/hbase_regionserver/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog_checks_base>=11.0.0",

--- a/jfrog_platform/pyproject.toml
+++ b/jfrog_platform/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.2.0",

--- a/kernelcare/pyproject.toml
+++ b/kernelcare/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",

--- a/lighthouse/pyproject.toml
+++ b/lighthouse/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/logstash/pyproject.toml
+++ b/logstash/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/neo4j/pyproject.toml
+++ b/neo4j/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=23.7.0",

--- a/neutrona/pyproject.toml
+++ b/neutrona/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base",

--- a/nextcloud/pyproject.toml
+++ b/nextcloud/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/ns1/pyproject.toml
+++ b/ns1/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.2.0",

--- a/nvml/pyproject.toml
+++ b/nvml/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/octoprint/pyproject.toml
+++ b/octoprint/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base",

--- a/open_policy_agent/pyproject.toml
+++ b/open_policy_agent/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",

--- a/php_apcu/pyproject.toml
+++ b/php_apcu/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",

--- a/php_opcache/pyproject.toml
+++ b/php_opcache/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",

--- a/pihole/pyproject.toml
+++ b/pihole/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=10.1.0",

--- a/ping/pyproject.toml
+++ b/ping/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base",

--- a/portworx/pyproject.toml
+++ b/portworx/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/puma/pyproject.toml
+++ b/puma/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",

--- a/purefa/pyproject.toml
+++ b/purefa/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.8",
 ]

--- a/purefb/pyproject.toml
+++ b/purefb/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.8",
 ]

--- a/reboot_required/pyproject.toml
+++ b/reboot_required/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=5.1.0",

--- a/redis_sentinel/pyproject.toml
+++ b/redis_sentinel/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/redisenterprise/pyproject.toml
+++ b/redisenterprise/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",

--- a/redpanda/pyproject.toml
+++ b/redpanda/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.2.0",

--- a/resin/pyproject.toml
+++ b/resin/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",

--- a/riak_repl/pyproject.toml
+++ b/riak_repl/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/sendmail/pyproject.toml
+++ b/sendmail/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/snmpwalk/pyproject.toml
+++ b/snmpwalk/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/sortdb/pyproject.toml
+++ b/sortdb/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/speedtest/pyproject.toml
+++ b/speedtest/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",

--- a/stardog/pyproject.toml
+++ b/stardog/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/storm/pyproject.toml
+++ b/storm/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/syncthing/pyproject.toml
+++ b/syncthing/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=25.1.0",

--- a/tidb/pyproject.toml
+++ b/tidb/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.2.0",

--- a/traefik/pyproject.toml
+++ b/traefik/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/trino/pyproject.toml
+++ b/trino/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=23.6.0",

--- a/unbound/pyproject.toml
+++ b/unbound/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/unifi_console/pyproject.toml
+++ b/unifi_console/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.9",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.2.0",

--- a/upsc/pyproject.toml
+++ b/upsc/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/vespa/pyproject.toml
+++ b/vespa/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=4.2.0",

--- a/zabbix/pyproject.toml
+++ b/zabbix/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
+    "Private :: Do Not Upload",
 ]
 dependencies = [
     "datadog-checks-base>=11.0.0",


### PR DESCRIPTION
### What does this PR do?

Add the `Private :: Do Not Upload` classifier to all existing integrations.

### Motivation

See https://github.com/DataDog/integrations-core/pull/13066

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
