### PR TITLE
go_pprof_scraper: fix typos and inconsistencies in docs

### DIFF
--- a/go_pprof_scraper/README.md
+++ b/go_pprof_scraper/README.md
@@ -17,7 +17,7 @@ Follow the instructions below to install and configure this check for an Agent r
 
 ### Installation
 
-If you are using an Agent version >= 7.21/6.21, follow the instructions below to install the RedisEnterprise check on your host. See the dedicated Agent guide for [installing community integrations][14] to install checks with an [Agent version < v7.21/v6.21][15] or the [Docker Agent][16]:
+If you are using an Agent version >= 7.21/6.21, follow the instructions below to install the `go_pprof_scraper` check on your host. See the dedicated Agent guide for [installing community integrations][14] to install checks with an [Agent version < v7.21/v6.21][15] or the [Docker Agent][16]:
 
 1. [Download and launch the Datadog Agent][2].
 2. Run the following command to install the integrations wheel with the Agent:

--- a/go_pprof_scraper/assets/configuration/spec.yaml
+++ b/go_pprof_scraper/assets/configuration/spec.yaml
@@ -45,9 +45,9 @@ files:
         between the samples at the beginning and end of profiling.
 
         For the heap profile, the in-use (also known as "live heap") samples
-        may be negative if "cumulative" is false. This will not currently
-        display properly in the profile UI, so it is recommended to set
-        "cumulative" to true.
+        may be negative if "cumulative" is false. This does not display
+        accurately in the profile UI, so Datadog does not recommend setting
+        "cumulative" to false.
         
         In order to use profile aggregation, "cumulative" must set to false.
         Note that setting "cumulative" to false will cause the profiled

--- a/go_pprof_scraper/assets/configuration/spec.yaml
+++ b/go_pprof_scraper/assets/configuration/spec.yaml
@@ -44,8 +44,10 @@ files:
         period specified by "duration". The profiles will hold the difference
         between the samples at the beginning and end of profiling.
 
-        For the heap profile, the in-use (also known as "live heap") samples may
-        be negative if "cumulative" is true.
+        For the heap profile, the in-use (also known as "live heap") samples
+        may be negative if "cumulative" is false. This will not currently
+        display properly in the profile UI, so it is recommended to set
+        "cumulative" to true.
         
         In order to use profile aggregation, "cumulative" must set to false.
         Note that setting "cumulative" to false will cause the profiled

--- a/go_pprof_scraper/datadog_checks/go_pprof_scraper/data/conf.yaml.example
+++ b/go_pprof_scraper/datadog_checks/go_pprof_scraper/data/conf.yaml.example
@@ -43,9 +43,9 @@ instances:
     ## between the samples at the beginning and end of profiling.
     ##
     ## For the heap profile, the in-use (also known as "live heap") samples
-    ## may be negative if "cumulative" is false. This will not currently
-    ## display properly in the profile UI, so it is recommended to set
-    ## "cumulative" to true.
+    ## may be negative if "cumulative" is false. This does not display
+    ## accurately in the profile UI, so Datadog does not recommend setting
+    ## "cumulative" to false.
     ##
     ## In order to use profile aggregation, "cumulative" must set to false.
     ## Note that setting "cumulative" to false will cause the profiled

--- a/go_pprof_scraper/datadog_checks/go_pprof_scraper/data/conf.yaml.example
+++ b/go_pprof_scraper/datadog_checks/go_pprof_scraper/data/conf.yaml.example
@@ -42,8 +42,10 @@ instances:
     ## period specified by "duration". The profiles will hold the difference
     ## between the samples at the beginning and end of profiling.
     ##
-    ## For the heap profile, the in-use (also known as "live heap") samples may
-    ## be negative if "cumulative" is true.
+    ## For the heap profile, the in-use (also known as "live heap") samples
+    ## may be negative if "cumulative" is false. This will not currently
+    ## display properly in the profile UI, so it is recommended to set
+    ## "cumulative" to true.
     ##
     ## In order to use profile aggregation, "cumulative" must set to false.
     ## Note that setting "cumulative" to false will cause the profiled


### PR DESCRIPTION
### What does this PR do?

Fixes a typo and an inconsistency in the `go_pprof_scraper` integration docs.

### Motivation

README.md had the wrong name for the integration, and the configuration docs
incorrectly described the behavior of the "cumulative" parameter.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
