### PR TITLE
add back link that was accidentally removed

### DIFF
--- a/lambdatest/README.md
+++ b/lambdatest/README.md
@@ -44,3 +44,5 @@ For support or feature requests, contact LambdaTest on the following channels:
 Email: support@lambdatest.com
 Phone: +1-(866)-430-7087
 Website: https://www.lambdatest.com/
+
+[1]: https://www.lambdatest.com/support/docs/datadog-integration/


### PR DESCRIPTION
### What does this PR do?
Adds back the missing link.

### Motivation
A link was removed from the LambdaTest readme that was still being used in a previous PR:
`[1]: https://www.lambdatest.com/support/docs/datadog-integration/` -- https://github.com/DataDog/integrations-extras/pull/1582/files

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

