### PR TITLE
Fix login prefix slash

### DIFF
--- a/unifi_console/datadog_checks/unifi_console/api.py
+++ b/unifi_console/datadog_checks/unifi_console/api.py
@@ -55,7 +55,7 @@ class UnifiAPI(object):
             if float(config.version[1:]) < 4:
                 raise APIError("%s controllers no longer supported" % config.version)
             self.url = self.config.url
-            self.auth_url = self.url + "api/login"
+            self.auth_url = self.url + "/api/login"
         else:
             raise APIError("%s controllers no longer supported" % config.version)
 


### PR DESCRIPTION
Related to https://github.com/DataDog/integrations-extras/pull/1562, adds the `/` prefix to the login url 