### PR TITLE
Validate the manifest file before the dashboards in the CI

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -51,6 +51,10 @@ jobs:
       run: |
         ddev validate config $CHANGED
 
+    - name: Run manifest validation
+      run: |
+        ddev validate manifest $CHANGED
+
     - name: Run dashboard validation
       run: |
         ddev validate dashboards $CHANGED
@@ -66,10 +70,6 @@ jobs:
     - name: Run JMX metrics validation
       run: |
         ddev validate jmx-metrics $CHANGED
-
-    - name: Run manifest validation
-      run: |
-        ddev validate manifest $CHANGED
         
     - name: Run metadata validation
       run: |


### PR DESCRIPTION
### What does this PR do?

Run the manifest validation before the dashboards validation.

### Motivation

See https://github.com/DataDog/integrations-core/pull/13283

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
