### PR TITLE
Edit to pyproject.toml to fix the builder

### DIFF
--- a/fiddler/pyproject.toml
+++ b/fiddler/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools<61",
-    "fiddler-client>=1.5.0",
 ]
 build-backend = "hatchling.build"
 
@@ -30,15 +28,14 @@ classifiers = [
 ]
 dependencies = [
     "datadog-checks-base>=25.1.0",
+    "fiddler-client",
 ]
 dynamic = [
     "version",
 ]
 
 [project.optional-dependencies]
-deps = [
-    "fiddler-client",
-]
+deps = []
 
 [project.urls]
 Source = "https://github.com/DataDog/integrations-extras"

--- a/fiddler/pyproject.toml
+++ b/fiddler/pyproject.toml
@@ -28,14 +28,15 @@ classifiers = [
 ]
 dependencies = [
     "datadog-checks-base>=25.1.0",
-    "fiddler-client",
 ]
 dynamic = [
     "version",
 ]
 
 [project.optional-dependencies]
-deps = []
+deps = [
+    "fiddler-client",
+]
 
 [project.urls]
 Source = "https://github.com/DataDog/integrations-extras"


### PR DESCRIPTION
### What does this PR do?
This PR removes unneeded packages from the builder package and adds fiddler-client as a dependency. The builder image couldn't build this because it couldn't install numpy/pandas, which are dependencies for `fiddler-client` but there's no need to have that to build the wheel. We do however need `fiddler-client` to be installed when the wheel is installed so I've added it as a mandatory dependency.

I tested this locally by building the wheel in the builder image and then installing it. Although, the check doesn't run there's no loading errors:

Docker:
```
=========
Collector
=========

  Running Checks
  ==============
    
    fiddler (1.0.0)
    ---------------
      Instance ID: fiddler:e985691205e752f [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/fiddler.d/conf.yaml
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 616ms
      Last Execution Date : 2023-02-14 18:12:02 UTC (1676398322000)
      Last Successful Execution Date : Never
      Error: <Truncated>
```

Also worth noting that I couldn't run this on mac due to adhoc signing of c-bindings. Not sure why. Could be due to mac OS's library validation:
https://www.tenable.com/audits/items/CIS_Apple_macOS_11_v1.2.0_L1.audit:e53b2df565bba14df49f057ce72a3672

```
Original error was: dlopen(/Users/steven/.local/lib/python3.8/site-packages/numpy/core/_multiarray_umath.cpython-38-darwin.so, 0x0002): tried: '/Users/steven/.local/lib/python3.8/site-packages/numpy/core/_multiarray_umath.cpython-38-darwin.so' (code signature in <A22C71E5-435E-3779-872F-B41920E28032> '/Users/steven/.local/lib/python3.8/site-packages/numpy/core/_multiarray_umath.cpython-38-darwin.so' not valid for use in process: mapped file has no Team ID and is not a platform binary (signed with custom identity or adhoc?))
```
