### PR TITLE
(DOCS-4551) Update app_id to match logo in Druids

### DIFF
--- a/unifi_console/manifest.json
+++ b/unifi_console/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "2.0.0",
   "app_uuid": "224a050d-7ed3-4e7a-ada6-410f61393fc0",
-  "app_id": "unifi-console",
+  "app_id": "unifi_console",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
### What does this PR do?

Update the integration's `app_id` to match the logo name in Druids. This allows it to appear when searching for it in the main list of integrations.

**Preview:**
https://docs-staging.datadoghq.com/bryce/docs4551-update-pull-config-preview/integrations/?q=unifi

### Motivation

DOCS-4551

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
