### PR TITLE
Remove container-integrations from rbltracker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -110,7 +110,7 @@
 /puma/                                   @plasticine
 /purefa/                                 @chrroberts-pure pure-observability@purestorage.com @DataDog/marketplace-review
 /purefb/                                 @chrroberts-pure pure-observability@purestorage.com @DataDog/marketplace-review
-/rbltracker/                             
+/rbltracker/                             @DataDog/agent-integrations
 /reboot_required/                        @montdidier support@krugerheavyindustries.com
 /redisenterprise/                        @maguec christian@redislabs.com
 /redis_sentinel/                         @DataDog/agent-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -110,7 +110,7 @@
 /puma/                                   @plasticine
 /purefa/                                 @chrroberts-pure pure-observability@purestorage.com @DataDog/marketplace-review
 /purefb/                                 @chrroberts-pure pure-observability@purestorage.com @DataDog/marketplace-review
-/rbltracker/                             @DataDog/container-integrations
+/rbltracker/                             
 /reboot_required/                        @montdidier support@krugerheavyindustries.com
 /redisenterprise/                        @maguec christian@redislabs.com
 /redis_sentinel/                         @DataDog/agent-integrations
@@ -398,9 +398,9 @@
 /puma/*metadata.csv                      @plasticine @DataDog/documentation
 /puma/manifest.json                      @plasticine @DataDog/documentation
 /puma/README.md                          @plasticine @DataDog/documentation
-/rbltracker/*metadata.csv                @DataDog/container-integrations @DataDog/documentation
-/rbltracker/manifest.json                @DataDog/container-integrations @DataDog/documentation
-/rbltracker/README.md                    @DataDog/container-integrations @DataDog/documentation
+/rbltracker/*metadata.csv                @DataDog/documentation
+/rbltracker/manifest.json                @DataDog/documentation
+/rbltracker/README.md                    @DataDog/documentation
 /reboot_required/*metadata.csv           @montdidier support@krugerheavyindustries.com @DataDog/documentation
 /reboot_required/manifest.json           @montdidier support@krugerheavyindustries.com @DataDog/documentation
 /reboot_required/README.md               @montdidier support@krugerheavyindustries.com @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?

Remove `container-integrations` team from `rbltracker` github CODEOWNERS file.

### Motivation

@DataDog/container-integrations is not responsible of this integration.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
