### PR TITLE
(DOCS-4340) Add extras flag to build command

### DIFF
--- a/php_opcache/README.md
+++ b/php_opcache/README.md
@@ -16,7 +16,7 @@ To install the `php_opcache` check on your host:
 1. Install the [developer toolkit][3].
  on any machine.
 
-2. Run `ddev release build php_opcache` to build the package.
+2. Run `ddev -e release build php_opcache` to build the package.
 
 3. [Download the Datadog Agent][4].
 

--- a/php_opcache/datadog_checks/php_opcache/data/conf.yaml.example
+++ b/php_opcache/datadog_checks/php_opcache/data/conf.yaml.example
@@ -41,7 +41,7 @@ init_config:
     #
     # service: <SERVICE>
 
-## Every instance is scheduled independent of the others.
+## Every instance is scheduled independently of the others.
 #
 instances:
 
@@ -207,13 +207,19 @@ instances:
     ##     path (required): The absolute path for the file to read from.
     ##     pattern: A regular expression pattern with a single capture group used to find the
     ##              token rather than using the entire file, for example: Your secret is (.+)
+    ##   - type: oauth
+    ##     url (required): The token endpoint.
+    ##     client_id (required): The client identifier.
+    ##     client_secret (required): The client secret.
+    ##     basic_auth: Whether the provider expects credentials to be transmitted in
+    ##                 an HTTP Basic Auth header. The default is: false
     ##
     ## The available writers are:
     ##
     ##   - type: header
     ##     name (required): The name of the field, for example: Authorization
     ##     value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
-    ##     placeholder: The substring in `value` to replace by the token, defaults to: <TOKEN>
+    ##     placeholder: The substring in `value` to replace with the token, defaults to: <TOKEN>
     #
     # auth_token:
     #   reader:
@@ -350,7 +356,7 @@ instances:
     # log_requests: false
 
     ## @param persist_connections - boolean - optional - default: false
-    ## Whether or not to persist cookies and use connection pooling for increased performance.
+    ## Whether or not to persist cookies and use connection pooling for improved performance.
     #
     # persist_connections: false
 


### PR DESCRIPTION
### What does this PR do?

Adds the extras flag to the OPCache instructions. Users don't always configure their dev tools to use the extras repo, so this prevents them from running into issues when they try to install the integration.

### Motivation

[DOCS-4340](https://datadoghq.atlassian.net/browse/DOCS-4340)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?


[DOCS-4340]: https://datadoghq.atlassian.net/browse/DOCS-4340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ