### PR TITLE
Fix `Comment PR on failure` job

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -110,6 +110,8 @@ jobs:
     - name: Comment PR on failure
       if: failure()
       uses: actions/github-script@0.3.0
+      permissions:
+        pull-requests: write
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -9,6 +9,7 @@ on:
     - master
 
 permissions:
+  contents: read
   pull-requests: write
 
 env:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
     - master
-  pull_request:
+  pull_request_target:
     branches:
     - master
 
 env:
-  CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
+  CHANGED: ${{ github.event_name == 'pull_request_target' && 'changed' || '' }}
 
 jobs:
   build:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -8,10 +8,6 @@ on:
     branches:
     - master
 
-permissions:
-  contents: read
-  pull-requests: write
-
 env:
   CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
 
@@ -113,6 +109,7 @@ jobs:
 
     - name: Comment PR on failure
       if: failure()
+      continue-on-error: true
       uses: actions/github-script@0.3.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - master
-  pull_request:
+  pull_request_target:
     branches:
     - master
 

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -9,7 +9,7 @@ on:
     - master
 
 env:
-  CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
+  CHANGED: ${{ github.event_name == 'pull_request_target' && 'changed' || '' }}
 
 jobs:
   build:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -8,13 +8,14 @@ on:
     branches:
     - master
 
+permissions:
+  pull-requests: write
+
 env:
   CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
 
 jobs:
   build:
-    permissions:
-      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -13,6 +13,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:
@@ -110,8 +112,6 @@ jobs:
     - name: Comment PR on failure
       if: failure()
       uses: actions/github-script@0.3.0
-      permissions:
-        pull-requests: write
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
     - master
-  pull_request_target:
+  pull_request:
     branches:
     - master
 
 env:
-  CHANGED: ${{ github.event_name == 'pull_request_target' && 'changed' || '' }}
+  CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
 
 jobs:
   build:

--- a/gitea/assets/configuration/spec.yaml
+++ b/gitea/assets/configuration/spec.yaml
@@ -23,4 +23,4 @@ files:
     options:
     - template: instances/openmetrics
       overrides:
-        openmetrics_endpoint.value.example: http://%%host%%:4000/metrics
+        openmetrics_endpoint.value.example: http://%%host%%:5000/metrics

--- a/gitea/assets/configuration/spec.yaml
+++ b/gitea/assets/configuration/spec.yaml
@@ -23,4 +23,4 @@ files:
     options:
     - template: instances/openmetrics
       overrides:
-        openmetrics_endpoint.value.example: http://%%host%%:3000/metrics
+        openmetrics_endpoint.value.example: http://%%host%%:4000/metrics

--- a/gitea/assets/configuration/spec.yaml
+++ b/gitea/assets/configuration/spec.yaml
@@ -23,4 +23,4 @@ files:
     options:
     - template: instances/openmetrics
       overrides:
-        openmetrics_endpoint.value.example: http://%%host%%:5000/metrics
+        openmetrics_endpoint.value.example: http://%%host%%:3000/metrics


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

The `Comment PR on failure` step fails if we are trying to comment a PR that comes from a fork. Because of that, the user is polluted by this error and have to scroll up to find the actual error. 

This PR allow this step to fail, but we won't have a comment on the PR in this case. (example here: https://github.com/DataDog/integrations-extras/actions/runs/3265449767/jobs/5367676891 for this commit https://github.com/DataDog/integrations-extras/pull/1573/commits/d295039ff87607097389a9ad231eef8e01a07868)

### Motivation

What inspired you to submit this pull request?

https://datadoghq.atlassian.net/browse/AITOOLS-45


### Additional Notes

I tried different things:
1. Updating the permissions in the workflow file, did not work.
2. We could use the [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) but I think it's not a good idea security wise

I tested different things on a personal repo/fork and it did not work either. If you have a better solution, let me know

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
