### PR TITLE
Revert "[mkt-480] update uninstallation header to be h2 in readmes and manifests"

### DIFF
--- a/adaptive_shield/README.md
+++ b/adaptive_shield/README.md
@@ -11,7 +11,7 @@ With the Adaptive Shield integration, you can track and monitor SaaS posture ale
 4. Click on **OAuth** to authorize.
 
 
-## Uninstallation
+### Uninstallation
 
 When you uninstall this integration, any previous authorizations are revoked. 
 

--- a/adaptive_shield/manifest.json
+++ b/adaptive_shield/manifest.json
@@ -6,7 +6,6 @@
     "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
-    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Track SaaS posture alerts",

--- a/lambdatest/README.md
+++ b/lambdatest/README.md
@@ -31,7 +31,7 @@ Here's how you can track incidents in Datadog with LambdaTest:
 4. A confirmation email is sent once the integration configuration is complete.
 5. Once Datadog is integrated with your LambdaTest account, start logging bugs and performing cross-browser testing.
 
-## Uninstallation
+### Uninstallation
 
 Once you uninstall this integration, any previous authorizations are revoked. 
 

--- a/lambdatest/manifest.json
+++ b/lambdatest/manifest.json
@@ -6,7 +6,6 @@
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
-    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Most powerful automation testing platform",

--- a/vantage/README.md
+++ b/vantage/README.md
@@ -14,7 +14,7 @@ Visit [Vantage][4] to sign up for free. Once registered, visit the [Vantage inte
 
 Once integrated, begin exploring your Datadog costs within Vantage. You can create filters for specific Datadog organizations and services alongside costs from any of the other supported Vantage providers.
 
-## Uninstallation
+### Uninstallation
 
 To remove the Datadog integration from Vantage, navigate to the [Vantage integrations page][1] and click **Remove**. Additionally, uninstall this integration from Datadog by clicking the **Uninstall Integration** button below. Once you uninstall this integration, any previous authorizations are revoked. 
 

--- a/vantage/manifest.json
+++ b/vantage/manifest.json
@@ -6,7 +6,6 @@
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
-    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Import your Datadog costs and track them alongside other infrastructure spending",


### PR DESCRIPTION
Reverts DataDog/integrations-extras#1704 

DO NOT MERGE. I am syncing this revert because we need to wait for[ another PR](https://github.com/DataDog/dogweb/pull/88785/files) to be in place prior to syncing this