### PR TITLE
Release the integration

### DIFF
--- a/go_pprof_scraper/CHANGELOG.md
+++ b/go_pprof_scraper/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG - Go-pprof-scraper
 
-## 1.0.0 / 2022-11-10
+## 1.0.1 / 2022-11-10
 
 * [Added] Add Go pprof scraper integration. See [#1541](https://github.com/DataDog/integrations-extras/pull/1541).

--- a/go_pprof_scraper/datadog_checks/go_pprof_scraper/__about__.py
+++ b/go_pprof_scraper/datadog_checks/go_pprof_scraper/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.0'
+__version__ = '1.0.1'


### PR DESCRIPTION
### What does this PR do?

Release the `go_pprof_scraper` integration

### Motivation

- We faced an issue with the release pipeline when we released the version 1.0.0. The wheel was not uploaded and we do not manage to trigger it again
- We wanted to bootstrap the pipeline again but I merged [a PR](https://github.com/DataDog/integrations-extras/pull/1612) that changes the `pyproject,toml` file. This file is signed.
- The safest (but not cleanest, I know) way to build the wheel is to create a new version to trigger the pipeline. 
- This means this integration won't have a 1.0.0 version

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
