### PR TITLE
go_pprof_scraper: properly encode UDS path in URL

### DIFF
--- a/go_pprof_scraper/datadog_checks/go_pprof_scraper/check.py
+++ b/go_pprof_scraper/datadog_checks/go_pprof_scraper/check.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import requests_unixsocket
 from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout
+from requests.utils import quote
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 
@@ -88,7 +89,10 @@ class GoPprofScraperCheck(AgentCheck):
 
         self.trace_agent_socket = datadog_agent.get_config("apm_config.receiver_socket")
         if self.trace_agent_socket:
-            self.trace_agent_socket = "http+unix://{}/profiling/v1/input".format(self.trace_agent_socket)
+            # requets_unixsocket expects the path to be URL-encoded. We pass
+            # safe="" to quote so that the "/" are escaped.
+            path = quote(self.trace_agent_socket, safe="")
+            self.trace_agent_socket = "http+unix://{}/profiling/v1/input".format(path)
 
     def _get_profile(self, profile):
         query_params = {}

--- a/go_pprof_scraper/datadog_checks/go_pprof_scraper/check.py
+++ b/go_pprof_scraper/datadog_checks/go_pprof_scraper/check.py
@@ -87,6 +87,10 @@ class GoPprofScraperCheck(AgentCheck):
         # this is being run by the agent
         self.trace_agent_url = "http://localhost:{}/profiling/v1/input".format(self.trace_agent_port)
 
+        # If modifying UDS-related code, run the end-to-end tests with the
+        # GO_PPROF_TEST_UDS environment variable defined so that the agent will
+        # listen over UDS rather than TCP, e.g.
+        #   env GO_PPROF_TEST_UDS=yes ddev env start --dev go_pprof_scraper py3.8
         self.trace_agent_socket = datadog_agent.get_config("apm_config.receiver_socket")
         if self.trace_agent_socket:
             # requets_unixsocket expects the path to be URL-encoded. We pass
@@ -167,6 +171,10 @@ class GoPprofScraperCheck(AgentCheck):
             # "Datadog-Container-ID" header to the request.
 
             if self.trace_agent_socket:
+                # If modifying UDS-related code, run the end-to-end tests with
+                # the GO_PPROF_TEST_UDS environment variable defined so that
+                # the agent will listen over UDS rather than TCP, e.g.
+                #   env GO_PPROF_TEST_UDS=yes ddev env start --dev go_pprof_scraper py3.8
                 session = requests_unixsocket.Session()
                 r = session.post(self.trace_agent_socket, files=files)
             else:

--- a/go_pprof_scraper/tests/conftest.py
+++ b/go_pprof_scraper/tests/conftest.py
@@ -25,6 +25,8 @@ def dd_environment():
     # We need to enable the trace-agent for testing since it won't be enabled by
     # default
     agent_env_vars = {"DD_APM_PROFILING_DD_URL": "http://localhost:9999/profiles", "DD_APM_ENABLED": "true"}
+    if os.getenv("GO_PPROF_TEST_UDS"):
+        agent_env_vars["DD_APM_RECEIVER_SOCKET"] = "/var/run/datadog-apm.socket"
     with docker_run(
         compose_file,
         endpoints=[URL],


### PR DESCRIPTION
### What does this PR do?

If the trace agent is listening for profiles over UDS, then quote the path to
the socket (to distinguish the path to the socket from the resource URL).

### Motivation

To make this integration work for agents receiving profiles over UDS.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
