### PR TITLE
[APW] Fix integration dashboards' json definitions

### DIFF
--- a/1e/assets/dashboards/1EDashboard.json
+++ b/1e/assets/dashboards/1EDashboard.json
@@ -790,6 +790,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "a8s-w6g-u4v"
+  "reflow_type": "fixed"
 }

--- a/ably/assets/dashboards/ably.json
+++ b/ably/assets/dashboards/ably.json
@@ -459,6 +459,5 @@
     ],
     "layout_type": "ordered",
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "2iv-ues-pz7"
+    "reflow_type": "fixed"
 }

--- a/akamai_datastream_2/assets/dashboards/akamai_datastream_2_overview.json
+++ b/akamai_datastream_2/assets/dashboards/akamai_datastream_2_overview.json
@@ -1630,6 +1630,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "3uk-dxb-qk8"
+  "reflow_type": "fixed"
 }

--- a/altostra/assets/dashboards/altostra.json
+++ b/altostra/assets/dashboards/altostra.json
@@ -90,6 +90,5 @@
   "template_variables": [],
   "layout_type": "free",
   "is_read_only": false,
-  "notify_list": [],
-  "id": "h34-96a-svp"
+  "notify_list": []
 }

--- a/aqua/assets/dashboards/overview.json
+++ b/aqua/assets/dashboards/overview.json
@@ -690,6 +690,5 @@
   "template_variables": [],
   "layout_type": "free",
   "is_read_only": true,
-  "notify_list": [],
-  "id": 246
+  "notify_list": []
 }

--- a/buoyant_cloud/assets/dashboards/buoyant_cloud_overview.json
+++ b/buoyant_cloud/assets/dashboards/buoyant_cloud_overview.json
@@ -79,6 +79,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "u7g-8q5-xa5"
+  "reflow_type": "fixed"
 }

--- a/census/assets/dashboards/census_overview.json
+++ b/census/assets/dashboards/census_overview.json
@@ -315,6 +315,5 @@
   "template_variables": [],
   "layout_type": "ordered",
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "j99-x6b-j66"
+  "reflow_type": "fixed"
 }

--- a/cockroachdb_dedicated/assets/dashboards/cockroach_cloud_overview.json
+++ b/cockroachdb_dedicated/assets/dashboards/cockroach_cloud_overview.json
@@ -1128,6 +1128,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "sea-key-spi"
+  "reflow_type": "fixed"
 }

--- a/contrastsecurity/assets/dashboards/contrast_security_protect.json
+++ b/contrastsecurity/assets/dashboards/contrast_security_protect.json
@@ -283,6 +283,5 @@
   "template_variables": [],
   "layout_type": "free",
   "is_read_only": true,
-  "notify_list": [],
-  "id": 30296
+  "notify_list": []
 }

--- a/cyral/assets/dashboards/cyral_overview.json
+++ b/cyral/assets/dashboards/cyral_overview.json
@@ -288,6 +288,5 @@
     "template_variables": [],
     "layout_type": "free",
     "is_read_only": true,
-    "notify_list": [],
-    "id": 30346
+    "notify_list": []
   }

--- a/datazoom/assets/dashboards/datazoom_overview.json
+++ b/datazoom/assets/dashboards/datazoom_overview.json
@@ -1710,6 +1710,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "2jc-ztd-bat"
+  "reflow_type": "fixed"
 }

--- a/embrace_mobile/assets/dashboards/embrace_mobile_overview.json
+++ b/embrace_mobile/assets/dashboards/embrace_mobile_overview.json
@@ -153,6 +153,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "i9w-zy5-92p"
+  "reflow_type": "fixed"
 }

--- a/f5-distributed-cloud/assets/dashboards/f5xc_access.json
+++ b/f5-distributed-cloud/assets/dashboards/f5xc_access.json
@@ -330,6 +330,5 @@
         "template_variables": []
       }
     ],
-    "reflow_type": "fixed",
-    "id": "i9a-m66-8cz"
+    "reflow_type": "fixed"
   }

--- a/federatorai/assets/dashboards/application-overview.json
+++ b/federatorai/assets/dashboards/application-overview.json
@@ -871,6 +871,5 @@
     ],
     "layout_type": "free",
     "is_read_only": true,
-    "notify_list": [],
-    "id": 30420
+    "notify_list": []
 }

--- a/federatorai/assets/dashboards/cluster-overview.json
+++ b/federatorai/assets/dashboards/cluster-overview.json
@@ -539,6 +539,5 @@
     ],
     "layout_type": "free",
     "is_read_only": true,
-    "notify_list": [],
-    "id": 30422
+    "notify_list": []
 }

--- a/federatorai/assets/dashboards/cost-analysis-overview.json
+++ b/federatorai/assets/dashboards/cost-analysis-overview.json
@@ -586,6 +586,5 @@
     ],
     "layout_type": "free",
     "is_read_only": true,
-    "notify_list": [],
-    "id": 30421
+    "notify_list": []
 }

--- a/federatorai/assets/dashboards/overview.json
+++ b/federatorai/assets/dashboards/overview.json
@@ -329,6 +329,5 @@
     ],
   "layout_type": "free",
   "is_read_only": true,
-  "notify_list": [],
-  "id": 30323
+  "notify_list": []
 }

--- a/filemage/assets/dashboards/overview.json
+++ b/filemage/assets/dashboards/overview.json
@@ -201,6 +201,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "9u5-rsv-qyd"
+  "reflow_type": "fixed"
 }

--- a/gatekeeper/assets/dashboards/gatekeeper_overview.json
+++ b/gatekeeper/assets/dashboards/gatekeeper_overview.json
@@ -720,6 +720,5 @@
 	"layout_type": "ordered",
 	"is_read_only": false,
 	"notify_list": [],
-	"reflow_type": "fixed",
-	"id": "dz8-fng-ibp"
+	"reflow_type": "fixed"
 }

--- a/gitea/assets/dashboards/gitea_overview.json
+++ b/gitea/assets/dashboards/gitea_overview.json
@@ -1046,6 +1046,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "9j7-35v-e4y"
+  "reflow_type": "fixed"
 }

--- a/harness_cloud_cost_management/assets/dashboards/harness_cloud_cost_management_overview.json
+++ b/harness_cloud_cost_management/assets/dashboards/harness_cloud_cost_management_overview.json
@@ -188,6 +188,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "nmn-5us-s9h"
+  "reflow_type": "fixed"
 }

--- a/hasura_cloud/assets/dashboards/hasura_cloud.json
+++ b/hasura_cloud/assets/dashboards/hasura_cloud.json
@@ -441,6 +441,5 @@
     ],
     "layout_type": "ordered",
     "is_read_only": false,
-    "notify_list": [],
-    "id": "pih-xhv-ccd"
+    "notify_list": []
   }

--- a/hcp_vault/assets/dashboards/hcp_vault_overview.json
+++ b/hcp_vault/assets/dashboards/hcp_vault_overview.json
@@ -534,6 +534,5 @@
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "t74-tge-23e"
+    "reflow_type": "fixed"
 }

--- a/insightfinder/assets/dashboards/ifdashboard.json
+++ b/insightfinder/assets/dashboards/ifdashboard.json
@@ -287,6 +287,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "mp4-6pb-gku"
+  "reflow_type": "fixed"
 }

--- a/isdown/assets/dashboards/isdown_overview.json
+++ b/isdown/assets/dashboards/isdown_overview.json
@@ -59,6 +59,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "pjp-g7j-srq"
+  "reflow_type": "fixed"
 }

--- a/k6/assets/dashboards/overview.json
+++ b/k6/assets/dashboards/overview.json
@@ -336,6 +336,5 @@
   ],
   "layout_type": "free",
   "is_read_only": true,
-  "notify_list": [],
-  "id": 30318
+  "notify_list": []
 }

--- a/launchdarkly/assets/dashboards/launchdarkly.json
+++ b/launchdarkly/assets/dashboards/launchdarkly.json
@@ -99,6 +99,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "9nj-iid-76x"
+  "reflow_type": "fixed"
 }

--- a/mergify/assets/dashboards/mergify_overview.json
+++ b/mergify/assets/dashboards/mergify_overview.json
@@ -100,6 +100,5 @@
   ],
   "layout_type": "ordered",
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "5s8-u3t-m29"
+  "reflow_type": "fixed"
 }

--- a/neoload/assets/dashboards/neoload_overview.json
+++ b/neoload/assets/dashboards/neoload_overview.json
@@ -299,6 +299,5 @@
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "wez-hb9-wqn"
+    "reflow_type": "fixed"
 }

--- a/nn_sdwan/assets/dashboards/nn_sdwan_overview.json
+++ b/nn_sdwan/assets/dashboards/nn_sdwan_overview.json
@@ -852,6 +852,5 @@
     ],
     "layout_type": "free",
     "is_read_only": false,
-    "notify_list": [],
-    "id": "dzw-bz7-vch"
+    "notify_list": []
 }

--- a/nomad/assets/dashboards/overview.json
+++ b/nomad/assets/dashboards/overview.json
@@ -1046,6 +1046,5 @@
     ],
     "layout_type": "free",
     "is_read_only": true,
-    "notify_list": [],
-    "id": 30336
+    "notify_list": []
   }

--- a/ns1/assets/dashboards/overview.json
+++ b/ns1/assets/dashboards/overview.json
@@ -2009,6 +2009,5 @@
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "e47-gct-h3r"
+    "reflow_type": "fixed"
 }

--- a/octoprint/assets/dashboards/octoprint_overview.json
+++ b/octoprint/assets/dashboards/octoprint_overview.json
@@ -1,6 +1,5 @@
 {
     "description": "## OctoPrint\n\nDashboard for monitoring [OctoPrint](https://octoprint.org), a web interface for managing 3d printers.\n\nUseful links:\n\n- [OctoPrint Docs](https://docs.octoprint.org/)\n\n- [OctoPrint Repo](https://github.com/OctoPrint/OctoPrint)",
-    "id": "v37-99w-rzh",
     "is_read_only": false,
     "layout_type": "free",
     "notify_list": [],

--- a/pagerduty/assets/dashboards/pagerduty_overview.json
+++ b/pagerduty/assets/dashboards/pagerduty_overview.json
@@ -181,6 +181,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "ehn-una-j8c"
+  "reflow_type": "fixed"
 }

--- a/perimeterx/assets/dashboards/PerimeterX_Bot_Defender_Dashboard.json
+++ b/perimeterx/assets/dashboards/PerimeterX_Bot_Defender_Dashboard.json
@@ -465,6 +465,5 @@
     ],
     "layout_type": "free",
     "is_read_only": true,
-    "notify_list": [],
-    "id": 30353
+    "notify_list": []
   }

--- a/planetscale/assets/dashboards/planetscale_overview.json
+++ b/planetscale/assets/dashboards/planetscale_overview.json
@@ -761,6 +761,5 @@
   "is_read_only": false,
   "notify_list": [],
   "template_variable_presets": [],
-  "reflow_type": "fixed",
-  "id": "qcq-f45-wct"
+  "reflow_type": "fixed"
 }

--- a/postman/assets/dashboards/overview.json
+++ b/postman/assets/dashboards/overview.json
@@ -687,6 +687,5 @@
   ],
   "layout_type": "free",
   "is_read_only": true,
-  "notify_list": [],
-  "id": "3rk-5wh-5pd"
+  "notify_list": []
 }

--- a/purefa/assets/dashboards/purefa_overview.json
+++ b/purefa/assets/dashboards/purefa_overview.json
@@ -900,6 +900,5 @@
   ],
   "layout_type": "ordered",
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "2hn-ep7-uba"
+  "reflow_type": "fixed"
 }

--- a/purefa/assets/dashboards/purefa_overview_legacy.json
+++ b/purefa/assets/dashboards/purefa_overview_legacy.json
@@ -865,6 +865,5 @@
     ],
     "layout_type": "ordered",
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "a9w-uji-pru"
+    "reflow_type": "fixed"
   }

--- a/redisenterprise/assets/dashboards/redis_enterprise_active_active.json
+++ b/redisenterprise/assets/dashboards/redis_enterprise_active_active.json
@@ -499,6 +499,5 @@
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "3qi-dq6-ifv"
+    "reflow_type": "fixed"
 }

--- a/redisenterprise/assets/dashboards/redisenterprise_cluster_top_view.json
+++ b/redisenterprise/assets/dashboards/redisenterprise_cluster_top_view.json
@@ -513,6 +513,5 @@
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "a2v-g3y-u2r"
+    "reflow_type": "fixed"
 }

--- a/redisenterprise/assets/dashboards/redisenterprise_overview.json
+++ b/redisenterprise/assets/dashboards/redisenterprise_overview.json
@@ -986,6 +986,5 @@
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "7m3-5r4-6zm"
+    "reflow_type": "fixed"
 }

--- a/redisenterprise/assets/dashboards/redisenterprise_rof.json
+++ b/redisenterprise/assets/dashboards/redisenterprise_rof.json
@@ -694,6 +694,5 @@
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "d7t-cgx-58v"
+    "reflow_type": "fixed"
 }

--- a/redpanda/assets/dashboards/overview.json
+++ b/redpanda/assets/dashboards/overview.json
@@ -825,6 +825,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "ysv-y6f-3ix"
+  "reflow_type": "fixed"
 }

--- a/rookout/assets/dashboards/rookout_overview.json
+++ b/rookout/assets/dashboards/rookout_overview.json
@@ -147,6 +147,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "z4s-i55-ntn"
+  "reflow_type": "fixed"
 }

--- a/sedai/assets/dashboards/sedai_overview.json
+++ b/sedai/assets/dashboards/sedai_overview.json
@@ -609,6 +609,5 @@
             "template_variables": []
         }
     ],
-    "reflow_type": "fixed",
-    "id": "zru-wn8-gu9"
+    "reflow_type": "fixed"
 }

--- a/sigsci/assets/dashboards/overview.json
+++ b/sigsci/assets/dashboards/overview.json
@@ -591,6 +591,5 @@
 	"template_variables": [],
 	"layout_type": "free",
 	"is_read_only": true,
-	"notify_list": [],
-	"id": "79f-7rn-h9u"
+	"notify_list": []
 }

--- a/speedtest/assets/dashboards/speedtest.json
+++ b/speedtest/assets/dashboards/speedtest.json
@@ -433,6 +433,5 @@
     ],
     "layout_type": "free",
     "is_read_only": true,
-    "notify_list": [],
-    "id": 30417
+    "notify_list": []
   }

--- a/steadybit/assets/dashboards/steadybit.json
+++ b/steadybit/assets/dashboards/steadybit.json
@@ -268,6 +268,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "4n6-5up-dpz"
+  "reflow_type": "fixed"
 }

--- a/stormforge/assets/dashboards/stormforge_overview.json
+++ b/stormforge/assets/dashboards/stormforge_overview.json
@@ -1030,6 +1030,5 @@
   "layout_type": "ordered",
   "is_read_only": true,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "zyn-z79-4vk"
+  "reflow_type": "fixed"
 }

--- a/syncthing/assets/dashboards/syncthing_overview.json
+++ b/syncthing/assets/dashboards/syncthing_overview.json
@@ -231,6 +231,5 @@
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],
-    "reflow_type": "auto",
-    "id": "asg-c66-3re"
+    "reflow_type": "auto"
 }

--- a/tidb_cloud/assets/dashboards/overview.json
+++ b/tidb_cloud/assets/dashboards/overview.json
@@ -1252,6 +1252,5 @@
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "g48-n7e-c3f"
+    "reflow_type": "fixed"
 }

--- a/tyk/assets/dashboards/tyk_analytics_canvas.json
+++ b/tyk/assets/dashboards/tyk_analytics_canvas.json
@@ -509,6 +509,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "9uw-es2-tbz"
+  "reflow_type": "fixed"
 }

--- a/vercel/assets/dashboards/vercel_overview.json
+++ b/vercel/assets/dashboards/vercel_overview.json
@@ -338,6 +338,5 @@
   "layout_type": "ordered",
   "is_read_only": false,
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "e6w-9jb-mk9"
+  "reflow_type": "fixed"
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes the `id` field from all our integration dashboards' JSON definitions so that they pass the dashboard validation that we are introducing in the Asset Publishing Workflow (see #apw-dashboard-reporting on Slack)
Note that we only accept string `id`s in our dashboard validators, but integration dashboards ids are integer and they are autogenerated on Postgres).

### Motivation

What inspired you to submit this pull request?
We want to add asset validation for the Asset Publishing Workflow.
### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
