### PR TITLE
[nvml] add `compute_running_process` (processes running in gpu)

### DIFF
--- a/nvml/CHANGELOG.md
+++ b/nvml/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - nvml
 
+## 1.0.6
+
+* Add compute_running_process metrics.
+
 ## 1.0.5
 
 * Add fan speed to monitored metrics.

--- a/nvml/datadog_checks/nvml/__about__.py
+++ b/nvml/datadog_checks/nvml/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.5'
+__version__ = '1.0.6'

--- a/nvml/datadog_checks/nvml/data/conf.yaml.example
+++ b/nvml/datadog_checks/nvml/data/conf.yaml.example
@@ -9,7 +9,7 @@ init_config:
     #
     # service: <SERVICE>
 
-## Every instance is scheduled independent of the others.
+## Every instance is scheduled independently of the others.
 #
 instances:
 

--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -174,7 +174,11 @@ class NvmlCheck(AgentCheck):
         with NvmlCall("compute_running_processes", self.log):
             compute_running_processes = NvmlCheck.N.nvmlDeviceGetComputeRunningProcesses_v2(handle)
             for compute_running_process in compute_running_processes:
-                self.gauge('compute_running_process', compute_running_process.usedGpuMemory, tags=tags + [f"pid:{compute_running_process.pid}"])
+                self.gauge(
+                    'compute_running_process',
+                    compute_running_process.usedGpuMemory,
+                    tags=tags + [f"pid:{compute_running_process.pid}"],
+                )
 
     def _start_discovery(self):
         """Start daemon thread to discover which k8s pod is assigned to a GPU"""

--- a/nvml/datadog_checks/nvml/nvml.py
+++ b/nvml/datadog_checks/nvml/nvml.py
@@ -171,6 +171,11 @@ class NvmlCheck(AgentCheck):
             fan_speed = NvmlCheck.N.nvmlDeviceGetFanSpeed(handle)
             self.gauge('fan_speed', fan_speed, tags=tags)
 
+        with NvmlCall("compute_running_processes", self.log):
+            compute_running_processes = NvmlCheck.N.nvmlDeviceGetComputeRunningProcesses_v2(handle)
+            for compute_running_process in compute_running_processes:
+                self.gauge('compute_running_process', compute_running_process.usedGpuMemory, tags=tags + [f"pid:{compute_running_process.pid}"])
+
     def _start_discovery(self):
         """Start daemon thread to discover which k8s pod is assigned to a GPU"""
         # type: () -> None

--- a/nvml/metadata.csv
+++ b/nvml/metadata.csv
@@ -13,3 +13,4 @@ nvml.pcie_tx_throughput,gauge,,kibibyte,second,PCIe TX utilization,0,nvml,TX_uti
 nvml.pcie_rx_throughput,gauge,,kibibyte,second,PCIe RX utilization,0,nvml,RX_utilization,
 nvml.temperature,gauge,,,,Current temperature for this GPU in degrees celsius,0,nvml,temperature,
 nvml.fan_speed,gauge,,percent,,The current utilization for the fan,0,nvml,fan_speed,
+nvml.compute_running_process,gauge,,byte,,The current usage of gpu memory by process,0,nvml,compute_running_process,

--- a/nvml/tests/test_nvml.py
+++ b/nvml/tests/test_nvml.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from types import SimpleNamespace
+from collections import namedtuple
 
 import mock
 import pytest
@@ -76,7 +77,8 @@ class MockNvml:
 
     @staticmethod
     def nvmlDeviceGetComputeRunningProcesses_v2(h):
-        return [{ "pid": 1, "usedGpuMemory": 11}]
+        Mock = namedtuple('Mock', ['pid', 'usedGpuMemory'])
+        return [Mock(pid = 1, usedGpuMemory = 11)]
 
 
 @pytest.mark.unit
@@ -99,6 +101,6 @@ def test_check(aggregator, instance):
     aggregator.assert_metric('nvml.power_usage', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.temperature', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.fan_speed', tags=expected_tags, count=1)
-    aggregator.assert_metric('nvml.compute_running_process', tags=expected_tags+["pid:1"], count=2)
+    aggregator.assert_metric('nvml.compute_running_process', tags=expected_tags+["pid:1"], count=1)
 
     aggregator.assert_all_metrics_covered()

--- a/nvml/tests/test_nvml.py
+++ b/nvml/tests/test_nvml.py
@@ -74,6 +74,10 @@ class MockNvml:
     def nvmlDeviceGetFanSpeed(h):
         return 14
 
+    @staticmethod
+    def nvmlDeviceGetComputeRunningProcesses_v2(h):
+        return [{ "pid": 1, "usedGpuMemory": 11}]
+
 
 @pytest.mark.unit
 def test_check(aggregator, instance):
@@ -95,5 +99,6 @@ def test_check(aggregator, instance):
     aggregator.assert_metric('nvml.power_usage', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.temperature', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.fan_speed', tags=expected_tags, count=1)
+    aggregator.assert_metric('nvml.compute_running_process', tags=expected_tags+["pid:1"], count=2)
 
     aggregator.assert_all_metrics_covered()

--- a/nvml/tests/test_nvml.py
+++ b/nvml/tests/test_nvml.py
@@ -1,8 +1,8 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from types import SimpleNamespace
 from collections import namedtuple
+from types import SimpleNamespace
 
 import mock
 import pytest
@@ -78,7 +78,7 @@ class MockNvml:
     @staticmethod
     def nvmlDeviceGetComputeRunningProcesses_v2(h):
         Mock = namedtuple('Mock', ['pid', 'usedGpuMemory'])
-        return [Mock(pid = 1, usedGpuMemory = 11)]
+        return [Mock(pid=1, usedGpuMemory=11)]
 
 
 @pytest.mark.unit
@@ -101,6 +101,6 @@ def test_check(aggregator, instance):
     aggregator.assert_metric('nvml.power_usage', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.temperature', tags=expected_tags, count=1)
     aggregator.assert_metric('nvml.fan_speed', tags=expected_tags, count=1)
-    aggregator.assert_metric('nvml.compute_running_process', tags=expected_tags+["pid:1"], count=1)
+    aggregator.assert_metric('nvml.compute_running_process', tags=expected_tags + ["pid:1"], count=1)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Reports process pids running in GPU

### Motivation

We are using Datadog to monitor processes running in GPU.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
	<details>
		<summary>Test Result</summary>
		<img width="2560" alt="image" src="https://user-images.githubusercontent.com/46488521/197434080-17afba74-631b-4e4f-b1a8-c4698a5ff84b.png">
	</details>
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
