### PR TITLE
Removing "Integration" from titles

### DIFF
--- a/1e/manifest.json
+++ b/1e/manifest.json
@@ -9,7 +9,7 @@
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Send your 1E product metrics to Datadog.",
-    "title": "1E Integration",
+    "title": "1E",
     "media": [
       {
         "media_type": "image",

--- a/bottomline_recordandreplay/manifest.json
+++ b/bottomline_recordandreplay/manifest.json
@@ -9,7 +9,7 @@
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Monitor your 3270/5250 Mainframe users and resources using network traffic",
-    "title": "Bottomline's Record and Replay: Mainframe Integration",
+    "title": "Bottomline's Record and Replay: Mainframe",
     "media": [
       {
         "media_type": "image",

--- a/signl4/manifest.json
+++ b/signl4/manifest.json
@@ -9,7 +9,7 @@
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Get notified of your Datadog alerts and take actions using SIGNL4.",
-    "title": "SIGNL4 Integration for Datadog",
+    "title": "SIGNL4",
     "media": [],
     "classifier_tags": [
       "Category::Alerting",


### PR DESCRIPTION
### What does this PR do?
Now that tiles are redesigned to show which offerings are integrations (vs. software licenses, ui extensions, etc), we'll be removing the word "Integration" from titles to avoid redundancy

### Motivation

Feedback asking for "Integration" to be removed

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
