### PR TITLE
[Lighthouse] Add desktop emulation argument

### DIFF
--- a/lighthouse/datadog_checks/lighthouse/lighthouse.py
+++ b/lighthouse/datadog_checks/lighthouse/lighthouse.py
@@ -36,6 +36,8 @@ class LighthouseCheck(AgentCheck):
 
             if form_factor:
                 cmd.append("--form-factor=" + form_factor)
+                if form_factor == "desktop":
+                     cmd.append("--preset=desktop")
 
             json_string, error_message, exit_code = LighthouseCheck._get_lighthouse_report(cmd, self.log, False)
 

--- a/lighthouse/datadog_checks/lighthouse/lighthouse.py
+++ b/lighthouse/datadog_checks/lighthouse/lighthouse.py
@@ -37,7 +37,7 @@ class LighthouseCheck(AgentCheck):
             if form_factor:
                 cmd.append("--form-factor=" + form_factor)
                 if form_factor == "desktop":
-                     cmd.append("--preset=desktop")
+                    cmd.append("--preset=desktop")
 
             json_string, error_message, exit_code = LighthouseCheck._get_lighthouse_report(cmd, self.log, False)
 


### PR DESCRIPTION
### What does this PR do?

Towards fixing https://github.com/DataDog/integrations-extras/issues/1325.

I can reproduce the issue locally, with Lighthouse 9.6.8:
```
% npx lighthouse --version
9.6.8
% npx lighthouse https://www.intercom.com --output json --quiet --chrome-flags='--headless' --form-factor=desktop
Runtime error encountered: Screen emulation mobile setting (true) does not match formFactor setting (desktop). See https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md
Error: Screen emulation mobile setting (true) does not match formFactor setting (desktop). See https://github.com/GoogleChrome/lighthouse/blob/master/docs/emulation.md
    at Object.assertValidSettings (/Users/horia.andrei/.nvm/versions/node/v17.0.1/lib/node_modules/lighthouse/lighthouse-core/fraggle-rock/config/validation.js:224:13)
    at resolveSettings (/Users/horia.andrei/.nvm/versions/node/v17.0.1/lib/node_modules/lighthouse/lighthouse-core/config/config-helpers.js:323:14)
    at new Config (/Users/horia.andrei/.nvm/versions/node/v17.0.1/lib/node_modules/lighthouse/lighthouse-core/config/config.js:195:22)
    at generateConfig (/Users/horia.andrei/.nvm/versions/node/v17.0.1/lib/node_modules/lighthouse/lighthouse-core/index.js:66:10)
    at lighthouse (/Users/horia.andrei/.nvm/versions/node/v17.0.1/lib/node_modules/lighthouse/lighthouse-core/index.js:44:18)
    at runLighthouse (file:///Users/horia.andrei/.nvm/versions/node/v17.0.1/lib/node_modules/lighthouse/lighthouse-cli/run.js:252:14)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

According to Lighthouse docs [here](https://github.com/GoogleChrome/lighthouse/blob/main/docs/emulation.md), in order to set emulation to desktop you need to add the `--preset=desktop` argument.

```
% npx lighthouse https://www.intercom.com --output json --quiet --chrome-flags='--headless' --form-factor=desktop --preset=desktop --output-path=./lighthouse.json
% ls lighthouse.json
lighthouse.json
```

### Motivation

I'm facing the same bug in production 🐛 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
