### PR TITLE
Clarify metrics integration support

### DIFF
--- a/jfrog_platform/README.md
+++ b/jfrog_platform/README.md
@@ -33,6 +33,12 @@ JFrog Artifactory and Xray metrics API integration with Datadog allows you to se
 
 ### Metrics collection
 
+#### Note:
+
+Metrics collection is available only for [JFrog Platform Self-Hosted users. JFrog Cloud is not supported.][22]
+
+#### Setup and Configure
+
 1. Enable Metrics for Artifactory and Xray:
 
     1. [Enable Metrics for Artifactory][7]
@@ -201,3 +207,4 @@ Need help? Contact [Datadog support][15].
 [19]: https://www.jfrog.com/confluence/display/JFROG/User+Profile#UserProfile-APIKey
 [20]: https://docs.datadoghq.com/agent/logs/?tab=tailfiles#activate-log-collection
 [21]: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile#tail-directories-by-using-wildcards
+[22]: https://www.jfrog.com/confluence/display/JFROG/Open+Metrics


### PR DESCRIPTION
### What does this PR do?

This makes clear that the metrics integration is not compatible with JFrog Cloud, in line with [JFrog's documentation](https://www.jfrog.com/confluence/display/JFROG/Open+Metrics).

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
