### PR TITLE
Updating uninstallation instructions for LambdaTest

### DIFF
--- a/lambdatest/README.md
+++ b/lambdatest/README.md
@@ -33,7 +33,7 @@ Here's how you can track incidents in Datadog with LambdaTest:
 
 ### Uninstallation
 
-Once you uninstall this integration, any previous authorizations will be revoked. 
+Once you uninstall this integration, any previous authorizations are revoked. 
 
 Additionally, ensure that all API keys associated with this integration have been disabled by searching for the integration name on the [API Keys management page](https://app.datadoghq.com/organization-settings/api-keys).
 

--- a/lambdatest/README.md
+++ b/lambdatest/README.md
@@ -33,7 +33,7 @@ Here's how you can track incidents in Datadog with LambdaTest:
 
 ### Uninstallation
 
-To ensure this integration is fully uninstalled, revoke authorization in the Configure tab of this tile or in [OAuth Apps](https://app.datadoghq.com/organization-settings/oauth-applications) within Organization Settings in Datadog. 
+Once you uninstall this integration, any previous authorizations will be revoked. 
 
 Additionally, ensure that all API keys associated with this integration have been disabled by searching for the integration name on the [API Keys management page](https://app.datadoghq.com/organization-settings/api-keys).
 


### PR DESCRIPTION
### What does this PR do?

We've just made a change so that when a user clicks uninstall, any previous authorizations of this integration through OAuth will be revoked. Updating the uninstallation instructions to reflect that. 

### Motivation

Ensuring that uninstallation instructions are up to date.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
