### PR TITLE
(DOCS-4595) Add event details

### DIFF
--- a/buoyant_cloud/README.md
+++ b/buoyant_cloud/README.md
@@ -33,7 +33,13 @@ Additionally, ensure that all API keys associated with this integration have bee
 
 ### Events
 
-Buoyant Cloud sends [events][3] to Datadog.
+Buoyant Cloud sends [events][3] to Datadog, including:
+
+- Linkerd health alerts
+- Linkerd configuration alerts
+- Workload traffic alerts
+- Workload rollouts
+- Manual events
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What does this PR do?

Add details about Buoyant cloud integration events.

### Motivation

DOCS-4595

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?

This re-adds the event details removed in this suggestion:
https://github.com/DataDog/integrations-extras/pull/1693#discussion_r1052631947

I've since confirmed with @emarsha94 that the event details can be added back in.
