### PR TITLE
Update LaunchDarkly dashboard instructions

### DIFF
--- a/launchdarkly/README.md
+++ b/launchdarkly/README.md
@@ -24,13 +24,14 @@ The LaunchDarkly events integration uses a [Datadog API key][3], which can be cr
 
 ### Dashboard widget
 
+1. On the [LaunchDarkly integration tile][8], make sure the LaunchDarkly integration is installed.
 1. In Datadog, navigate to an existing dashboard or create a new one.
-2. Press the **Add Widgets** button to expose the widget drawer.
-3. Search for **LaunchDarkly** to find the LaunchDarkly widget in the **Apps** section of the widget drawer.
-4. Click or drag the LaunchDarkly widget icon to add it your your dashboard and open the **LaunchDarkly editor** modal.
-5. Press the **Connect** button to connect your LaunchDarkly account. A new window opens prompting you to authorize Datadog.
-6. Click **Authorize**. You are returned to Datadog.
-7. Next, configure the following widget options in the **LaunchDarkly editor**:
+1. Press the **Add Widgets** button to expose the widget drawer.
+1. Search for **LaunchDarkly** to find the LaunchDarkly widget in the **Apps** section of the widget drawer.
+1. Click or drag the LaunchDarkly widget icon to add it your your dashboard and open the **LaunchDarkly editor** modal.
+1. Press the **Connect** button to connect your LaunchDarkly account. A new window opens prompting you to authorize Datadog.
+1. Click **Authorize**. You are returned to Datadog.
+1. Next, configure the following widget options in the **LaunchDarkly editor**:
 
    - **LaunchDarkly project**: The name of the LaunchDarkly project you wish to associate with the dashboard widget.
    - **LaunchDarkly environment**: The name of the LaunchDarkly environment you wish to associate with the dashboard widget.
@@ -38,8 +39,8 @@ The LaunchDarkly events integration uses a [Datadog API key][3], which can be cr
    - **LaunchDarkly tag filter**: An optional `+` separated list tags used to filter the feature flags displayed in the widget. If multiple tags are included, only flags that match **all** included tags appear in the widget. If omitted, all of the project's feature flags appear in the widget.
    - **Sort**: The order the flags are displayed in the widget. Defaults to **Newest**.
 
-8. Optionally give the widget a title.
-9. Press **Save** to finish configuring the Datadog dashboard widget.
+1. Optionally give the widget a title.
+1. Press **Save** to finish configuring the Datadog dashboard widget.
 
 ### Relay Proxy metrics
 
@@ -78,3 +79,4 @@ Learn more about [LaunchDarkly][1] and the [Datadog events integration][4].
 [5]: https://github.com/launchdarkly/ld-relay/blob/v6/docs/metrics.md
 [6]: https://github.com/launchdarkly/ld-relay/blob/v6/docs/endpoints.md
 [7]: https://docs.datadoghq.com/help/
+[8]: https://app.datadoghq.com/integrations/launchdarkly

--- a/launchdarkly/README.md
+++ b/launchdarkly/README.md
@@ -29,8 +29,8 @@ The LaunchDarkly events integration uses a [Datadog API key][3], which can be cr
 1. Press the **Add Widgets** button to expose the widget drawer.
 1. Search for **LaunchDarkly** to find the LaunchDarkly widget in the **Apps** section of the widget drawer.
 1. Click or drag the LaunchDarkly widget icon to add it your your dashboard and open the **LaunchDarkly editor** modal.
-1. Press the **Connect** button to connect your LaunchDarkly account. A new window opens prompting you to authorize Datadog.
-1. Click **Authorize**. You are returned to Datadog.
+1. Press the **Connect** button to connect your LaunchDarkly account. A new window opens, prompting you to authorize Datadog.
+1. Click **Authorize**, which should navigate you back to Datadog.
 1. Next, configure the following widget options in the **LaunchDarkly editor**:
 
    - **LaunchDarkly project**: The name of the LaunchDarkly project you wish to associate with the dashboard widget.
@@ -39,7 +39,7 @@ The LaunchDarkly events integration uses a [Datadog API key][3], which can be cr
    - **LaunchDarkly tag filter**: An optional `+` separated list tags used to filter the feature flags displayed in the widget. If multiple tags are included, only flags that match **all** included tags appear in the widget. If omitted, all of the project's feature flags appear in the widget.
    - **Sort**: The order the flags are displayed in the widget. Defaults to **Newest**.
 
-1. Optionally give the widget a title.
+1. Optionally, give the widget a title.
 1. Press **Save** to finish configuring the Datadog dashboard widget.
 
 ### Relay Proxy metrics


### PR DESCRIPTION
Some users are confused about not being able to find the LaunchDarkly widget in the dashboard search. This clarifies that they need to install the integration before it will show up in the search.

### Motivation

See [DOCS-4905](https://datadoghq.atlassian.net/browse/DOCS-4905) and attached support ticket.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?


[DOCS-4905]: https://datadoghq.atlassian.net/browse/DOCS-4905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ