### PR TITLE
[NS1] Update Top10 usage query in overview.json

### DIFF
--- a/ns1/assets/dashboards/overview.json
+++ b/ns1/assets/dashboards/overview.json
@@ -1225,7 +1225,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:system.cpu.user{*} by {service}",
+                                            "query": "avg:ns1.usage.zone{*} by {zone}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "avg"


### PR DESCRIPTION
### What does this PR do?
Update Top10 usage widget query in overview.json.

`Usage - Top 10 Zones`  widget query the incorrect metric.
- AS_IS : `system.cpu.user`
- TO_BE : `ns1.usage.zone`

![NS1 Dashboard Datadog 2023-04-04 at 3 31 38 PM](https://user-images.githubusercontent.com/15884634/229709604-a78e643f-4a9b-4f9c-93bd-ba1c687ddfa5.jpg)

### Motivation
Reported Issue : https://datadog.zendesk.com/agent/tickets/1156860