### PR TITLE
go_pprof_scraper: correctly handle URLs without trailing slashes

### DIFF
--- a/go_pprof_scraper/CHANGELOG.md
+++ b/go_pprof_scraper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Go-pprof-scraper
 
-## 1.0.3 / 2023-01-11
+## 1.0.3 / 2023-01-17
 
 * [Fixed] The `pprof_url` parameter no longer requires a trailing "/" to work properly.
 

--- a/go_pprof_scraper/CHANGELOG.md
+++ b/go_pprof_scraper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - Go-pprof-scraper
 
+## 1.0.3 / 2023-01-11
+
+* [Fixed] The `pprof_url` parameter no longer requires a trailing "/" to work properly.
+
 ## 1.0.2 / 2022-12-27
 
 * [Fixed] Decrease `min_collection_interval` value to prevent long pause between collecting profiles.

--- a/go_pprof_scraper/assets/configuration/spec.yaml
+++ b/go_pprof_scraper/assets/configuration/spec.yaml
@@ -15,7 +15,10 @@ files:
         type: string
     - name: pprof_url
       required: true
-      description: URL of the /debug/pprof endpoint to collect
+      description: |
+        URL of the /debug/pprof endpoint to collect. Profiles will be requested
+        from the URL obtained by appending "/profile", "/heap", etc. to the
+        given URL.
       value:
         example: "http://myservice:1234/debug/pprof/"
         type: string

--- a/go_pprof_scraper/datadog_checks/go_pprof_scraper/__about__.py
+++ b/go_pprof_scraper/datadog_checks/go_pprof_scraper/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/go_pprof_scraper/datadog_checks/go_pprof_scraper/check.py
+++ b/go_pprof_scraper/datadog_checks/go_pprof_scraper/check.py
@@ -55,6 +55,9 @@ class GoPprofScraperCheck(AgentCheck):
         self.url = self.instance.get("pprof_url")
         if not self.url:
             raise ConfigurationError("pprof_url is required")
+        if not self.url.endswith("/"):
+            # TODO: log a warning that we're mucking with the provided path?
+            self.url += "/"
         self.hostname = urlparse(self.url).hostname
         if self.hostname == "localhost" or self.hostname == "127.0.0.1":
             self.hostname = socket.gethostname()

--- a/go_pprof_scraper/datadog_checks/go_pprof_scraper/check.py
+++ b/go_pprof_scraper/datadog_checks/go_pprof_scraper/check.py
@@ -56,7 +56,6 @@ class GoPprofScraperCheck(AgentCheck):
         if not self.url:
             raise ConfigurationError("pprof_url is required")
         if not self.url.endswith("/"):
-            # TODO: log a warning that we're mucking with the provided path?
             self.url += "/"
         self.hostname = urlparse(self.url).hostname
         if self.hostname == "localhost" or self.hostname == "127.0.0.1":

--- a/go_pprof_scraper/datadog_checks/go_pprof_scraper/data/conf.yaml.example
+++ b/go_pprof_scraper/datadog_checks/go_pprof_scraper/data/conf.yaml.example
@@ -20,7 +20,9 @@ instances:
     # env: prod
 
     ## @param pprof_url - string - required
-    ## URL of the /debug/pprof endpoint to collect
+    ## URL of the /debug/pprof endpoint to collect. Profiles will be requested
+    ## from the URL obtained by appending "/profile", "/heap", etc. to the
+    ## given URL.
     #
     pprof_url: http://myservice:1234/debug/pprof/
 

--- a/go_pprof_scraper/tests/conftest.py
+++ b/go_pprof_scraper/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 from datadog_checks.dev import docker_run, get_docker_hostname, get_here
 
-URL = "http://{}:8888/debug/pprof/".format(get_docker_hostname())
+URL = "http://{}:8888/debug/pprof".format(get_docker_hostname())
 INSTANCE = {
     "pprof_url": URL,
     "profiles": ["heap"],


### PR DESCRIPTION
### What does this PR do?

Add a trailing slash if one isn't already there. This PR also updates the `pprof_url` documentation to explain how profiles will be collected.

### Motivation

If the `pprof_url` parameter doesn't have a trailing slash, profiles won't be collected from the expected URL. For example, given

	pprof_url: "http://1.2.3.4:6060/debug/pprof"

the CPU profile will be requested from

	"http://1.2.3.4:6060/debug/profile"

rather than

	"http://1.2.3.4:6060/debug/pprof/profile"

which is what it _should_ do. This is due to the way [urljoin](https://docs.python.org/3/library/urllib.parse.html?highlight=urljoin#urllib.parse.urljoin) works.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
