### PR TITLE
Update codeowners tech partner integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,8 @@
 /agora_analytics/                        @Agora zhangpeizhe@agora.io @DataDog/marketplace-review
 /akamai_datastream_2/                    @DataDog/web-integrations
 /alertnow/                               @Uijong-Kim uijong.kim@bespinglobal.com
-/algorithmia/                            @koverholt support@algorithmia.io
-/altostra/                               @yevk @altostra/engineering
+/algorithmia/                            @koverholt support@algorithmia.io @DataDog/marketplace-review
+/altostra/                               @yevk @altostra/engineering @DataDog/marketplace-review
 /ambassador/                             @datawire hello@datawire.io
 /amixr/                                  @iskhakov ildar@amixr.io
 /apache-apisix/                          @bisakhmondal bisakhmondal00@gmail.com
@@ -39,8 +39,8 @@
 /configcat/                              @configcat
 /contrastsecurity/                       @kristianamitchellcontrastsecurity kristiana.mitchell@contrastsecurity.com
 /convox/                                 @DataDog/agent-integrations
-/cortex/                                 @cortexapps/engineering support@getcortexapp.com
-/cyral/                                  @tyrannosaurus-becks product@cyral.com
+/cortex/                                 @cortexapps/engineering support@getcortexapp.com @DataDog/marketplace-review
+/cyral/                                  @tyrannosaurus-becks product@cyral.com @DataDog/marketplace-review
 /data_runner/                            @DataDog/apps-sdk @DataDog/marketplace-review
 /datazoom/                               @DataDog/web-integrations
 /drata/                                  @jason-drata support@drata.com @DataDog/marketplace-review
@@ -69,13 +69,13 @@
 /gremlin/                                support@gremlin.com
 /grpc_check/                             @keisku
 /harness_cloud_cost_management/          @akashbdj support@harness.io @DataDog/marketplace-review
-/hasura_cloud/                           @ShraddhaAg @shahidhk support@hasura.io
+/hasura_cloud/                           @ShraddhaAg @shahidhk support@hasura.io @DataDog/marketplace-review
 /hbase_master/                           @everpeace
 /hbase_regionserver/                     @everpeace
 /hcp_vault/                              @DataDog/agent-integrations
 /hikaricp/                               @bertaudamien
 /jfrog_platform/                         @jfrog/partner-engineering
-/ilert/                                  @yacut support@ilert.com
+/ilert/                                  @yacut support@ilert.com @DataDog/marketplace-review
 /insightfinder/                          @dearmore @erinlmcmahon support@insightfinder.com @DataDog/marketplace-review
 /isdown/                                 @ntomas support@isdown.app @DataDog/marketplace-review
 /rum_javascript/                         @DataDog/rum-app
@@ -85,19 +85,19 @@
 /launchdarkly/                           support@launchdarkly.com @DataDog/marketplace-review
 /lacework/                               @DataDog/agent-integrations
 /lambdatest/                             @prateeksainilambdatest @DataDog/marketplace-review
-/launchdarkly/                           support@launchdarkly.com
+/launchdarkly/                           support@launchdarkly.com 
 /lighthouse/                             @DataDog/agent-integrations
 /logstash/                               @ervansetiawan ervansetiawan@gmail.com
 /logzio/                                 @DataDog/agent-integrations
 /mongodb_atlas/                          @DataDog/web-integrations
 /mendix/                                 @mendix/cloud @DataDog/agent-integrations @DataDog/marketplace-review
-/n2ws/                                   @eliadeini eliad.eini@n2ws.com
-/neo4j/                                  @davidfauth help@neo4j.com
+/n2ws/                                   @eliadeini eliad.eini@n2ws.com @DataDog/marketplace-review
+/neo4j/                                  @davidfauth help@neo4j.com @DataDog/marketplace-review
 /neoload/                                @Neotys-Labs/r-d @DataDog/marketplace-review
 /neutrona/                               @DavidFlamini david@neutrona.com
 /nextcloud/                              @eplanet
 /nn_sdwan/                               @nikhilguptanetnologyio @habibmadaninetnologyio @DataDog/marketplace-review
-/nobl9/                                  @ian-bartholomew support@nobl9.com
+/nobl9/                                  @ian-bartholomew support@nobl9.com @DataDog/marketplace-review
 /nomad/                                  @irabinovitch
 /ns1/                                    @Zach-Johnson zjohnson@ns1.com @DataDog/marketplace-review
 /nvml/                                   @cep21
@@ -112,7 +112,7 @@
 /planetscale/                            @DataDog/web-integrations support@planetscale.com
 /pliant/                                 @hello-pliant hello@pliant.io
 /portworx/                               @pault84 paul@portworx.com
-/postman/                                @shashankawasthi88  integrations-partnerships@postman.com
+/postman/                                @shashankawasthi88  integrations-partnerships@postman.com @DataDog/marketplace-review
 /pulsar/                                 @zzzming itestmycode@gmail.com
 /pulumi/                                 @isaac-pulumi team@pulumi.com @DataDog/marketplace-review
 /puma/                                   @plasticine
@@ -120,11 +120,11 @@
 /purefb/                                 @chrroberts-pure pure-observability@purestorage.com @DataDog/marketplace-review
 /rbltracker/                             @DataDog/agent-integrations
 /reboot_required/                        @montdidier support@krugerheavyindustries.com
-/redisenterprise/                        @maguec christian@redislabs.com
+/redisenterprise/                        @maguec christian@redislabs.com @DataDog/marketplace-review
 /redis_sentinel/                         @DataDog/agent-integrations
 /redpanda/                               @rkruze roko@vectorized.io
 /resin/                                  @brentm5
-/retool/                                 @jamiecuffe
+/retool/                                 @jamiecuffe @DataDog/marketplace-review
 /riak_repl/                              @abtreece
 /rigor/                                  support@rigor.com
 /rookout/                                support@rookout.com @DataDog/marketplace-review
@@ -139,10 +139,10 @@
 /scalr/                                  @soltysss @DataDog/marketplace-review
 /sedai/                                  @praveenprakash @DataDog/marketplace-review
 /sendmail/                               @dabcoder david.bouchare@datadoghq.com
-/signl4/                                 @rons4 ron@signl4.com
+/signl4/                                 @rons4 ron@signl4.com @DataDog/marketplace-review
 /sigsci/                                 @signalsciences info@signalsciences.com
 /shoreline/                              @ivang-shoreline @ciprian-shoreline @alinshoreline @cioc-shoreline @cristi-shoreline support@shoreline.io @DataDog/marketplace-review
-/sleuth/                                 @mtbnut pleal@sleuth.io
+/sleuth/                                 @mtbnut pleal@sleuth.io @DataDog/marketplace-review
 /snmpwalk/                               @DataDog/agent-integrations
 /sortdb/                                 @namrata4 namrata.deshpande4@gmail.com
 /speedscale/                             @kenahrens ken@speedscale.com @DataDog/marketplace-review
@@ -150,9 +150,9 @@
 /split/                                  @jeremy-lq
 /sqreen/                                 @DataDog/agent-integrations
 /squadcast/                              it@squadcast.com
-/stackpulse/                             @torqio/rnd support@torq.io
+/stackpulse/                             @torqio/rnd support@torq.io @DataDog/marketplace-review
 /stardog/                                @snowell support@stardog.com
-/statsig/                                @marcos-statsig support@statsig.com
+/statsig/                                @marcos-statsig support@statsig.com @DataDog/marketplace-review
 /steadybit/                              @bripkens support@steadybit.com @DataDog/marketplace-review
 /storm/                                  @platinummonkey
 /stormforge/                             @bradbeam @tperol support@stormforge.io @DataDog/marketplace-review


### PR DESCRIPTION
Update the codeowners file to include @DataDog/marketplace-review on tech partner integrations

### What does this PR do?

Update the codeowners file to include @DataDog/marketplace-review on tech partner integrations

### Motivation

For agent eng to easily distinguish between community supported and tech partners 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
