### PR TITLE
Need to modify timeout parameter

### DIFF
--- a/grpc_check/datadog_checks/grpc_check/data/conf.yaml.example
+++ b/grpc_check/datadog_checks/grpc_check/data/conf.yaml.example
@@ -23,7 +23,7 @@ instances:
     #
     # grpc_server_service: <GRPC_SERVER_SERVICE>
 
-    ## @param timeout - integer - optional - default: 1000
+    ## @param timeout - integer - required - default: 1000
     ## duration of time in milliseconds to allow for the RPC.
     #
     # timeout: 1000


### PR DESCRIPTION
In the spec, we should expect timeout to be 1000 by default. But if the timeout parameter is not specified, it is set to 0 as shown on Line 77 of check.py, and this triggers a ConfigurationError on Line 91 of check.py.

### What does this PR do?

A fix to a configuration issue for installing the integration.

### Motivation

A user has reported that they were facing issues with setting up the integration locally on their host. After investigating, it appears that the following Python modules also need to be installed locally:

- grpcio
- grpcio-health-checking

Additionally, the timeout parameter is written as "optional" in the [conf.yaml.example](https://github.com/DataDog/integrations-extras/blob/master/grpc_check/datadog_checks/grpc_check/data/conf.yaml.example) file, however, after inspecting the integration's check.py file, the timeout parameter is actually set to 0 by default. This can be seen on Line 77: https://github.com/DataDog/integrations-extras/blob/master/grpc_check/datadog_checks/grpc_check/check.py#L77

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
