### PR TITLE
update api keys link to filter to app title

### DIFF
--- a/adaptive_shield/README.md
+++ b/adaptive_shield/README.md
@@ -15,7 +15,7 @@ With the Adaptive Shield integration, you can track and monitor SaaS posture ale
 
 When you uninstall this integration, any previous authorizations are revoked. 
 
-Additionally, ensure that all API keys associated with this integration have been disabled by searching for the integration name on the [API Keys management page](https://app.datadoghq.com/organization-settings/api-keys).
+Additionally, ensure that all API keys associated with this integration have been disabled by searching for the integration name on the [API Keys management page](https://app.datadoghq.com/organization-settings/api-keys?filter=Adaptive%20Shield).
 
 
 ## Support

--- a/buoyant_cloud/README.md
+++ b/buoyant_cloud/README.md
@@ -47,7 +47,7 @@ Need help? Get support from the following sources:
 [2]: https://buoyant.cloud/notifications
 [3]: https://app.datadoghq.com/event/explorer
 [4]: https://buoyant.cloud/settings
-[5]: https://app.datadoghq.com/organization-settings/api-keys
+[5]: https://app.datadoghq.com/organization-settings/api-keys?filter=Buoyant%20Cloud
 [6]: https://docs.buoyant.cloud
 [7]: https://slack.linkerd.io
 [8]: mailto:cloud@buoyant.io

--- a/lambdatest/README.md
+++ b/lambdatest/README.md
@@ -35,7 +35,7 @@ Here's how you can track incidents in Datadog with LambdaTest:
 
 Once you uninstall this integration, any previous authorizations are revoked. 
 
-Additionally, ensure that all API keys associated with this integration have been disabled by searching for the integration name on the [API Keys management page](https://app.datadoghq.com/organization-settings/api-keys).
+Additionally, ensure that all API keys associated with this integration have been disabled by searching for the integration name on the [API Keys management page](https://app.datadoghq.com/organization-settings/api-keys?filter=LambdaTest).
 
 ## Support
 

--- a/vantage/README.md
+++ b/vantage/README.md
@@ -27,5 +27,5 @@ Need help? Contact [Vantage support](mailto:support@vantage.sh).
 
 [1]: https://console.vantage.sh/settings/integrations
 [2]: https://app.datadoghq.com/organization-settings/oauth-applications
-[3]: https://app.datadoghq.com/organization-settings/api-keys
+[3]: https://app.datadoghq.com/organization-settings/api-keys?filter=Vantage
 [4]: https://console.vantage.sh


### PR DESCRIPTION
### What does this PR do?
Updates api keys page link to include a filter with the app title in the uninstallation instructions for integrations with oauth.
A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
