### PR TITLE
Removing Marketplace category from Buoyant Cloud & Bottomline

### DIFF
--- a/bottomline_recordandreplay/manifest.json
+++ b/bottomline_recordandreplay/manifest.json
@@ -34,7 +34,6 @@
     ],
     "classifier_tags": [
       "Category::Mainframe",
-      "Category::Marketplace",
       "Offering::Integration",
       "Supported OS::Linux",
       "Supported OS::Windows"

--- a/buoyant_cloud/manifest.json
+++ b/buoyant_cloud/manifest.json
@@ -55,7 +55,6 @@
     ],
     "classifier_tags": [
       "Category::Cloud",
-      "Category::Marketplace",
       "Category::Network",
       "Category::Security",
       "Offering::Integration",


### PR DESCRIPTION
### What does this PR do?

Removes the Marketplace category from the Buoyant Cloud and Bottomline free integration listings

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
