### PR TITLE
[doc] Update traefik doc to add metric

### DIFF
--- a/traefik/metadata.csv
+++ b/traefik/metadata.csv
@@ -1,3 +1,4 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 traefik.total_status_code_count,gauge,,,,total count for each returned status code,0,traefik,,
 traefik.total_count,gauge,,,,count total number of requests,0,traefik,,
+traefik.service.request.total,count,,,,count total count of HTTP requests processed on a service,0,traefik,,

--- a/traefik/metadata.csv
+++ b/traefik/metadata.csv
@@ -1,4 +1,4 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 traefik.total_status_code_count,gauge,,,,total count for each returned status code,0,traefik,,
 traefik.total_count,gauge,,,,count total number of requests,0,traefik,,
-traefik.service.request.total,count,,,,count total count of HTTP requests processed on a service,0,traefik,,
+traefik.service.request.total,count,,,,total count of HTTP requests processed on a service,0,traefik,,


### PR DESCRIPTION
Request to add additional functioning standard metric to Traefik documentation. 

Ticket for reference: https://datadog.zendesk.com/agent/tickets/1079764

Traefik documentation for reference: https://doc.traefik.io/traefik/observability/metrics/overview/

### What does this PR do?

This PR updates the documentation with an additional standard metric for the Traefik integration.

### Motivation

https://datadog.zendesk.com/agent/tickets/1079764

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?

Link to Traefik documentation doc for reference: https://doc.traefik.io/traefik/observability/metrics/overview/
