### PR TITLE
Update link to dcgm exporter

### DIFF
--- a/nvml/README.md
+++ b/nvml/README.md
@@ -74,6 +74,6 @@ Need help? Contact [Datadog support][11].
 [11]: https://docs.datadoghq.com/help
 [12]: https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/#monitoring-device-plugin-resources
 [13]: https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html
-[14]:https://github.com/NVIDIA/gpu-monitoring-tools/blob/master/exporters/prometheus-dcgm/dcgm-exporter/dcgm-exporter
+[14]: https://github.com/NVIDIA/dcgm-exporter
 [15]: https://github.com/DataDog/integrations-extras/blob/master/nvml/tests/Dockerfile
 [16]: https://github.com/DataDog/integrations-extras/blob/master/nvml/assets/service_checks.json


### PR DESCRIPTION
The previous [link](https://github.com/NVIDIA/gpu-monitoring-tools/blob/master/exporters/prometheus-dcgm/dcgm-exporter/dcgm-exporter) points to a deprecated repo. 

The overall gpu-monitoring repo for NVIDIA was deprecated in August 2021 and have since split the repos into smaller components. Link 14 was updated to reflect the new repo for the dcgm-exporter.

### What does this PR do?

Updates the github repository link to the NVIDIA dcgm-exporter. 

### Motivation

Mentioned by customer during a webinar that the links in the page need updating. 
