### PR TITLE
[mkt-480] update uninstallation header to be h2 in readmes and manifests

### DIFF
--- a/adaptive_shield/README.md
+++ b/adaptive_shield/README.md
@@ -11,7 +11,7 @@ With the Adaptive Shield integration, you can track and monitor SaaS posture ale
 4. Click on **OAuth** to authorize.
 
 
-### Uninstallation
+## Uninstallation
 
 When you uninstall this integration, any previous authorizations are revoked. 
 

--- a/adaptive_shield/manifest.json
+++ b/adaptive_shield/manifest.json
@@ -6,6 +6,7 @@
     "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
+    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Track SaaS posture alerts",

--- a/lambdatest/README.md
+++ b/lambdatest/README.md
@@ -31,7 +31,7 @@ Here's how you can track incidents in Datadog with LambdaTest:
 4. A confirmation email is sent once the integration configuration is complete.
 5. Once Datadog is integrated with your LambdaTest account, start logging bugs and performing cross-browser testing.
 
-### Uninstallation
+## Uninstallation
 
 Once you uninstall this integration, any previous authorizations are revoked. 
 

--- a/lambdatest/manifest.json
+++ b/lambdatest/manifest.json
@@ -6,6 +6,7 @@
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
+    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Most powerful automation testing platform",

--- a/vantage/README.md
+++ b/vantage/README.md
@@ -14,7 +14,7 @@ Visit [Vantage][4] to sign up for free. Once registered, visit the [Vantage inte
 
 Once integrated, begin exploring your Datadog costs within Vantage. You can create filters for specific Datadog organizations and services alongside costs from any of the other supported Vantage providers.
 
-### Uninstallation
+## Uninstallation
 
 To remove the Datadog integration from Vantage, navigate to the [Vantage integrations page][1] and click **Remove**. Additionally, uninstall this integration from Datadog by clicking the **Uninstall Integration** button below. Once you uninstall this integration, any previous authorizations are revoked. 
 

--- a/vantage/manifest.json
+++ b/vantage/manifest.json
@@ -6,6 +6,7 @@
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
+    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Import your Datadog costs and track them alongside other infrastructure spending",


### PR DESCRIPTION
### What does this PR do?
Changes all READMEs that have the uninstallation field as an h3 to be an h2.

### Motivation
Uninstallation field for integrations-extras READMEs were originally made to be h3 headers since they would not show up otherwise. Now that we support the uninstallation h2 header, we should move those h3's to be h2's.
What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
