### PR TITLE
Do not display the integration on the public website

### DIFF
--- a/lightstep_incident_response/manifest.json
+++ b/lightstep_incident_response/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b61db30e-3cbc-4dbe-b055-824f9e46e006",
   "app_id": "lightstep-incident-response",
-  "display_on_public_website": true,
+  "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?

Do not display the integration on the public website

### Motivation

This integration will soon be removed.

https://datadoghq.atlassian.net/browse/AI-2863

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
