### PR TITLE
Fix Unifi Console login url for [v4|v5|v6|v7]

### DIFF
--- a/unifi_console/datadog_checks/unifi_console/api.py
+++ b/unifi_console/datadog_checks/unifi_console/api.py
@@ -55,7 +55,7 @@ class UnifiAPI(object):
             if float(config.version[1:]) < 4:
                 raise APIError("%s controllers no longer supported" % config.version)
             self.url = self.config.url
-            self.auth_url = self.url + "api/login"
+            self.auth_url = self.url + "/api/login"
         else:
             raise APIError("%s controllers no longer supported" % config.version)
 


### PR DESCRIPTION
### What does this PR do?

Simple fix that I encountered locally when I tried to stup this integration. 

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
