### PR TITLE
[APW] Fix more integration dashboards' json definition

### DIFF
--- a/adaptive_shield/assets/dashboards/adaptive_shield_overview.json
+++ b/adaptive_shield/assets/dashboards/adaptive_shield_overview.json
@@ -1,1 +1,174 @@
-{"title":"Adaptive Shield Alerts Dashboard","description":"## Adaptive Shield Alerts Dashboard\n\nMonitor and analyze alerts from Adaptive Shield: configuration drifts, integration failures and security check degradations.\n","widgets":[{"id":1027599137725360,"definition":{"type":"image","url":"https://7938840.fs1.hubspotusercontent-na1.net/hubfs/7938840/Adaptive%20Shield%20-%20Main%20Logo@4x%20(2)%20(1).png","url_dark_theme":"https://7938840.fs1.hubspotusercontent-na1.net/hubfs/7938840/Logo%20New@2x.png","sizing":"contain","has_background":true,"has_border":true,"vertical_align":"center","horizontal_align":"center"},"layout":{"x":0,"y":0,"width":12,"height":2}},{"id":5819790721138146,"definition":{"title":"Adaptive Shield Alerts Stream","title_size":"16","title_align":"left","type":"event_stream","query":"source:adaptive_shield","event_size":"s"},"layout":{"x":0,"y":2,"width":4,"height":4}},{"id":2633793451677842,"definition":{"title":"Alerts Count Per Type","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1","limit":{"order":"desc"}}],"style":{"palette":"classic"},"response_format":"scalar","queries":[{"search":{"query":"source:adaptive_shield"},"data_source":"events","compute":{"metric":"@evt.id","aggregation":"cardinality"},"name":"query1","indexes":["*"],"group_by":[{"facet":"type","sort":{"metric":"@evt.id","aggregation":"cardinality","order":"desc"},"limit":10}]}]}],"type":"sunburst","legend":{"type":"automatic"}},"layout":{"x":4,"y":2,"width":4,"height":4}},{"id":5325858656995348,"definition":{"title":"Alerts Count Per Integration","title_size":"16","title_align":"left","type":"query_table","requests":[{"formulas":[{"formula":"query1","conditional_formats":[],"limit":{"count":25,"order":"desc"},"cell_display_mode":"bar"}],"response_format":"scalar","queries":[{"search":{"query":"source:adaptive_shield"},"data_source":"events","compute":{"metric":"@evt.id","aggregation":"cardinality"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@aggregation_key","sort":{"metric":"@evt.id","aggregation":"cardinality","order":"desc"},"limit":10}]}]}],"has_search_bar":"auto"},"layout":{"x":8,"y":2,"width":4,"height":4}},{"id":2809903660624346,"definition":{"title":"Alerts Over Time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"response_format":"timeseries","queries":[{"search":{"query":"source:adaptive_shield"},"data_source":"events","compute":{"metric":"@evt.id","aggregation":"cardinality"},"name":"query1","indexes":["*"],"group_by":[{"facet":"type","sort":{"metric":"@evt.id","aggregation":"cardinality","order":"desc"},"limit":100}]}],"style":{"palette":"cool","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"include_zero":false,"scale":"log"}},"layout":{"x":0,"y":6,"width":12,"height":5}}],"template_variables":[],"layout_type":"ordered","is_read_only":false,"notify_list":[],"reflow_type":"fixed","id":"xnt-cru-ef7"}
+{
+  "title": "Adaptive Shield Alerts Dashboard",
+  "description": "## Adaptive Shield Alerts Dashboard\n\nMonitor and analyze alerts from Adaptive Shield: configuration drifts, integration failures and security check degradations.\n",
+  "widgets": [
+    {
+      "id": 1027599137725360,
+      "definition": {
+        "type": "image",
+        "url": "https://7938840.fs1.hubspotusercontent-na1.net/hubfs/7938840/Adaptive%20Shield%20-%20Main%20Logo@4x%20(2)%20(1).png",
+        "url_dark_theme": "https://7938840.fs1.hubspotusercontent-na1.net/hubfs/7938840/Logo%20New@2x.png",
+        "sizing": "contain",
+        "has_background": true,
+        "has_border": true,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      },
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 2 }
+    },
+    {
+      "id": 5819790721138146,
+      "definition": {
+        "title": "Adaptive Shield Alerts Stream",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "event_stream",
+        "query": "source:adaptive_shield",
+        "event_size": "s"
+      },
+      "layout": { "x": 0, "y": 2, "width": 4, "height": 4 }
+    },
+    {
+      "id": 2633793451677842,
+      "definition": {
+        "title": "Alerts Count Per Type",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1", "limit": { "order": "desc" } }],
+            "style": { "palette": "classic" },
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "source:adaptive_shield" },
+                "data_source": "events",
+                "compute": {
+                  "metric": "@evt.id",
+                  "aggregation": "cardinality"
+                },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "type",
+                    "sort": {
+                      "metric": "@evt.id",
+                      "aggregation": "cardinality",
+                      "order": "desc"
+                    },
+                    "limit": 10
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "type": "sunburst",
+        "legend": { "type": "automatic" }
+      },
+      "layout": { "x": 4, "y": 2, "width": 4, "height": 4 }
+    },
+    {
+      "id": 5325858656995348,
+      "definition": {
+        "title": "Alerts Count Per Integration",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_table",
+        "requests": [
+          {
+            "formulas": [
+              {
+                "formula": "query1",
+                "conditional_formats": [],
+                "limit": { "count": 25, "order": "desc" },
+                "cell_display_mode": "bar"
+              }
+            ],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "source:adaptive_shield" },
+                "data_source": "events",
+                "compute": {
+                  "metric": "@evt.id",
+                  "aggregation": "cardinality"
+                },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@aggregation_key",
+                    "sort": {
+                      "metric": "@evt.id",
+                      "aggregation": "cardinality",
+                      "order": "desc"
+                    },
+                    "limit": 10
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "has_search_bar": "auto"
+      },
+      "layout": { "x": 8, "y": 2, "width": 4, "height": 4 }
+    },
+    {
+      "id": 2809903660624346,
+      "definition": {
+        "title": "Alerts Over Time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "search": { "query": "source:adaptive_shield" },
+                "data_source": "events",
+                "compute": {
+                  "metric": "@evt.id",
+                  "aggregation": "cardinality"
+                },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "type",
+                    "sort": {
+                      "metric": "@evt.id",
+                      "aggregation": "cardinality",
+                      "order": "desc"
+                    },
+                    "limit": 100
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": { "include_zero": false, "scale": "log" }
+      },
+      "layout": { "x": 0, "y": 6, "width": 12, "height": 5 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/agora_analytics/assets/dashboards/agora_analytics_overview.json
+++ b/agora_analytics/assets/dashboards/agora_analytics_overview.json
@@ -1,1 +1,404 @@
-{"title":"Agora Analytics","description":"Agora Analytics\n\nThis dashboard monitors ongoing Agora RTC usage, quality, and performance, allowing you to see whether your RTC service require attention.\n\nFor more details, please visit https://docs.agora.io/en/agora-analytics/analyze/video-voice-sdk/datadog-integration","widgets":[{"id":4552268843133742,"definition":{"title":"Online User Count","title_size":"16","title_align":"left","type":"query_value","requests":[{"response_format":"scalar","queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.online_user{*}","aggregator":"last"}],"conditional_formats":[{"comparator":">=","palette":"white_on_green","value":10000},{"comparator":"<","palette":"white_on_red","value":10000}],"formulas":[{"formula":"query1"}]}],"autoscale":true,"precision":2,"timeseries_background":{"type":"area"}},"layout":{"x":0,"y":0,"width":2,"height":2}},{"id":2729842319365608,"definition":{"title":"Online Channel Count","title_size":"16","title_align":"left","type":"query_value","requests":[{"response_format":"scalar","queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.online_channel{*}","aggregator":"last"}],"conditional_formats":[{"comparator":">=","palette":"white_on_green","value":1500},{"comparator":"<","palette":"white_on_red","value":1500}],"formulas":[{"formula":"query1"}]}],"autoscale":true,"precision":2,"timeseries_background":{"type":"area"}},"layout":{"x":2,"y":0,"width":2,"height":2}},{"id":1300084570186116,"definition":{"title":"Online User Count","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.online_user{*} by {product_type}"}],"response_format":"timeseries","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":4,"y":0,"width":3,"height":2}},{"id":6094328616410448,"definition":{"title":"Online Channel Count","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.online_channel{*} by {product_type}"}],"response_format":"timeseries","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":7,"y":0,"width":3,"height":2}},{"id":2261693519168000,"definition":{"title":"Audio Freeze Rate","title_size":"16","title_align":"left","type":"query_value","requests":[{"response_format":"scalar","queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.audio_freeze_rate{*}","aggregator":"last"}],"conditional_formats":[{"comparator":"<=","palette":"white_on_green","value":3},{"comparator":">","palette":"white_on_red","value":3}],"formulas":[{"formula":"query1 * 100"}]}],"autoscale":true,"custom_unit":"%","precision":2,"timeseries_background":{"type":"area"}},"layout":{"x":0,"y":2,"width":2,"height":2}},{"id":4926581209337736,"definition":{"title":"Video Freeze Rate","title_size":"16","title_align":"left","time":{},"type":"query_value","requests":[{"response_format":"scalar","queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.video_freeze_rate{*}","aggregator":"last"}],"conditional_formats":[{"comparator":"<=","palette":"white_on_green","value":5},{"comparator":">","palette":"white_on_red","value":5}],"formulas":[{"formula":"query1 * 100"}]}],"autoscale":true,"custom_unit":"%","precision":2,"timeseries_background":{"type":"area"}},"layout":{"x":2,"y":2,"width":2,"height":2}},{"id":6605137293154274,"definition":{"title":"Audio Freeze Rate","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.audio_freeze_rate{*} by {product_type}"}],"response_format":"timeseries","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":4,"y":2,"width":3,"height":2}},{"id":43450529811804,"definition":{"title":"Video Freeze Rate","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.video_freeze_rate{*} by {product_type}"}],"response_format":"timeseries","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":7,"y":2,"width":3,"height":2}},{"id":3318206441333366,"definition":{"title":"Join Success Rate In 5s","title_size":"16","title_align":"left","type":"query_value","requests":[{"response_format":"scalar","queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.join_success_in_5s_rate{*}","aggregator":"last"}],"conditional_formats":[{"comparator":">=","palette":"white_on_green","value":95},{"comparator":"<","palette":"white_on_red","value":95}],"formulas":[{"formula":"query1 * 100"}]}],"autoscale":true,"custom_unit":"%","precision":2,"timeseries_background":{"yaxis":{"include_zero":true},"type":"area"}},"layout":{"x":0,"y":4,"width":2,"height":2}},{"id":247709660961100,"definition":{"title":"Network Delay Rate","title_size":"16","title_align":"left","type":"query_value","requests":[{"response_format":"scalar","queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.network_delay_rate{*}","aggregator":"last"}],"conditional_formats":[{"comparator":"<=","palette":"white_on_green","value":5},{"comparator":">","palette":"white_on_red","value":5}],"formulas":[{"formula":"query1 * 100"}]}],"autoscale":true,"custom_unit":"%","precision":2,"timeseries_background":{"type":"area"}},"layout":{"x":2,"y":4,"width":2,"height":2}},{"id":2653352595362874,"definition":{"title":"Join Success Rate In 5s","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.join_success_in_5s_rate{*} by {product_type}"}],"response_format":"timeseries","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":4,"y":4,"width":3,"height":2}},{"id":3936298129096284,"definition":{"title":"Network Delay Rate","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"queries":[{"name":"query1","data_source":"metrics","query":"avg:agora.rtc.app_id.network_delay_rate{*} by {product_type}"}],"response_format":"timeseries","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":7,"y":4,"width":3,"height":2}}],"template_variables":[],"layout_type":"ordered","notify_list":[],"reflow_type":"fixed","id":"mhv-g62-m38"}
+{
+  "title": "Agora Analytics",
+  "description": "Agora Analytics\n\nThis dashboard monitors ongoing Agora RTC usage, quality, and performance, allowing you to see whether your RTC service require attention.\n\nFor more details, please visit https://docs.agora.io/en/agora-analytics/analyze/video-voice-sdk/datadog-integration",
+  "widgets": [
+    {
+      "id": 4552268843133742,
+      "definition": {
+        "title": "Online User Count",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.online_user{*}",
+                "aggregator": "last"
+              }
+            ],
+            "conditional_formats": [
+              {
+                "comparator": ">=",
+                "palette": "white_on_green",
+                "value": 10000
+              },
+              { "comparator": "<", "palette": "white_on_red", "value": 10000 }
+            ],
+            "formulas": [{ "formula": "query1" }]
+          }
+        ],
+        "autoscale": true,
+        "precision": 2,
+        "timeseries_background": { "type": "area" }
+      },
+      "layout": { "x": 0, "y": 0, "width": 2, "height": 2 }
+    },
+    {
+      "id": 2729842319365608,
+      "definition": {
+        "title": "Online Channel Count",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.online_channel{*}",
+                "aggregator": "last"
+              }
+            ],
+            "conditional_formats": [
+              {
+                "comparator": ">=",
+                "palette": "white_on_green",
+                "value": 1500
+              },
+              { "comparator": "<", "palette": "white_on_red", "value": 1500 }
+            ],
+            "formulas": [{ "formula": "query1" }]
+          }
+        ],
+        "autoscale": true,
+        "precision": 2,
+        "timeseries_background": { "type": "area" }
+      },
+      "layout": { "x": 2, "y": 0, "width": 2, "height": 2 }
+    },
+    {
+      "id": 1300084570186116,
+      "definition": {
+        "title": "Online User Count",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.online_user{*} by {product_type}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 4, "y": 0, "width": 3, "height": 2 }
+    },
+    {
+      "id": 6094328616410448,
+      "definition": {
+        "title": "Online Channel Count",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.online_channel{*} by {product_type}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 7, "y": 0, "width": 3, "height": 2 }
+    },
+    {
+      "id": 2261693519168000,
+      "definition": {
+        "title": "Audio Freeze Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.audio_freeze_rate{*}",
+                "aggregator": "last"
+              }
+            ],
+            "conditional_formats": [
+              { "comparator": "<=", "palette": "white_on_green", "value": 3 },
+              { "comparator": ">", "palette": "white_on_red", "value": 3 }
+            ],
+            "formulas": [{ "formula": "query1 * 100" }]
+          }
+        ],
+        "autoscale": true,
+        "custom_unit": "%",
+        "precision": 2,
+        "timeseries_background": { "type": "area" }
+      },
+      "layout": { "x": 0, "y": 2, "width": 2, "height": 2 }
+    },
+    {
+      "id": 4926581209337736,
+      "definition": {
+        "title": "Video Freeze Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.video_freeze_rate{*}",
+                "aggregator": "last"
+              }
+            ],
+            "conditional_formats": [
+              { "comparator": "<=", "palette": "white_on_green", "value": 5 },
+              { "comparator": ">", "palette": "white_on_red", "value": 5 }
+            ],
+            "formulas": [{ "formula": "query1 * 100" }]
+          }
+        ],
+        "autoscale": true,
+        "custom_unit": "%",
+        "precision": 2,
+        "timeseries_background": { "type": "area" }
+      },
+      "layout": { "x": 2, "y": 2, "width": 2, "height": 2 }
+    },
+    {
+      "id": 6605137293154274,
+      "definition": {
+        "title": "Audio Freeze Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.audio_freeze_rate{*} by {product_type}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 4, "y": 2, "width": 3, "height": 2 }
+    },
+    {
+      "id": 43450529811804,
+      "definition": {
+        "title": "Video Freeze Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.video_freeze_rate{*} by {product_type}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 7, "y": 2, "width": 3, "height": 2 }
+    },
+    {
+      "id": 3318206441333366,
+      "definition": {
+        "title": "Join Success Rate In 5s",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.join_success_in_5s_rate{*}",
+                "aggregator": "last"
+              }
+            ],
+            "conditional_formats": [
+              { "comparator": ">=", "palette": "white_on_green", "value": 95 },
+              { "comparator": "<", "palette": "white_on_red", "value": 95 }
+            ],
+            "formulas": [{ "formula": "query1 * 100" }]
+          }
+        ],
+        "autoscale": true,
+        "custom_unit": "%",
+        "precision": 2,
+        "timeseries_background": {
+          "yaxis": { "include_zero": true },
+          "type": "area"
+        }
+      },
+      "layout": { "x": 0, "y": 4, "width": 2, "height": 2 }
+    },
+    {
+      "id": 247709660961100,
+      "definition": {
+        "title": "Network Delay Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.network_delay_rate{*}",
+                "aggregator": "last"
+              }
+            ],
+            "conditional_formats": [
+              { "comparator": "<=", "palette": "white_on_green", "value": 5 },
+              { "comparator": ">", "palette": "white_on_red", "value": 5 }
+            ],
+            "formulas": [{ "formula": "query1 * 100" }]
+          }
+        ],
+        "autoscale": true,
+        "custom_unit": "%",
+        "precision": 2,
+        "timeseries_background": { "type": "area" }
+      },
+      "layout": { "x": 2, "y": 4, "width": 2, "height": 2 }
+    },
+    {
+      "id": 2653352595362874,
+      "definition": {
+        "title": "Join Success Rate In 5s",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.join_success_in_5s_rate{*} by {product_type}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 4, "y": 4, "width": 3, "height": 2 }
+    },
+    {
+      "id": 3936298129096284,
+      "definition": {
+        "title": "Network Delay Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:agora.rtc.app_id.network_delay_rate{*} by {product_type}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 7, "y": 4, "width": 3, "height": 2 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/bottomline_recordandreplay/assets/dashboards/bottomline_activity_overview.json
+++ b/bottomline_recordandreplay/assets/dashboards/bottomline_activity_overview.json
@@ -1,1 +1,251 @@
-{"title":"Bottomline Activity Overview","description":"![alt text](https://www.bottomline.com/application/themes/rawnet/app/images/interface/bottomline-white-header.svg)","widgets":[{"id":1620325210319756,"definition":{"type":"image","url":"https://raw.githubusercontent.com/nbk96f1/datadog/main/assets/bottomline_logo_light.svg","sizing":"none","has_background":false,"has_border":false,"vertical_align":"center","horizontal_align":"center"},"layout":{"x":0,"y":0,"width":2,"height":2}},{"id":8590505409726332,"definition":{"title":"myApp Resource Usage - Last Hour","type":"treemap","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"@bottomline.mainframe.activity.type:Access"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@bottomline.mainframe.activity.resource.code","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":2,"y":0,"width":4,"height":2}},{"id":6342817910179456,"definition":{"title":"Top User Activity - Last Hour","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"@bottomline.mainframe.activity.type:(Access OR LOGIN)"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@bottomline.mainframe.activity.usr.id","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":6,"y":0,"width":3,"height":2}},{"id":2609080682289860,"definition":{"title":"Resource Response Times","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"response_format":"timeseries","queries":[{"search":{"query":""},"data_source":"logs","compute":{"metric":"@bottomline.mainframe.activity.resource.duration","aggregation":"avg"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@bottomline.mainframe.activity.resource.code","sort":{"metric":"@bottomline.mainframe.activity.resource.duration","aggregation":"avg","order":"desc"},"limit":10}]}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":9,"y":0,"width":3,"height":2}},{"id":4926463881985070,"definition":{"title":"Security Events","title_size":"16","title_align":"left","type":"event_stream","query":"","event_size":"s"},"layout":{"x":0,"y":2,"width":8,"height":3}},{"id":7318977966357418,"definition":{"title":"","type":"manage_status","display_format":"countsAndList","color_preference":"text","hide_zero_counts":true,"query":"","sort":"status,asc","count":50,"start":0,"summary_type":"monitors","show_priority":false,"show_last_triggered":false},"layout":{"x":8,"y":2,"width":4,"height":3}},{"id":2438452734059528,"definition":{"title":"Activity by Geo","title_size":"16","title_align":"left","type":"geomap","requests":[{"formulas":[{"formula":"a","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:bottomline"},"data_source":"logs","compute":{"aggregation":"count"},"name":"a","indexes":["*"],"group_by":[{"facet":"@network.client.geoip.country.iso_code","sort":{"aggregation":"count","order":"desc"},"limit":10,"should_exclude_missing":true}]}]}],"style":{"palette":"hostmap_blues","palette_flip":false},"view":{"focus":"WORLD"}},"layout":{"x":0,"y":5,"width":8,"height":3}},{"id":5875343794323414,"definition":{"title":"Monitored Users","title_size":"16","title_align":"left","time":{},"type":"query_value","requests":[{"response_format":"scalar","queries":[{"data_source":"logs","name":"query1","search":{"query":"source:bottomline"},"indexes":["*"],"compute":{"aggregation":"cardinality","metric":"@bottomline.mainframe.activity.usr.id"},"group_by":[]}],"formulas":[{"formula":"query1"}]}],"autoscale":true,"precision":2},"layout":{"x":8,"y":5,"width":4,"height":3}},{"id":6655858015610626,"definition":{"type":"image","url":"https://www.bottomline.com/application/themes/rawnet/app/images/interface/bottomline-white-header.svg","sizing":"contain","margin":"md","has_background":false,"has_border":false,"vertical_align":"center","horizontal_align":"center"},"layout":{"x":0,"y":8,"width":2,"height":2}}],"template_variables":[],"layout_type":"ordered","is_read_only":false,"notify_list":[],"reflow_type":"fixed","id":"fgx-h9p-hp6"}
+{
+  "title": "Bottomline Activity Overview",
+  "description": "![alt text](https://www.bottomline.com/application/themes/rawnet/app/images/interface/bottomline-white-header.svg)",
+  "widgets": [
+    {
+      "id": 1620325210319756,
+      "definition": {
+        "type": "image",
+        "url": "https://raw.githubusercontent.com/nbk96f1/datadog/main/assets/bottomline_logo_light.svg",
+        "sizing": "none",
+        "has_background": false,
+        "has_border": false,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      },
+      "layout": { "x": 0, "y": 0, "width": 2, "height": 2 }
+    },
+    {
+      "id": 8590505409726332,
+      "definition": {
+        "title": "myApp Resource Usage - Last Hour",
+        "type": "treemap",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": {
+                  "query": "@bottomline.mainframe.activity.type:Access"
+                },
+                "data_source": "logs",
+                "compute": { "aggregation": "count" },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@bottomline.mainframe.activity.resource.code",
+                    "sort": { "aggregation": "count", "order": "desc" },
+                    "limit": 10
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "layout": { "x": 2, "y": 0, "width": 4, "height": 2 }
+    },
+    {
+      "id": 6342817910179456,
+      "definition": {
+        "title": "Top User Activity - Last Hour",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "toplist",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": {
+                  "query": "@bottomline.mainframe.activity.type:(Access OR LOGIN)"
+                },
+                "data_source": "logs",
+                "compute": { "aggregation": "count" },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@bottomline.mainframe.activity.usr.id",
+                    "sort": { "aggregation": "count", "order": "desc" },
+                    "limit": 10
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "layout": { "x": 6, "y": 0, "width": 3, "height": 2 }
+    },
+    {
+      "id": 2609080682289860,
+      "definition": {
+        "title": "Resource Response Times",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "search": { "query": "" },
+                "data_source": "logs",
+                "compute": {
+                  "metric": "@bottomline.mainframe.activity.resource.duration",
+                  "aggregation": "avg"
+                },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@bottomline.mainframe.activity.resource.code",
+                    "sort": {
+                      "metric": "@bottomline.mainframe.activity.resource.duration",
+                      "aggregation": "avg",
+                      "order": "desc"
+                    },
+                    "limit": 10
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 9, "y": 0, "width": 3, "height": 2 }
+    },
+    {
+      "id": 4926463881985070,
+      "definition": {
+        "title": "Security Events",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "event_stream",
+        "query": "",
+        "event_size": "s"
+      },
+      "layout": { "x": 0, "y": 2, "width": 8, "height": 3 }
+    },
+    {
+      "id": 7318977966357418,
+      "definition": {
+        "title": "",
+        "type": "manage_status",
+        "display_format": "countsAndList",
+        "color_preference": "text",
+        "hide_zero_counts": true,
+        "query": "",
+        "sort": "status,asc",
+        "count": 50,
+        "start": 0,
+        "summary_type": "monitors",
+        "show_priority": false,
+        "show_last_triggered": false
+      },
+      "layout": { "x": 8, "y": 2, "width": 4, "height": 3 }
+    },
+    {
+      "id": 2438452734059528,
+      "definition": {
+        "title": "Activity by Geo",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "geomap",
+        "requests": [
+          {
+            "formulas": [
+              { "formula": "a", "limit": { "count": 10, "order": "desc" } }
+            ],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "source:bottomline" },
+                "data_source": "logs",
+                "compute": { "aggregation": "count" },
+                "name": "a",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@network.client.geoip.country.iso_code",
+                    "sort": { "aggregation": "count", "order": "desc" },
+                    "limit": 10,
+                    "should_exclude_missing": true
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "style": { "palette": "hostmap_blues", "palette_flip": false },
+        "view": { "focus": "WORLD" }
+      },
+      "layout": { "x": 0, "y": 5, "width": 8, "height": 3 }
+    },
+    {
+      "id": 5875343794323414,
+      "definition": {
+        "title": "Monitored Users",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "data_source": "logs",
+                "name": "query1",
+                "search": { "query": "source:bottomline" },
+                "indexes": ["*"],
+                "compute": {
+                  "aggregation": "cardinality",
+                  "metric": "@bottomline.mainframe.activity.usr.id"
+                },
+                "group_by": []
+              }
+            ],
+            "formulas": [{ "formula": "query1" }]
+          }
+        ],
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": { "x": 8, "y": 5, "width": 4, "height": 3 }
+    },
+    {
+      "id": 6655858015610626,
+      "definition": {
+        "type": "image",
+        "url": "https://www.bottomline.com/application/themes/rawnet/app/images/interface/bottomline-white-header.svg",
+        "sizing": "contain",
+        "margin": "md",
+        "has_background": false,
+        "has_border": false,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      },
+      "layout": { "x": 0, "y": 8, "width": 2, "height": 2 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/cloudsmith/assets/dashboards/cloudsmith_overview.json
+++ b/cloudsmith/assets/dashboards/cloudsmith_overview.json
@@ -1,1 +1,325 @@
-{"title":"Cloudsmith Overview","description":"## Cloudsmith \nCloudsmith is a Cloud-native Package management tool. This integration allows Cloudsmith users to monitor their storage, bandwidth, and token usage in Datadog. \n\nCheck packages across your entire organization for storage and bandwidth usage and alert you when usage is getting close to your limit. Your status changes to a warning above 75% usage and critical above 85% usage. \n\nFor further reading, see the:\n\n- [Cloudsmith Documentation](https://cloudsmith.com)\n\nClone this template to make changes and add your own graphs and widgets. (cloned)","widgets":[{"id":2,"definition":{"title":"Cloudsmith","banner_img":"https://raw.githubusercontent.com/ciaracarey/test_cs_images/main/datadog-cloudsmith-logo-634x251.png","show_title":false,"type":"group","layout_type":"ordered","widgets":[{"id":1570560629046493,"definition":{"type":"note","content":"[Cloudsmith](https://cloudsmith.com) is a cloud-native, hosted, package management service with a deep focus on providing the best universal support for all native package and container technologies.\n\nThe integration with Datadog allows Cloudsmith users to monitor their storage, bandwidth, and token usage in Datadog.","background_color":"white","font_size":"14","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":0,"y":0,"width":6,"height":2}}]},"layout":{"x":0,"y":0,"width":6,"height":5}},{"id":1,"definition":{"title":"Overview of usage","show_title":true,"type":"group","layout_type":"ordered","widgets":[{"id":1390985517334205,"definition":{"title":"Percentage Storage Used","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"conditional_formats":[{"comparator":">","palette":"red_on_white","value":85},{"comparator":">","palette":"yellow_on_white","value":75}],"response_format":"scalar","queries":[{"query":"avg:cloudsmith.storage_used{*}","data_source":"metrics","name":"query1","aggregator":"avg"}]}],"autoscale":true,"precision":2},"layout":{"x":0,"y":0,"width":3,"height":2}},{"id":3166709670495934,"definition":{"type":"note","content":"Track the storage and bandwidth usage of your packages in a Cloudsmith organisation. If your usage is above 75%, the status changes to amber and if you usage is above 85%, the status changes to red.\n\nSee [Track your Bandwidth & Storage limits with our Quota API](https://cloudsmith.com/blog/track-your-bandwidth-storage-limits-with-our-quota-api) for more details.\n\n","background_color":"white","font_size":"14","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":3,"y":0,"width":3,"height":4}},{"id":6344085258702783,"definition":{"title":"Percentage Bandwidth Used","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"conditional_formats":[{"comparator":">=","palette":"red_on_white","value":85},{"comparator":">","palette":"yellow_on_white","value":75}],"response_format":"scalar","queries":[{"query":"avg:cloudsmith.bandwidth_used{*}","data_source":"metrics","name":"query1","aggregator":"avg"}]}],"autoscale":true,"precision":2},"layout":{"x":0,"y":2,"width":3,"height":2}}]},"layout":{"x":6,"y":0,"width":6,"height":5}},{"id":7490658912792070,"definition":{"title":"Audit Logs","title_size":"16","title_align":"left","time":{},"requests":[{"query":{"data_source":"event_stream","query_string":"source:cloudsmith @aggregation_key:audit_log","event_size":"s"},"response_format":"event_list","columns":[]}],"type":"list_stream"},"layout":{"x":0,"y":0,"width":12,"height":4}},{"id":3,"definition":{"title":"Token Overview","show_title":true,"type":"group","layout_type":"ordered","widgets":[{"id":8971161252725269,"definition":{"type":"image","url":"https://cloudsmith.com/img/cloudsmith-mini-dark.svg","url_dark_theme":"https://cloudsmith.com/img/cloudsmith-mini.svg","sizing":"contain"},"layout":{"x":0,"y":0,"width":2,"height":2}},{"id":8871727855771134,"definition":{"type":"note","content":"Track your entitlement token usage for your organization. View the amount of tokens created, the total amount downloaded by all tokens, and the bandwidth used by tokens. \n\nEntitlement tokens are read-only tokens used for downloading files and gaining read-only access to repository contents. See [Entitlements](https://help.cloudsmith.io/docs/entitlements) for more information.","background_color":"white","font_size":"14","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":2,"y":0,"width":8,"height":2}},{"id":6383822446946945,"definition":{"title":"Token Count","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"query":"avg:cloudsmith.token_count{*}","data_source":"metrics","name":"query1","aggregator":"avg"}]}],"autoscale":true,"precision":2},"layout":{"x":0,"y":2,"width":2,"height":2}},{"id":1745585157577347,"definition":{"title":"Total Downloads by Tokens","title_size":"16","title_align":"left","show_legend":false,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"response_format":"timeseries","queries":[{"query":"avg:cloudsmith.token_download_total{*}","data_source":"metrics","name":"query1"}],"display_type":"line"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]},"layout":{"x":2,"y":2,"width":4,"height":2}},{"id":5049902402844905,"definition":{"title":"Total Bandwidth Consumed by Tokens","title_size":"16","title_align":"left","show_legend":false,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"response_format":"timeseries","queries":[{"query":"avg:cloudsmith.token_bandwidth_total{*}","data_source":"metrics","name":"query1"}],"display_type":"line"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]},"layout":{"x":6,"y":2,"width":4,"height":2}}]},"layout":{"x":0,"y":0,"width":12,"height":5,"is_column_break":true}},{"id":2282516981148608,"definition":{"title":"Vulnerabilities Scan Result","title_size":"16","title_align":"left","time":{},"requests":[{"query":{"data_source":"event_stream","query_string":"source:cloudsmith @aggregation_key:vulnerabilities","event_size":"s"},"response_format":"event_list","columns":[]}],"type":"list_stream"},"layout":{"x":0,"y":0,"width":12,"height":4}}],"template_variables":[],"layout_type":"ordered","notify_list":[],"reflow_type":"fixed","id":"biv-6x6-2xq"}
+{
+  "title": "Cloudsmith Overview",
+  "description": "## Cloudsmith \nCloudsmith is a Cloud-native Package management tool. This integration allows Cloudsmith users to monitor their storage, bandwidth, and token usage in Datadog. \n\nCheck packages across your entire organization for storage and bandwidth usage and alert you when usage is getting close to your limit. Your status changes to a warning above 75% usage and critical above 85% usage. \n\nFor further reading, see the:\n\n- [Cloudsmith Documentation](https://cloudsmith.com)\n\nClone this template to make changes and add your own graphs and widgets. (cloned)",
+  "widgets": [
+    {
+      "id": 2,
+      "definition": {
+        "title": "Cloudsmith",
+        "banner_img": "https://raw.githubusercontent.com/ciaracarey/test_cs_images/main/datadog-cloudsmith-logo-634x251.png",
+        "show_title": false,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 1570560629046493,
+            "definition": {
+              "type": "note",
+              "content": "[Cloudsmith](https://cloudsmith.com) is a cloud-native, hosted, package management service with a deep focus on providing the best universal support for all native package and container technologies.\n\nThe integration with Datadog allows Cloudsmith users to monitor their storage, bandwidth, and token usage in Datadog.",
+              "background_color": "white",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 0, "y": 0, "width": 6, "height": 2 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 0, "width": 6, "height": 5 }
+    },
+    {
+      "id": 1,
+      "definition": {
+        "title": "Overview of usage",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 1390985517334205,
+            "definition": {
+              "title": "Percentage Storage Used",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">",
+                      "palette": "red_on_white",
+                      "value": 85
+                    },
+                    {
+                      "comparator": ">",
+                      "palette": "yellow_on_white",
+                      "value": 75
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "avg:cloudsmith.storage_used{*}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "avg"
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2
+            },
+            "layout": { "x": 0, "y": 0, "width": 3, "height": 2 }
+          },
+          {
+            "id": 3166709670495934,
+            "definition": {
+              "type": "note",
+              "content": "Track the storage and bandwidth usage of your packages in a Cloudsmith organisation. If your usage is above 75%, the status changes to amber and if you usage is above 85%, the status changes to red.\n\nSee [Track your Bandwidth & Storage limits with our Quota API](https://cloudsmith.com/blog/track-your-bandwidth-storage-limits-with-our-quota-api) for more details.\n\n",
+              "background_color": "white",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 3, "y": 0, "width": 3, "height": 4 }
+          },
+          {
+            "id": 6344085258702783,
+            "definition": {
+              "title": "Percentage Bandwidth Used",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">=",
+                      "palette": "red_on_white",
+                      "value": 85
+                    },
+                    {
+                      "comparator": ">",
+                      "palette": "yellow_on_white",
+                      "value": 75
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "avg:cloudsmith.bandwidth_used{*}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "avg"
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2
+            },
+            "layout": { "x": 0, "y": 2, "width": 3, "height": 2 }
+          }
+        ]
+      },
+      "layout": { "x": 6, "y": 0, "width": 6, "height": 5 }
+    },
+    {
+      "id": 7490658912792070,
+      "definition": {
+        "title": "Audit Logs",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "requests": [
+          {
+            "query": {
+              "data_source": "event_stream",
+              "query_string": "source:cloudsmith @aggregation_key:audit_log",
+              "event_size": "s"
+            },
+            "response_format": "event_list",
+            "columns": []
+          }
+        ],
+        "type": "list_stream"
+      },
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 4 }
+    },
+    {
+      "id": 3,
+      "definition": {
+        "title": "Token Overview",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 8971161252725269,
+            "definition": {
+              "type": "image",
+              "url": "https://cloudsmith.com/img/cloudsmith-mini-dark.svg",
+              "url_dark_theme": "https://cloudsmith.com/img/cloudsmith-mini.svg",
+              "sizing": "contain"
+            },
+            "layout": { "x": 0, "y": 0, "width": 2, "height": 2 }
+          },
+          {
+            "id": 8871727855771134,
+            "definition": {
+              "type": "note",
+              "content": "Track your entitlement token usage for your organization. View the amount of tokens created, the total amount downloaded by all tokens, and the bandwidth used by tokens. \n\nEntitlement tokens are read-only tokens used for downloading files and gaining read-only access to repository contents. See [Entitlements](https://help.cloudsmith.io/docs/entitlements) for more information.",
+              "background_color": "white",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 2, "y": 0, "width": 8, "height": 2 }
+          },
+          {
+            "id": 6383822446946945,
+            "definition": {
+              "title": "Token Count",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "avg:cloudsmith.token_count{*}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "avg"
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2
+            },
+            "layout": { "x": 0, "y": 2, "width": 2, "height": 2 }
+          },
+          {
+            "id": 1745585157577347,
+            "definition": {
+              "title": "Total Downloads by Tokens",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": false,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "query": "avg:cloudsmith.token_download_total{*}",
+                      "data_source": "metrics",
+                      "name": "query1"
+                    }
+                  ],
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear",
+                "label": "",
+                "min": "auto",
+                "max": "auto"
+              },
+              "markers": []
+            },
+            "layout": { "x": 2, "y": 2, "width": 4, "height": 2 }
+          },
+          {
+            "id": 5049902402844905,
+            "definition": {
+              "title": "Total Bandwidth Consumed by Tokens",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": false,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "query": "avg:cloudsmith.token_bandwidth_total{*}",
+                      "data_source": "metrics",
+                      "name": "query1"
+                    }
+                  ],
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear",
+                "label": "",
+                "min": "auto",
+                "max": "auto"
+              },
+              "markers": []
+            },
+            "layout": { "x": 6, "y": 2, "width": 4, "height": 2 }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 12,
+        "height": 5,
+        "is_column_break": true
+      }
+    },
+    {
+      "id": 2282516981148608,
+      "definition": {
+        "title": "Vulnerabilities Scan Result",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "requests": [
+          {
+            "query": {
+              "data_source": "event_stream",
+              "query_string": "source:cloudsmith @aggregation_key:vulnerabilities",
+              "event_size": "s"
+            },
+            "response_format": "event_list",
+            "columns": []
+          }
+        ],
+        "type": "list_stream"
+      },
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 4 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/emnify/assets/dashboards/emnify_dashboard.json
+++ b/emnify/assets/dashboards/emnify_dashboard.json
@@ -1,6 +1,5 @@
 {
   "description": "Observe your consumption analytics all in one dashboard. Analyze patterns of usage across your devices inventory.",
-  "id": "ajg-fdu-uyn",
   "is_read_only": false,
   "layout_type": "ordered",
   "notify_list": [ ],

--- a/federatorai/assets/dashboards/cost-management-cluster-overview.json
+++ b/federatorai/assets/dashboards/cost-management-cluster-overview.json
@@ -732,7 +732,6 @@
                         }
                      ],
                      "custom_links":[
-                        
                      ]
                   },
                   "layout":{
@@ -802,7 +801,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -924,7 +923,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -976,7 +975,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -1725,7 +1724,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -1795,7 +1794,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -1917,7 +1916,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -1969,7 +1968,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2712,7 +2711,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2782,7 +2781,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2904,7 +2903,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2956,7 +2955,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2983,15 +2982,14 @@
          "default":"*",
          "prefix":"kube_cluster_name",
          "available_values":[
-            
+
          ]
       }
    ],
    "layout_type":"ordered",
    "is_read_only":false,
    "notify_list":[
-      
+
    ],
-   "reflow_type":"fixed",
-   "id":"kse-vgg-p84"
+   "reflow_type":"fixed"
 }

--- a/federatorai/assets/dashboards/cost-management-namespace-overview.json
+++ b/federatorai/assets/dashboards/cost-management-namespace-overview.json
@@ -729,7 +729,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -799,7 +799,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -1545,7 +1545,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -1615,7 +1615,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2361,7 +2361,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2431,7 +2431,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2458,7 +2458,7 @@
          "default":"*",
          "prefix":"kube_cluster_name",
          "available_values":[
-            
+
          ]
       },
       {
@@ -2466,15 +2466,14 @@
          "default":"*",
          "prefix":"kube_namespace",
          "available_values":[
-            
+
          ]
       }
    ],
    "layout_type":"ordered",
    "is_read_only":false,
    "notify_list":[
-      
+
    ],
-   "reflow_type":"fixed",
-   "id":"dbf-dmt-85i"
+   "reflow_type":"fixed"
 }

--- a/federatorai/assets/dashboards/cost-management-node-overview.json
+++ b/federatorai/assets/dashboards/cost-management-node-overview.json
@@ -708,7 +708,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -760,7 +760,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -811,7 +811,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -1536,7 +1536,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -1588,7 +1588,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -1636,7 +1636,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2361,7 +2361,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2413,7 +2413,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2464,7 +2464,7 @@
                         }
                      ],
                      "custom_links":[
-                        
+
                      ]
                   },
                   "layout":{
@@ -2491,7 +2491,7 @@
          "default":"*",
          "prefix":"kube_cluster_name",
          "available_values":[
-            
+
          ]
       },
       {
@@ -2499,15 +2499,14 @@
          "default":"*",
          "prefix":"host",
          "available_values":[
-            
+
          ]
       }
    ],
    "layout_type":"ordered",
    "is_read_only":false,
    "notify_list":[
-      
+
    ],
-   "reflow_type":"fixed",
-   "id":"jku-aa3-7dn"
+   "reflow_type":"fixed"
 }

--- a/fiddler/assets/dashboards/fiddler_overview.json
+++ b/fiddler/assets/dashboards/fiddler_overview.json
@@ -1,1 +1,360 @@
-{"title":"Fiddler Model Performance","description":"## Fiddler Model Performance Dashboard\n\nThis dashboard displays the model performance metrics that was pulled into DataDog from the Fiddler Model Performance Management tool. You can customize this dashboard to show all of your model specific metrics and data.","widgets":[{"id":8730254853653876,"definition":{"type":"image","url":"https://global-uploads.webflow.com/5e067beb4c88a64e31622d4b/623e2b19056c2266cff2d854_fiddler-ai-logo.svg","sizing":"contain","margin":"lg","has_background":true,"has_border":true,"vertical_align":"center","horizontal_align":"center"},"layout":{"x":0,"y":0,"width":6,"height":2}},{"id":939346948899802,"definition":{"type":"note","content":"Building trust into AI","background_color":"white","font_size":"56","text_align":"center","vertical_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":6,"y":0,"width":6,"height":2}},{"id":3011627381688894,"definition":{"title":"Model Accuracy","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"conditional_formats":[{"comparator":">","palette":"white_on_green","value":0.8},{"comparator":">","palette":"white_on_yellow","value":0.6},{"comparator":">","palette":"white_on_red","value":0}],"response_format":"scalar","queries":[{"query":"avg:fiddler.accuracy{$project,$model}","data_source":"metrics","name":"query1","aggregator":"avg"}]}],"autoscale":true,"precision":2,"timeseries_background":{"type":"area","yaxis":{"include_zero":false}}},"layout":{"x":0,"y":2,"width":4,"height":2}},{"id":52421755218508,"definition":{"title":"Prediction Drift","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"conditional_formats":[{"comparator":">","palette":"white_on_red","value":0.7},{"comparator":">","palette":"white_on_yellow","value":0.3},{"comparator":">","palette":"white_on_green","value":0}],"response_format":"scalar","queries":[{"query":"avg:fiddler.histogram_drift{feature:prob_loan_status}","data_source":"metrics","name":"query1","aggregator":"avg"}]}],"autoscale":true,"precision":2,"timeseries_background":{"type":"area","yaxis":{"include_zero":false}}},"layout":{"x":4,"y":2,"width":4,"height":2}},{"id":1697409658936488,"definition":{"title":"Model Traffic","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"conditional_formats":[{"comparator":">","palette":"custom_bg","value":2},{"comparator":">","palette":"custom_bg","value":0}],"response_format":"scalar","queries":[{"query":"avg:fiddler.traffic_count{$project,$model}","data_source":"metrics","name":"query1","aggregator":"avg"}]}],"autoscale":true,"precision":1,"timeseries_background":{"type":"bars","yaxis":{}}},"layout":{"x":8,"y":2,"width":4,"height":2}},{"id":5289184382622970,"definition":{"title":"Model Traffic","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"response_format":"timeseries","queries":[{"query":"avg:fiddler.traffic_count{*} by {model}","data_source":"metrics","name":"query1"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"},{"formulas":[{"formula":"query0"}],"response_format":"timeseries","queries":[{"query":"avg:fiddler.traffic_count{*} by {model}","data_source":"metrics","name":"query0"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":0,"y":4,"width":6,"height":3}},{"id":3361228858411406,"definition":{"title":"Model Performance Metrics","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"},{"formula":"query2"},{"formula":"query3"},{"formula":"query4"},{"formula":"query5"},{"formula":"query6"},{"formula":"query7"}],"response_format":"timeseries","queries":[{"query":"avg:fiddler.fpr{$project,$model}","data_source":"metrics","name":"query1"},{"query":"avg:fiddler.f1_score{$project,$model}","data_source":"metrics","name":"query2"},{"query":"avg:fiddler.tpr{$project,$model}","data_source":"metrics","name":"query3"},{"query":"avg:fiddler.accuracy{$project,$model}","data_source":"metrics","name":"query4"},{"query":"avg:fiddler.auc{$project,$model}","data_source":"metrics","name":"query5"},{"query":"avg:fiddler.precision{$project,$model}","data_source":"metrics","name":"query6"},{"query":"avg:fiddler.recall{$project,$model}","data_source":"metrics","name":"query7"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":6,"y":4,"width":6,"height":3}},{"id":894816583866318,"definition":{"title":"Output Drift","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"response_format":"timeseries","queries":[{"query":"avg:fiddler.histogram_drift{feature:probability_churn}","data_source":"metrics","name":"query1"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"},{"formulas":[{"formula":"query0"}],"response_format":"timeseries","queries":[{"query":"avg:fiddler.histogram_drift{feature:prob_loan_status}","data_source":"metrics","name":"query0"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":0,"y":7,"width":6,"height":3}},{"id":6241039958772764,"definition":{"title":"Feature Averages Over Time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"response_format":"timeseries","queries":[{"query":"avg:fiddler.output_average{$project,$model,$feature} by {feature}","data_source":"metrics","name":"query1"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}]},"layout":{"x":6,"y":7,"width":6,"height":3}}],"template_variables":[{"name":"project","prefix":"project","available_values":[],"default":"*"},{"name":"model","prefix":"model","available_values":[],"default":"*"},{"name":"feature","prefix":"feature","available_values":[],"default":"*"}],"layout_type":"ordered","notify_list":[],"reflow_type":"fixed","id":"zeh-g4g-tkv"}
+{
+  "title": "Fiddler Model Performance",
+  "description": "## Fiddler Model Performance Dashboard\n\nThis dashboard displays the model performance metrics that was pulled into DataDog from the Fiddler Model Performance Management tool. You can customize this dashboard to show all of your model specific metrics and data.",
+  "widgets": [
+    {
+      "id": 8730254853653876,
+      "definition": {
+        "type": "image",
+        "url": "https://global-uploads.webflow.com/5e067beb4c88a64e31622d4b/623e2b19056c2266cff2d854_fiddler-ai-logo.svg",
+        "sizing": "contain",
+        "margin": "lg",
+        "has_background": true,
+        "has_border": true,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      },
+      "layout": { "x": 0, "y": 0, "width": 6, "height": 2 }
+    },
+    {
+      "id": 939346948899802,
+      "definition": {
+        "type": "note",
+        "content": "Building trust into AI",
+        "background_color": "white",
+        "font_size": "56",
+        "text_align": "center",
+        "vertical_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      },
+      "layout": { "x": 6, "y": 0, "width": 6, "height": 2 }
+    },
+    {
+      "id": 3011627381688894,
+      "definition": {
+        "title": "Model Accuracy",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 0.8 },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 0.6 },
+              { "comparator": ">", "palette": "white_on_red", "value": 0 }
+            ],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "query": "avg:fiddler.accuracy{$project,$model}",
+                "data_source": "metrics",
+                "name": "query1",
+                "aggregator": "avg"
+              }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 2,
+        "timeseries_background": {
+          "type": "area",
+          "yaxis": { "include_zero": false }
+        }
+      },
+      "layout": { "x": 0, "y": 2, "width": 4, "height": 2 }
+    },
+    {
+      "id": 52421755218508,
+      "definition": {
+        "title": "Prediction Drift",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_red", "value": 0.7 },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 0.3 },
+              { "comparator": ">", "palette": "white_on_green", "value": 0 }
+            ],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "query": "avg:fiddler.histogram_drift{feature:prob_loan_status}",
+                "data_source": "metrics",
+                "name": "query1",
+                "aggregator": "avg"
+              }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 2,
+        "timeseries_background": {
+          "type": "area",
+          "yaxis": { "include_zero": false }
+        }
+      },
+      "layout": { "x": 4, "y": 2, "width": 4, "height": 2 }
+    },
+    {
+      "id": 1697409658936488,
+      "definition": {
+        "title": "Model Traffic",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "conditional_formats": [
+              { "comparator": ">", "palette": "custom_bg", "value": 2 },
+              { "comparator": ">", "palette": "custom_bg", "value": 0 }
+            ],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "query": "avg:fiddler.traffic_count{$project,$model}",
+                "data_source": "metrics",
+                "name": "query1",
+                "aggregator": "avg"
+              }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 1,
+        "timeseries_background": { "type": "bars", "yaxis": {} }
+      },
+      "layout": { "x": 8, "y": 2, "width": 4, "height": 2 }
+    },
+    {
+      "id": 5289184382622970,
+      "definition": {
+        "title": "Model Traffic",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "query": "avg:fiddler.traffic_count{*} by {model}",
+                "data_source": "metrics",
+                "name": "query1"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          },
+          {
+            "formulas": [{ "formula": "query0" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "query": "avg:fiddler.traffic_count{*} by {model}",
+                "data_source": "metrics",
+                "name": "query0"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 4, "width": 6, "height": 3 }
+    },
+    {
+      "id": 3361228858411406,
+      "definition": {
+        "title": "Model Performance Metrics",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [
+              { "formula": "query1" },
+              { "formula": "query2" },
+              { "formula": "query3" },
+              { "formula": "query4" },
+              { "formula": "query5" },
+              { "formula": "query6" },
+              { "formula": "query7" }
+            ],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "query": "avg:fiddler.fpr{$project,$model}",
+                "data_source": "metrics",
+                "name": "query1"
+              },
+              {
+                "query": "avg:fiddler.f1_score{$project,$model}",
+                "data_source": "metrics",
+                "name": "query2"
+              },
+              {
+                "query": "avg:fiddler.tpr{$project,$model}",
+                "data_source": "metrics",
+                "name": "query3"
+              },
+              {
+                "query": "avg:fiddler.accuracy{$project,$model}",
+                "data_source": "metrics",
+                "name": "query4"
+              },
+              {
+                "query": "avg:fiddler.auc{$project,$model}",
+                "data_source": "metrics",
+                "name": "query5"
+              },
+              {
+                "query": "avg:fiddler.precision{$project,$model}",
+                "data_source": "metrics",
+                "name": "query6"
+              },
+              {
+                "query": "avg:fiddler.recall{$project,$model}",
+                "data_source": "metrics",
+                "name": "query7"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 6, "y": 4, "width": 6, "height": 3 }
+    },
+    {
+      "id": 894816583866318,
+      "definition": {
+        "title": "Output Drift",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "query": "avg:fiddler.histogram_drift{feature:probability_churn}",
+                "data_source": "metrics",
+                "name": "query1"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          },
+          {
+            "formulas": [{ "formula": "query0" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "query": "avg:fiddler.histogram_drift{feature:prob_loan_status}",
+                "data_source": "metrics",
+                "name": "query0"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 7, "width": 6, "height": 3 }
+    },
+    {
+      "id": 6241039958772764,
+      "definition": {
+        "title": "Feature Averages Over Time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "query": "avg:fiddler.output_average{$project,$model,$feature} by {feature}",
+                "data_source": "metrics",
+                "name": "query1"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 6, "y": 7, "width": 6, "height": 3 }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "project",
+      "prefix": "project",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "model",
+      "prefix": "model",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "feature",
+      "prefix": "feature",
+      "available_values": [],
+      "default": "*"
+    }
+  ],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/lambdatest/assets/dashboards/overview.json
+++ b/lambdatest/assets/dashboards/overview.json
@@ -1,1 +1,242 @@
-{"title":"LambdaTest","description":"","widgets":[{"id":3658125808741612,"definition":{"type":"image","url":"https://www.lambdatest.com/resources/images/logos/logo.svg","sizing":"contain","margin":"md","has_background":false,"has_border":false,"vertical_align":"center","horizontal_align":"center"},"layout":{"x":0,"y":0,"width":3,"height":3}},{"id":451236619174862,"definition":{"type":"note","content":"Track your test analytics from LambdaTest on one dashboard.\n\nYou can track and glean insights from data like number of tests per day, pass/fail rate, OS usage, browser usage, and test devices. Our easy-to-understand visualizations will make data consumption simple and intuitive. \nMoreover, you can also build your own dashboard to track metrics that matter. \n\nFor full visibility into your test runs, go to the [LambdaTest Dashboard](https://accounts.lambdatest.com/dashboard)","background_color":"white","font_size":"16","text_align":"left","vertical_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":3,"y":0,"width":9,"height":3}},{"id":6578866953559460,"definition":{"title":"Number of tests per day","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"horizontal","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"alias":"Tests","formula":"query1"}],"response_format":"timeseries","queries":[{"search":{"query":""},"data_source":"logs","compute":{"interval":86400000,"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@product","sort":{"aggregation":"count","order":"desc"},"limit":10}]}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]},"layout":{"x":0,"y":3,"width":12,"height":4}},{"id":7850274038409555,"definition":{"title":"Pass/Fail Rate","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"horizontal","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"alias":"Passed","formula":"a"},{"alias":"Failed","formula":"b"},{"alias":"Others","formula":"d"}],"response_format":"timeseries","queries":[{"search":{"query":"@status:Completed"},"data_source":"logs","compute":{"interval":86400000,"aggregation":"count"},"name":"a","indexes":["*"],"group_by":[]},{"search":{"query":"@status:Failed"},"data_source":"logs","compute":{"interval":86400000,"aggregation":"count"},"name":"b","indexes":["*"],"group_by":[]},{"search":{"query":"-@status:Failed -@status:Completed"},"data_source":"logs","compute":{"interval":86400000,"aggregation":"count"},"name":"d","indexes":["*"],"group_by":[]}],"style":{"palette":"dog_classic"},"display_type":"bars"}]},"layout":{"x":0,"y":7,"width":12,"height":4}},{"id":1608569804984058,"definition":{"title":"OS Usage","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1","limit":{"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":""},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@test_env_os","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst","legend":{"type":"automatic"}},"layout":{"x":0,"y":11,"width":4,"height":5}},{"id":3187683595740304,"definition":{"title":"Browser Usage","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1","limit":{"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":""},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@test_env_browser","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst","legend":{"type":"automatic"}},"layout":{"x":4,"y":11,"width":4,"height":5}},{"id":4096046188582372,"definition":{"title":"Real Device Usage","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1","limit":{"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"@product:(\"Web Automation Real Device\" OR \"Manual App Testing Real Device\" OR \"Manual Browser Testing Real Device\" OR \"App Automation Real Device\")"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@test_env_device","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst","legend":{"type":"automatic"}},"layout":{"x":8,"y":11,"width":4,"height":5}}],"template_variables":[],"layout_type":"ordered","is_read_only":false,"notify_list":[],"reflow_type":"fixed","id":"cut-gtf-ka4"}
+{
+  "title": "LambdaTest",
+  "description": "",
+  "widgets": [
+    {
+      "id": 3658125808741612,
+      "definition": {
+        "type": "image",
+        "url": "https://www.lambdatest.com/resources/images/logos/logo.svg",
+        "sizing": "contain",
+        "margin": "md",
+        "has_background": false,
+        "has_border": false,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      },
+      "layout": { "x": 0, "y": 0, "width": 3, "height": 3 }
+    },
+    {
+      "id": 451236619174862,
+      "definition": {
+        "type": "note",
+        "content": "Track your test analytics from LambdaTest on one dashboard.\n\nYou can track and glean insights from data like number of tests per day, pass/fail rate, OS usage, browser usage, and test devices. Our easy-to-understand visualizations will make data consumption simple and intuitive. \nMoreover, you can also build your own dashboard to track metrics that matter. \n\nFor full visibility into your test runs, go to the [LambdaTest Dashboard](https://accounts.lambdatest.com/dashboard)",
+        "background_color": "white",
+        "font_size": "16",
+        "text_align": "left",
+        "vertical_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      },
+      "layout": { "x": 3, "y": 0, "width": 9, "height": 3 }
+    },
+    {
+      "id": 6578866953559460,
+      "definition": {
+        "title": "Number of tests per day",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "horizontal",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "alias": "Tests", "formula": "query1" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "search": { "query": "" },
+                "data_source": "logs",
+                "compute": { "interval": 86400000, "aggregation": "count" },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@product",
+                    "sort": { "aggregation": "count", "order": "desc" },
+                    "limit": 10
+                  }
+                ]
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      },
+      "layout": { "x": 0, "y": 3, "width": 12, "height": 4 }
+    },
+    {
+      "id": 7850274038409555,
+      "definition": {
+        "title": "Pass/Fail Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "horizontal",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [
+              { "alias": "Passed", "formula": "a" },
+              { "alias": "Failed", "formula": "b" },
+              { "alias": "Others", "formula": "d" }
+            ],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "search": { "query": "@status:Completed" },
+                "data_source": "logs",
+                "compute": { "interval": 86400000, "aggregation": "count" },
+                "name": "a",
+                "indexes": ["*"],
+                "group_by": []
+              },
+              {
+                "search": { "query": "@status:Failed" },
+                "data_source": "logs",
+                "compute": { "interval": 86400000, "aggregation": "count" },
+                "name": "b",
+                "indexes": ["*"],
+                "group_by": []
+              },
+              {
+                "search": { "query": "-@status:Failed -@status:Completed" },
+                "data_source": "logs",
+                "compute": { "interval": 86400000, "aggregation": "count" },
+                "name": "d",
+                "indexes": ["*"],
+                "group_by": []
+              }
+            ],
+            "style": { "palette": "dog_classic" },
+            "display_type": "bars"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 7, "width": 12, "height": 4 }
+    },
+    {
+      "id": 1608569804984058,
+      "definition": {
+        "title": "OS Usage",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1", "limit": { "order": "desc" } }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "" },
+                "data_source": "logs",
+                "compute": { "aggregation": "count" },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@test_env_os",
+                    "sort": { "aggregation": "count", "order": "desc" },
+                    "limit": 10
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "type": "sunburst",
+        "legend": { "type": "automatic" }
+      },
+      "layout": { "x": 0, "y": 11, "width": 4, "height": 5 }
+    },
+    {
+      "id": 3187683595740304,
+      "definition": {
+        "title": "Browser Usage",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1", "limit": { "order": "desc" } }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "" },
+                "data_source": "logs",
+                "compute": { "aggregation": "count" },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@test_env_browser",
+                    "sort": { "aggregation": "count", "order": "desc" },
+                    "limit": 10
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "type": "sunburst",
+        "legend": { "type": "automatic" }
+      },
+      "layout": { "x": 4, "y": 11, "width": 4, "height": 5 }
+    },
+    {
+      "id": 4096046188582372,
+      "definition": {
+        "title": "Real Device Usage",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1", "limit": { "order": "desc" } }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": {
+                  "query": "@product:(\"Web Automation Real Device\" OR \"Manual App Testing Real Device\" OR \"Manual Browser Testing Real Device\" OR \"App Automation Real Device\")"
+                },
+                "data_source": "logs",
+                "compute": { "aggregation": "count" },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@test_env_device",
+                    "sort": { "aggregation": "count", "order": "desc" },
+                    "limit": 10
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "type": "sunburst",
+        "legend": { "type": "automatic" }
+      },
+      "layout": { "x": 8, "y": 11, "width": 4, "height": 5 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/mendix/assets/dashboards/MendixApplicationOverview.json
+++ b/mendix/assets/dashboards/MendixApplicationOverview.json
@@ -1024,6 +1024,5 @@
   ],
   "layout_type": "ordered",
   "notify_list": [],
-  "reflow_type": "fixed",
-  "id": "pga-3qr-2v4"
+  "reflow_type": "fixed"
 }

--- a/n2ws/assets/dashboards/N2WSBackup&Recovery-BackupSuccessRates(ColumnGraphs).json
+++ b/n2ws/assets/dashboards/N2WSBackup&Recovery-BackupSuccessRates(ColumnGraphs).json
@@ -1,1 +1,858 @@
-{"title":"N2WS Backup & Recovery - Backup Success Rates (Column Graphs)","description":"## N2WS Backup & Recovery Dashboard\n\nThis dashboard summarizes data that was collected from all N2WS Backup & Recovery hosts that are connected to DataDog\n","widgets":[{"id":2637556285457016,"layout":{"x":69,"y":16,"width":13,"height":8},"definition":{"title":"Accounts","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.accounts_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[{"link":"https://{{host.value}}/ui/dashboard/","label":"Go to host's Dashboard"}],"precision":0}},{"id":1132115760137398,"layout":{"x":69,"y":25,"width":13,"height":8},"definition":{"title":"Policies","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.policies_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":6833713613288876,"layout":{"x":13,"y":0,"width":24,"height":6},"definition":{"type":"free_text","text":"N2WS Backup & Recovery  Servers Status","color":"#2B13E6","font_size":"56","text_align":"left"}},{"id":3660811894528512,"layout":{"x":0,"y":16,"width":37,"height":26},"definition":{"title":"Available hosts","title_size":"16","title_align":"left","type":"hostmap","requests":{"fill":{"q":"avg:system.cpu.user{*} by {host}"}},"node_type":"host","no_metric_hosts":false,"no_group_hosts":true,"custom_links":[{"link":"https://{{$ip.value}}/ui/dashboard/","label":"Go to host's Dashboard"}],"style":{"palette":"green_to_orange","palette_flip":false}}},{"id":4889683502691186,"layout":{"x":39,"y":16,"width":13,"height":8},"definition":{"title":"Backup to EBS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user}))*100","aggregator":"avg","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":">","palette":"white_on_yellow","value":50},{"comparator":"<","palette":"white_on_yellow","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":4495620089867176,"layout":{"x":39,"y":25,"width":13,"height":8},"definition":{"title":"DR backups","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user}))*100","aggregator":"last","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":"<","palette":"white_on_yellow","value":80},{"comparator":">","palette":"white_on_yellow","value":50}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":7599208437230966,"layout":{"x":39,"y":34,"width":13,"height":8},"definition":{"title":"Backup to S3","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user}))*100","aggregator":"last","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":">","palette":"white_on_yellow","value":50},{"comparator":"<","palette":"white_on_yellow","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":4085517614690048,"layout":{"x":0,"y":0,"width":12,"height":8},"definition":{"type":"image","url":"https://n2ws.com/wp-content/uploads/2018/10/N2WS_Logo-Primary-2.svg","sizing":"fit"}},{"id":2595322878823152,"layout":{"x":119,"y":44,"width":37,"height":25},"definition":{"title":"Total amount of snapshots by type over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"vertical","legend_columns":["avg","min","max","value","sum"],"time":{},"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}","on_right_yaxis":false,"metadata":[{"expression":"sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}","alias_name":"DynamoDB snapshots "},{"expression":"sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}","alias_name":"EFS snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}","alias_name":"RDS snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}","alias_name":"DR RDS snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}","alias_name":"Volumes snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}","alias_name":"Aurora snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}","alias_name":"Redshift snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}","alias_name":"DR Volume snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}","alias_name":"DR Aurora snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}","alias_name":"FSx snapshots"}],"style":{"palette":"cool","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"},"markers":[]}},{"id":1844247243659372,"layout":{"x":0,"y":44,"width":37,"height":25},"definition":{"title":"Backups success over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"time":{},"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}","on_right_yaxis":false,"metadata":[{"expression":"sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}","alias_name":"Successful EBS backups"},{"expression":"sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}","alias_name":"EBS backup failures"},{"expression":"sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}","alias_name":"Partially successful backups"}],"style":{"palette":"warm","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"},"markers":[]}},{"id":5584509867253186,"layout":{"x":39,"y":44,"width":38,"height":25},"definition":{"title":"Backups DR success over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"time":{},"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} by {cpm}","on_right_yaxis":false,"metadata":[{"expression":"sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} by {cpm}","alias_name":"Successful DR backups"},{"expression":"sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user} by {cpm}","alias_name":"DR backups failure"},{"expression":"sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} by {cpm}","alias_name":"Partially successful DR backups"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"},"markers":[]}},{"id":614497561179518,"layout":{"x":79,"y":44,"width":38,"height":25},"definition":{"title":"S3 Backups success over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"time":{},"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} by {cpm}","on_right_yaxis":false,"metadata":[{"expression":"sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} by {cpm}","alias_name":"Successful S3 backups"},{"expression":"sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user} by {cpm}","alias_name":"S3 backups failure"},{"expression":"sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} by {cpm}","alias_name":"Partially successful S3 backups"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"},"markers":[]}},{"id":7180936149683416,"layout":{"x":0,"y":71,"width":60,"height":26},"definition":{"title":"Alerts gathering for all hosts","title_size":"16","title_align":"left","time":{"live_span":"1w"},"type":"event_stream","query":"sources:n2ws tags:$user hosts:$host.value","tags_execution":"and","event_size":"l"}},{"id":5945986900303426,"layout":{"x":99,"y":16,"width":12,"height":8},"definition":{"title":"Instances","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_instances_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":4419154600287480,"layout":{"x":99,"y":34,"width":12,"height":8},"definition":{"title":"EFS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_efs_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":1935790075102,"layout":{"x":125,"y":25,"width":12,"height":8},"definition":{"title":"Redshift","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_redshift_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":7971473927039272,"layout":{"x":125,"y":16,"width":12,"height":8},"definition":{"title":"RDS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_rds_db_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":3588851606457020,"layout":{"x":112,"y":16,"width":12,"height":8},"definition":{"title":"Volumes","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_volumes_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":2}},{"id":981117228066646,"layout":{"x":112,"y":25,"width":12,"height":8},"definition":{"title":"Dynamo DB","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_ddb_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":7374759144596838,"layout":{"x":99,"y":25,"width":12,"height":8},"definition":{"title":"Aurora","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_rds_clus_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":6182576205949094,"layout":{"x":0,"y":8,"width":37,"height":7},"definition":{"type":"note","content":"This dashboard summarizes data collected from N2WS Backup & Recovery hosts connected to DataDog","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":163195945008220,"layout":{"x":39,"y":8,"width":28,"height":7},"definition":{"type":"note","content":"Success Rate","background_color":"blue","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":2923528343457910,"layout":{"x":53,"y":16,"width":14,"height":8},"definition":{"type":"note","content":"Indicates percentage of backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":8418227565588260,"layout":{"x":53,"y":25,"width":14,"height":8},"definition":{"type":"note","content":"Indicates percentage of DR (Disaster Recovery) backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":8748196710797844,"layout":{"x":53,"y":34,"width":14,"height":8},"definition":{"type":"note","content":"Indicates percentage of S3 backups that have succeeded (Glacier backups aren't counted). \nYou can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":2007395944978376,"layout":{"x":69,"y":8,"width":28,"height":7},"definition":{"type":"note","content":"Total Summary","background_color":"blue","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":3127155320728790,"layout":{"x":83,"y":16,"width":14,"height":8},"definition":{"type":"note","content":"Total number of accounts on all hosts","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":7272280144470548,"layout":{"x":83,"y":25,"width":14,"height":8},"definition":{"type":"note","content":"Total number of policies on all hosts","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":7845771991582078,"layout":{"x":99,"y":8,"width":57,"height":7},"definition":{"type":"note","content":"How many Entities have you backed up?","background_color":"blue","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":822785988778976,"layout":{"x":138,"y":16,"width":18,"height":26},"definition":{"type":"note","content":"Tracks number of entities backed up by all N2WS Backup & Recovery hosts.\n\nPlease note that if an instance, for example, was backed up by 2 N2WS hosts, it will be  counted twice.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":7702466249586728,"layout":{"x":61,"y":71,"width":16,"height":26},"definition":{"type":"note","content":"DataDog and N2WS Backup & Recovery hosts alerts","background_color":"blue","font_size":"24","text_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":6184828882153520,"layout":{"x":79,"y":71,"width":21,"height":8},"definition":{"title":"Average Volume Capacity ","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_usage_percentage_num{$host,$user}","aggregator":"avg","conditional_formats":[{"comparator":">","palette":"white_on_red","value":80},{"comparator":"<=","palette":"white_on_yellow","value":20},{"comparator":">","palette":"white_on_green","value":20},{"comparator":"<","palette":"white_on_green","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":5044747906249744,"layout":{"x":79,"y":80,"width":21,"height":8},"definition":{"title":"Volumes above high watermark","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_above_high_watermark_num{$host,$user}","aggregator":"last","conditional_formats":[{"comparator":">=","palette":"white_on_red","value":1},{"comparator":"<","palette":"white_on_green","value":1}]}],"text_align":"left","precision":0}},{"id":7142455690032772,"layout":{"x":101,"y":71,"width":38,"height":8},"definition":{"type":"note","content":"The average capacity of volumes that were backed up by N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":6406821361983512,"layout":{"x":101,"y":80,"width":38,"height":8},"definition":{"type":"note","content":"Number of backed up volumes that their capacity is higher than the high watermark defined in N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":1223244874390138,"layout":{"x":101,"y":89,"width":38,"height":8},"definition":{"type":"note","content":"Number of backed up volumes that their capacity is lower than the low watermark defined in N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":437205163209710,"layout":{"x":79,"y":89,"width":21,"height":8},"definition":{"title":"Volumes above high watermark","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_below_low_watermark_num{$host,$user}","aggregator":"last","conditional_formats":[{"comparator":">=","palette":"white_on_yellow","value":1},{"comparator":"<","palette":"white_on_green","value":1}]}],"text_align":"left","precision":0}},{"id":8357335241437432,"layout":{"x":140,"y":71,"width":16,"height":26},"definition":{"type":"note","content":"Backed Up Volumes Capacity Data","background_color":"blue","font_size":"24","text_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":3292035289888398,"layout":{"x":112,"y":34,"width":12,"height":8},"definition":{"title":"FSx","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_fsx_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}}],"template_variables":[{"name":"host","default":"*","prefix":"host"},{"name":"user","default":"*","prefix":"cpm"}],"layout_type":"free","is_read_only":false,"notify_list":[],"id":"pwa-b7h-shw"}
+{
+  "title": "N2WS Backup & Recovery - Backup Success Rates (Column Graphs)",
+  "description": "## N2WS Backup & Recovery Dashboard\n\nThis dashboard summarizes data that was collected from all N2WS Backup & Recovery hosts that are connected to DataDog\n",
+  "widgets": [
+    {
+      "id": 2637556285457016,
+      "layout": { "x": 69, "y": 16, "width": 13, "height": 8 },
+      "definition": {
+        "title": "Accounts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.accounts_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [
+          {
+            "link": "https://{{host.value}}/ui/dashboard/",
+            "label": "Go to host's Dashboard"
+          }
+        ],
+        "precision": 0
+      }
+    },
+    {
+      "id": 1132115760137398,
+      "layout": { "x": 69, "y": 25, "width": 13, "height": 8 },
+      "definition": {
+        "title": "Policies",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.policies_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 6833713613288876,
+      "layout": { "x": 13, "y": 0, "width": 24, "height": 6 },
+      "definition": {
+        "type": "free_text",
+        "text": "N2WS Backup & Recovery  Servers Status",
+        "color": "#2B13E6",
+        "font_size": "56",
+        "text_align": "left"
+      }
+    },
+    {
+      "id": 3660811894528512,
+      "layout": { "x": 0, "y": 16, "width": 37, "height": 26 },
+      "definition": {
+        "title": "Available hosts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "hostmap",
+        "requests": { "fill": { "q": "avg:system.cpu.user{*} by {host}" } },
+        "node_type": "host",
+        "no_metric_hosts": false,
+        "no_group_hosts": true,
+        "custom_links": [
+          {
+            "link": "https://{{$ip.value}}/ui/dashboard/",
+            "label": "Go to host's Dashboard"
+          }
+        ],
+        "style": { "palette": "green_to_orange", "palette_flip": false }
+      }
+    },
+    {
+      "id": 4889683502691186,
+      "layout": { "x": 39, "y": 16, "width": 13, "height": 8 },
+      "definition": {
+        "title": "Backup to EBS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user}))*100",
+            "aggregator": "avg",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 4495620089867176,
+      "layout": { "x": 39, "y": 25, "width": 13, "height": 8 },
+      "definition": {
+        "title": "DR backups",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user}))*100",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 7599208437230966,
+      "layout": { "x": 39, "y": 34, "width": 13, "height": 8 },
+      "definition": {
+        "title": "Backup to S3",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user}))*100",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 4085517614690048,
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 8 },
+      "definition": {
+        "type": "image",
+        "url": "https://n2ws.com/wp-content/uploads/2018/10/N2WS_Logo-Primary-2.svg",
+        "sizing": "fit"
+      }
+    },
+    {
+      "id": 2595322878823152,
+      "layout": { "x": 119, "y": 44, "width": 37, "height": 25 },
+      "definition": {
+        "title": "Total amount of snapshots by type over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "vertical",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}",
+            "on_right_yaxis": false,
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}",
+                "alias_name": "DynamoDB snapshots "
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}",
+                "alias_name": "EFS snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}",
+                "alias_name": "RDS snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}",
+                "alias_name": "DR RDS snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}",
+                "alias_name": "Volumes snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}",
+                "alias_name": "Aurora snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}",
+                "alias_name": "Redshift snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}",
+                "alias_name": "DR Volume snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}",
+                "alias_name": "DR Aurora snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}",
+                "alias_name": "FSx snapshots"
+              }
+            ],
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 1844247243659372,
+      "layout": { "x": 0, "y": 44, "width": 37, "height": 25 },
+      "definition": {
+        "title": "Backups success over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}",
+            "on_right_yaxis": false,
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}",
+                "alias_name": "Successful EBS backups"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}",
+                "alias_name": "EBS backup failures"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}",
+                "alias_name": "Partially successful backups"
+              }
+            ],
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 5584509867253186,
+      "layout": { "x": 39, "y": 44, "width": 38, "height": 25 },
+      "definition": {
+        "title": "Backups DR success over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} by {cpm}",
+            "on_right_yaxis": false,
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} by {cpm}",
+                "alias_name": "Successful DR backups"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user} by {cpm}",
+                "alias_name": "DR backups failure"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} by {cpm}",
+                "alias_name": "Partially successful DR backups"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 614497561179518,
+      "layout": { "x": 79, "y": 44, "width": 38, "height": 25 },
+      "definition": {
+        "title": "S3 Backups success over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} by {cpm}",
+            "on_right_yaxis": false,
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} by {cpm}",
+                "alias_name": "Successful S3 backups"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user} by {cpm}",
+                "alias_name": "S3 backups failure"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} by {cpm}",
+                "alias_name": "Partially successful S3 backups"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 7180936149683416,
+      "layout": { "x": 0, "y": 71, "width": 60, "height": 26 },
+      "definition": {
+        "title": "Alerts gathering for all hosts",
+        "title_size": "16",
+        "title_align": "left",
+        "time": { "live_span": "1w" },
+        "type": "event_stream",
+        "query": "sources:n2ws tags:$user hosts:$host.value",
+        "tags_execution": "and",
+        "event_size": "l"
+      }
+    },
+    {
+      "id": 5945986900303426,
+      "layout": { "x": 99, "y": 16, "width": 12, "height": 8 },
+      "definition": {
+        "title": "Instances",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_instances_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4419154600287480,
+      "layout": { "x": 99, "y": 34, "width": 12, "height": 8 },
+      "definition": {
+        "title": "EFS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_efs_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 1935790075102,
+      "layout": { "x": 125, "y": 25, "width": 12, "height": 8 },
+      "definition": {
+        "title": "Redshift",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_redshift_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 7971473927039272,
+      "layout": { "x": 125, "y": 16, "width": 12, "height": 8 },
+      "definition": {
+        "title": "RDS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_rds_db_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 3588851606457020,
+      "layout": { "x": 112, "y": 16, "width": 12, "height": 8 },
+      "definition": {
+        "title": "Volumes",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_volumes_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 2
+      }
+    },
+    {
+      "id": 981117228066646,
+      "layout": { "x": 112, "y": 25, "width": 12, "height": 8 },
+      "definition": {
+        "title": "Dynamo DB",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_ddb_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 7374759144596838,
+      "layout": { "x": 99, "y": 25, "width": 12, "height": 8 },
+      "definition": {
+        "title": "Aurora",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_rds_clus_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 6182576205949094,
+      "layout": { "x": 0, "y": 8, "width": 37, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "This dashboard summarizes data collected from N2WS Backup & Recovery hosts connected to DataDog",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 163195945008220,
+      "layout": { "x": 39, "y": 8, "width": 28, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Success Rate",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 2923528343457910,
+      "layout": { "x": 53, "y": 16, "width": 14, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Indicates percentage of backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 8418227565588260,
+      "layout": { "x": 53, "y": 25, "width": 14, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Indicates percentage of DR (Disaster Recovery) backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 8748196710797844,
+      "layout": { "x": 53, "y": 34, "width": 14, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Indicates percentage of S3 backups that have succeeded (Glacier backups aren't counted). \nYou can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 2007395944978376,
+      "layout": { "x": 69, "y": 8, "width": 28, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Total Summary",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 3127155320728790,
+      "layout": { "x": 83, "y": 16, "width": 14, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Total number of accounts on all hosts",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 7272280144470548,
+      "layout": { "x": 83, "y": 25, "width": 14, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Total number of policies on all hosts",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 7845771991582078,
+      "layout": { "x": 99, "y": 8, "width": 57, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "How many Entities have you backed up?",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 822785988778976,
+      "layout": { "x": 138, "y": 16, "width": 18, "height": 26 },
+      "definition": {
+        "type": "note",
+        "content": "Tracks number of entities backed up by all N2WS Backup & Recovery hosts.\n\nPlease note that if an instance, for example, was backed up by 2 N2WS hosts, it will be  counted twice.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 7702466249586728,
+      "layout": { "x": 61, "y": 71, "width": 16, "height": 26 },
+      "definition": {
+        "type": "note",
+        "content": "DataDog and N2WS Backup & Recovery hosts alerts",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 6184828882153520,
+      "layout": { "x": 79, "y": 71, "width": 21, "height": 8 },
+      "definition": {
+        "title": "Average Volume Capacity ",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_usage_percentage_num{$host,$user}",
+            "aggregator": "avg",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_red", "value": 80 },
+              { "comparator": "<=", "palette": "white_on_yellow", "value": 20 },
+              { "comparator": ">", "palette": "white_on_green", "value": 20 },
+              { "comparator": "<", "palette": "white_on_green", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 5044747906249744,
+      "layout": { "x": 79, "y": 80, "width": 21, "height": 8 },
+      "definition": {
+        "title": "Volumes above high watermark",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_above_high_watermark_num{$host,$user}",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">=", "palette": "white_on_red", "value": 1 },
+              { "comparator": "<", "palette": "white_on_green", "value": 1 }
+            ]
+          }
+        ],
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 7142455690032772,
+      "layout": { "x": 101, "y": 71, "width": 38, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "The average capacity of volumes that were backed up by N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 6406821361983512,
+      "layout": { "x": 101, "y": 80, "width": 38, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up volumes that their capacity is higher than the high watermark defined in N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 1223244874390138,
+      "layout": { "x": 101, "y": 89, "width": 38, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up volumes that their capacity is lower than the low watermark defined in N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 437205163209710,
+      "layout": { "x": 79, "y": 89, "width": 21, "height": 8 },
+      "definition": {
+        "title": "Volumes above high watermark",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_below_low_watermark_num{$host,$user}",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">=", "palette": "white_on_yellow", "value": 1 },
+              { "comparator": "<", "palette": "white_on_green", "value": 1 }
+            ]
+          }
+        ],
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 8357335241437432,
+      "layout": { "x": 140, "y": 71, "width": 16, "height": 26 },
+      "definition": {
+        "type": "note",
+        "content": "Backed Up Volumes Capacity Data",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 3292035289888398,
+      "layout": { "x": 112, "y": 34, "width": 12, "height": 8 },
+      "definition": {
+        "title": "FSx",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_fsx_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    }
+  ],
+  "template_variables": [
+    { "name": "host", "default": "*", "prefix": "host" },
+    { "name": "user", "default": "*", "prefix": "cpm" }
+  ],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": []
+}

--- a/n2ws/assets/dashboards/N2WSBackup&Recovery-EntityTypesDetails.json
+++ b/n2ws/assets/dashboards/N2WSBackup&Recovery-EntityTypesDetails.json
@@ -1,1 +1,974 @@
-{"title":"N2WS Backup & Recovery - Entity Types Details","description":"## N2WS Backup & Recovery - Detailed Dashboard by Entity Type \n\nThis dashboard summarizes data that was collected from all N2WS Backup & Recovery hosts that are connected to DataDog, giving more details about entities types","widgets":[{"id":6833713613288876,"layout":{"x":13,"y":0,"width":24,"height":6},"definition":{"type":"free_text","text":"N2WS Backup & Recovery  Servers Status","color":"#2B13E6","font_size":"56","text_align":"left"}},{"id":4085517614690048,"layout":{"x":0,"y":0,"width":12,"height":8},"definition":{"type":"image","url":"https://n2ws.com/wp-content/uploads/2018/10/N2WS_Logo-Primary-2.svg","sizing":"fit"}},{"id":3059142389457708,"layout":{"x":0,"y":53,"width":10,"height":6},"definition":{"title":"Instances","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_instances_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":4931723730478434,"layout":{"x":11,"y":67,"width":11,"height":6},"definition":{"title":"FSx","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_fsx_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":2428912746970058,"layout":{"x":23,"y":60,"width":11,"height":6},"definition":{"title":"Redshift","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_redshift_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":6882875583965308,"layout":{"x":23,"y":53,"width":11,"height":6},"definition":{"title":"RDS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_rds_db_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":1705799585091706,"layout":{"x":11,"y":53,"width":11,"height":6},"definition":{"title":"Volumes","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_volumes_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":2}},{"id":1828199094188556,"layout":{"x":11,"y":60,"width":11,"height":6},"definition":{"title":"Dynamo DB","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_ddb_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":5138781865653636,"layout":{"x":0,"y":60,"width":10,"height":6},"definition":{"title":"Aurora","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_rds_clus_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":5429842537420874,"layout":{"x":58,"y":60,"width":10,"height":6},"definition":{"title":"EFS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":2150896737699084,"layout":{"x":47,"y":60,"width":10,"height":6},"definition":{"title":"Redshift","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":4378878990717088,"layout":{"x":47,"y":53,"width":10,"height":6},"definition":{"title":"RDS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":1372798678484004,"layout":{"x":36,"y":53,"width":10,"height":6},"definition":{"title":"Volumes","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":2}},{"id":5430267548904274,"layout":{"x":36,"y":60,"width":10,"height":6},"definition":{"title":"Dynamo DB","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":6866015780446286,"layout":{"x":58,"y":53,"width":10,"height":6},"definition":{"title":"Aurora","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":4189990561597372,"layout":{"x":92,"y":53,"width":10,"height":6},"definition":{"title":"EFS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":3804091029771224,"layout":{"x":81,"y":53,"width":10,"height":6},"definition":{"title":"RDS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":2376719938053794,"layout":{"x":70,"y":53,"width":10,"height":6},"definition":{"title":"Volumes","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":2}},{"id":2595322878823152,"layout":{"x":104,"y":16,"width":54,"height":25},"definition":{"title":"Total amount of snapshots for all hosts by time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"vertical","legend_columns":["avg","min","max","value","sum"],"time":{},"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}","metadata":[{"expression":"sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}","alias_name":"DynamoDB snapshots "},{"expression":"sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}","alias_name":"EFS snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}","alias_name":"RDS snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}","alias_name":"DR RDS snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}","alias_name":"Volumes snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}","alias_name":"Aurora snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}","alias_name":"Redshift snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}","alias_name":"DR RDS snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}","alias_name":"FSx snapshots"},{"expression":"sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}","alias_name":"Summary"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"},"markers":[]}},{"id":5713746525788918,"layout":{"x":0,"y":75,"width":79,"height":29},"definition":{"title":"Alerts gathering for all hosts","title_size":"16","title_align":"left","time":{"live_span":"1w"},"type":"event_stream","query":"sources:n2ws tags:$user hosts:$host.value","tags_execution":"and","event_size":"l"}},{"id":6784160051087150,"layout":{"x":104,"y":43,"width":54,"height":30},"definition":{"title":"Backups success over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"time":{},"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}","on_right_yaxis":false,"metadata":[{"expression":"sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}","alias_name":"Successful EBS backups"},{"expression":"sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}","alias_name":"EBS backup failures"},{"expression":"sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}","alias_name":"Partially successful backups"}],"style":{"palette":"warm","line_type":"solid","line_width":"normal"},"display_type":"area"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"},"markers":[]}},{"id":208539378395674,"layout":{"x":70,"y":16,"width":13,"height":8},"definition":{"title":"Accounts","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.accounts_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[{"link":"https://{{host.value}}/ui/dashboard/","label":"Go to host's Dashboard"}],"precision":0}},{"id":4250125984175390,"layout":{"x":70,"y":25,"width":13,"height":8},"definition":{"title":"Policies","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.policies_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":3509183830204216,"layout":{"x":0,"y":16,"width":34,"height":26},"definition":{"title":"Available hosts","title_size":"16","title_align":"left","type":"hostmap","requests":{"fill":{"q":"avg:system.cpu.user{*} by {host}"}},"node_type":"host","no_metric_hosts":false,"no_group_hosts":true,"custom_links":[{"link":"https://{{$ip.value}}/ui/dashboard/","label":"Go to host's Dashboard"}],"style":{"palette":"green_to_orange","palette_flip":false}}},{"id":3358821477019238,"layout":{"x":36,"y":16,"width":13,"height":8},"definition":{"title":"Backup to EBS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user}))*100","aggregator":"avg","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":">","palette":"white_on_yellow","value":50},{"comparator":"<","palette":"white_on_yellow","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":3053098348251140,"layout":{"x":36,"y":25,"width":13,"height":8},"definition":{"title":"DR backups","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user}))*100","aggregator":"last","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":"<","palette":"white_on_yellow","value":80},{"comparator":">","palette":"white_on_yellow","value":50}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":7487526937796298,"layout":{"x":36,"y":34,"width":13,"height":8},"definition":{"title":"Backup to S3","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user}))*100","aggregator":"last","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":">","palette":"white_on_yellow","value":50},{"comparator":"<","palette":"white_on_yellow","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":892259706152026,"layout":{"x":0,"y":8,"width":34,"height":7},"definition":{"type":"note","content":"This dashboard summarizes data collected from N2WS Backup & Recovery hosts connected to DataDog","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":776355987885820,"layout":{"x":36,"y":8,"width":32,"height":7},"definition":{"type":"note","content":"Success Rate","background_color":"blue","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":1332884223536476,"layout":{"x":50,"y":16,"width":18,"height":8},"definition":{"type":"note","content":"Indicates percentage of backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":1122155945778222,"layout":{"x":50,"y":34,"width":18,"height":8},"definition":{"type":"note","content":"Indicates percentage of S3 backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":8947443314726402,"layout":{"x":70,"y":8,"width":32,"height":7},"definition":{"type":"note","content":"Total Summary","background_color":"blue","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":8276039098984018,"layout":{"x":84,"y":16,"width":18,"height":8},"definition":{"type":"note","content":"Total number of accounts on all hosts","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":456777395312592,"layout":{"x":84,"y":25,"width":18,"height":8},"definition":{"type":"note","content":"Total number of policies on all hosts","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":427414507061190,"layout":{"x":0,"y":43,"width":34,"height":9},"definition":{"type":"note","content":"Number of backed up entities by type","background_color":"blue","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}},{"id":1021831416109504,"layout":{"x":36,"y":43,"width":32,"height":9},"definition":{"type":"note","content":"Number of backed up snapshots by type","background_color":"blue","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}},{"id":177738093370028,"layout":{"x":70,"y":43,"width":32,"height":9},"definition":{"type":"note","content":"Number of backed up DR snapshots by type","background_color":"blue","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}},{"id":8191563201835872,"layout":{"x":104,"y":8,"width":54,"height":7},"definition":{"type":"note","content":"Backups over time","background_color":"blue","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":6947773291986968,"layout":{"x":81,"y":75,"width":21,"height":9},"definition":{"title":"Average Volume Capacity ","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_usage_percentage_num{$host,$user}","aggregator":"avg","conditional_formats":[{"comparator":">","palette":"white_on_red","value":80},{"comparator":"<=","palette":"white_on_yellow","value":20},{"comparator":">","palette":"white_on_green","value":20},{"comparator":"<","palette":"white_on_green","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":3448787702420418,"layout":{"x":81,"y":85,"width":21,"height":9},"definition":{"title":"Volumes above high watermark","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_above_high_watermark_num{$host,$user}","aggregator":"last","conditional_formats":[{"comparator":">=","palette":"white_on_red","value":1},{"comparator":"<","palette":"white_on_green","value":1}]}],"text_align":"left","precision":0}},{"id":3674873670941034,"layout":{"x":103,"y":75,"width":38,"height":9},"definition":{"type":"note","content":"The average capacity of volumes that were backed up by N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":2877859327576680,"layout":{"x":103,"y":85,"width":38,"height":9},"definition":{"type":"note","content":"Number of backed up volumes that their capacity is higher than the high watermark defined in N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":718476280112238,"layout":{"x":103,"y":95,"width":38,"height":9},"definition":{"type":"note","content":"Number of backed up volumes that their capacity is lower than the low watermark defined in N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":6879791920341324,"layout":{"x":81,"y":95,"width":21,"height":9},"definition":{"title":"Volumes above high watermark","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_below_low_watermark_num{$host,$user}","aggregator":"last","conditional_formats":[{"comparator":">=","palette":"white_on_yellow","value":1},{"comparator":"<","palette":"white_on_green","value":1}]}],"text_align":"left","precision":0}},{"id":1382593931662556,"layout":{"x":142,"y":75,"width":16,"height":29},"definition":{"type":"note","content":"Backed Up Volumes Capacity Data","background_color":"blue","font_size":"24","text_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":803122310080746,"layout":{"x":50,"y":25,"width":18,"height":8},"definition":{"type":"note","content":"Indicates percentage of DR (Disaster Recovery) backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":1058098339957476,"layout":{"x":47,"y":67,"width":10,"height":6},"definition":{"title":"FSx","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":4879977658802298,"layout":{"x":0,"y":67,"width":10,"height":6},"definition":{"title":"EFS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_efs_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}}],"template_variables":[{"name":"host","default":"*","prefix":"host"},{"name":"user","default":"*","prefix":"cpm"}],"layout_type":"free","is_read_only":false,"notify_list":[],"id":"qqz-a9v-jfn"}
+{
+  "title": "N2WS Backup & Recovery - Entity Types Details",
+  "description": "## N2WS Backup & Recovery - Detailed Dashboard by Entity Type \n\nThis dashboard summarizes data that was collected from all N2WS Backup & Recovery hosts that are connected to DataDog, giving more details about entities types",
+  "widgets": [
+    {
+      "id": 6833713613288876,
+      "layout": { "x": 13, "y": 0, "width": 24, "height": 6 },
+      "definition": {
+        "type": "free_text",
+        "text": "N2WS Backup & Recovery  Servers Status",
+        "color": "#2B13E6",
+        "font_size": "56",
+        "text_align": "left"
+      }
+    },
+    {
+      "id": 4085517614690048,
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 8 },
+      "definition": {
+        "type": "image",
+        "url": "https://n2ws.com/wp-content/uploads/2018/10/N2WS_Logo-Primary-2.svg",
+        "sizing": "fit"
+      }
+    },
+    {
+      "id": 3059142389457708,
+      "layout": { "x": 0, "y": 53, "width": 10, "height": 6 },
+      "definition": {
+        "title": "Instances",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_instances_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4931723730478434,
+      "layout": { "x": 11, "y": 67, "width": 11, "height": 6 },
+      "definition": {
+        "title": "FSx",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_fsx_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 2428912746970058,
+      "layout": { "x": 23, "y": 60, "width": 11, "height": 6 },
+      "definition": {
+        "title": "Redshift",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_redshift_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 6882875583965308,
+      "layout": { "x": 23, "y": 53, "width": 11, "height": 6 },
+      "definition": {
+        "title": "RDS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_rds_db_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 1705799585091706,
+      "layout": { "x": 11, "y": 53, "width": 11, "height": 6 },
+      "definition": {
+        "title": "Volumes",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_volumes_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 2
+      }
+    },
+    {
+      "id": 1828199094188556,
+      "layout": { "x": 11, "y": 60, "width": 11, "height": 6 },
+      "definition": {
+        "title": "Dynamo DB",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_ddb_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 5138781865653636,
+      "layout": { "x": 0, "y": 60, "width": 10, "height": 6 },
+      "definition": {
+        "title": "Aurora",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_rds_clus_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 5429842537420874,
+      "layout": { "x": 58, "y": 60, "width": 10, "height": 6 },
+      "definition": {
+        "title": "EFS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 2150896737699084,
+      "layout": { "x": 47, "y": 60, "width": 10, "height": 6 },
+      "definition": {
+        "title": "Redshift",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4378878990717088,
+      "layout": { "x": 47, "y": 53, "width": 10, "height": 6 },
+      "definition": {
+        "title": "RDS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 1372798678484004,
+      "layout": { "x": 36, "y": 53, "width": 10, "height": 6 },
+      "definition": {
+        "title": "Volumes",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 2
+      }
+    },
+    {
+      "id": 5430267548904274,
+      "layout": { "x": 36, "y": 60, "width": 10, "height": 6 },
+      "definition": {
+        "title": "Dynamo DB",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 6866015780446286,
+      "layout": { "x": 58, "y": 53, "width": 10, "height": 6 },
+      "definition": {
+        "title": "Aurora",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4189990561597372,
+      "layout": { "x": 92, "y": 53, "width": 10, "height": 6 },
+      "definition": {
+        "title": "EFS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 3804091029771224,
+      "layout": { "x": 81, "y": 53, "width": 10, "height": 6 },
+      "definition": {
+        "title": "RDS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 2376719938053794,
+      "layout": { "x": 70, "y": 53, "width": 10, "height": 6 },
+      "definition": {
+        "title": "Volumes",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 2
+      }
+    },
+    {
+      "id": 2595322878823152,
+      "layout": { "x": 104, "y": 16, "width": 54, "height": 25 },
+      "definition": {
+        "title": "Total amount of snapshots for all hosts by time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "vertical",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}, sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}",
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}",
+                "alias_name": "DynamoDB snapshots "
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}",
+                "alias_name": "EFS snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}",
+                "alias_name": "RDS snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}",
+                "alias_name": "DR RDS snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}",
+                "alias_name": "Volumes snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}",
+                "alias_name": "Aurora snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}",
+                "alias_name": "Redshift snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}",
+                "alias_name": "DR RDS snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}",
+                "alias_name": "FSx snapshots"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}+sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}",
+                "alias_name": "Summary"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 5713746525788918,
+      "layout": { "x": 0, "y": 75, "width": 79, "height": 29 },
+      "definition": {
+        "title": "Alerts gathering for all hosts",
+        "title_size": "16",
+        "title_align": "left",
+        "time": { "live_span": "1w" },
+        "type": "event_stream",
+        "query": "sources:n2ws tags:$user hosts:$host.value",
+        "tags_execution": "and",
+        "event_size": "l"
+      }
+    },
+    {
+      "id": 6784160051087150,
+      "layout": { "x": 104, "y": 43, "width": 54, "height": 30 },
+      "definition": {
+        "title": "Backups success over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}",
+            "on_right_yaxis": false,
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}",
+                "alias_name": "Successful EBS backups"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}",
+                "alias_name": "EBS backup failures"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}",
+                "alias_name": "Partially successful backups"
+              }
+            ],
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "area"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 208539378395674,
+      "layout": { "x": 70, "y": 16, "width": 13, "height": 8 },
+      "definition": {
+        "title": "Accounts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.accounts_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [
+          {
+            "link": "https://{{host.value}}/ui/dashboard/",
+            "label": "Go to host's Dashboard"
+          }
+        ],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4250125984175390,
+      "layout": { "x": 70, "y": 25, "width": 13, "height": 8 },
+      "definition": {
+        "title": "Policies",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.policies_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 3509183830204216,
+      "layout": { "x": 0, "y": 16, "width": 34, "height": 26 },
+      "definition": {
+        "title": "Available hosts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "hostmap",
+        "requests": { "fill": { "q": "avg:system.cpu.user{*} by {host}" } },
+        "node_type": "host",
+        "no_metric_hosts": false,
+        "no_group_hosts": true,
+        "custom_links": [
+          {
+            "link": "https://{{$ip.value}}/ui/dashboard/",
+            "label": "Go to host's Dashboard"
+          }
+        ],
+        "style": { "palette": "green_to_orange", "palette_flip": false }
+      }
+    },
+    {
+      "id": 3358821477019238,
+      "layout": { "x": 36, "y": 16, "width": 13, "height": 8 },
+      "definition": {
+        "title": "Backup to EBS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user}))*100",
+            "aggregator": "avg",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 3053098348251140,
+      "layout": { "x": 36, "y": 25, "width": 13, "height": 8 },
+      "definition": {
+        "title": "DR backups",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user}))*100",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 7487526937796298,
+      "layout": { "x": 36, "y": 34, "width": 13, "height": 8 },
+      "definition": {
+        "title": "Backup to S3",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user}))*100",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 892259706152026,
+      "layout": { "x": 0, "y": 8, "width": 34, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "This dashboard summarizes data collected from N2WS Backup & Recovery hosts connected to DataDog",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 776355987885820,
+      "layout": { "x": 36, "y": 8, "width": 32, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Success Rate",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 1332884223536476,
+      "layout": { "x": 50, "y": 16, "width": 18, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Indicates percentage of backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 1122155945778222,
+      "layout": { "x": 50, "y": 34, "width": 18, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Indicates percentage of S3 backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 8947443314726402,
+      "layout": { "x": 70, "y": 8, "width": 32, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Total Summary",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 8276039098984018,
+      "layout": { "x": 84, "y": 16, "width": 18, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Total number of accounts on all hosts",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 456777395312592,
+      "layout": { "x": 84, "y": 25, "width": 18, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Total number of policies on all hosts",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 427414507061190,
+      "layout": { "x": 0, "y": 43, "width": 34, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up entities by type",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 1021831416109504,
+      "layout": { "x": 36, "y": 43, "width": 32, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up snapshots by type",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 177738093370028,
+      "layout": { "x": 70, "y": 43, "width": 32, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up DR snapshots by type",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 8191563201835872,
+      "layout": { "x": 104, "y": 8, "width": 54, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Backups over time",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 6947773291986968,
+      "layout": { "x": 81, "y": 75, "width": 21, "height": 9 },
+      "definition": {
+        "title": "Average Volume Capacity ",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_usage_percentage_num{$host,$user}",
+            "aggregator": "avg",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_red", "value": 80 },
+              { "comparator": "<=", "palette": "white_on_yellow", "value": 20 },
+              { "comparator": ">", "palette": "white_on_green", "value": 20 },
+              { "comparator": "<", "palette": "white_on_green", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 3448787702420418,
+      "layout": { "x": 81, "y": 85, "width": 21, "height": 9 },
+      "definition": {
+        "title": "Volumes above high watermark",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_above_high_watermark_num{$host,$user}",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">=", "palette": "white_on_red", "value": 1 },
+              { "comparator": "<", "palette": "white_on_green", "value": 1 }
+            ]
+          }
+        ],
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 3674873670941034,
+      "layout": { "x": 103, "y": 75, "width": 38, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "The average capacity of volumes that were backed up by N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 2877859327576680,
+      "layout": { "x": 103, "y": 85, "width": 38, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up volumes that their capacity is higher than the high watermark defined in N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 718476280112238,
+      "layout": { "x": 103, "y": 95, "width": 38, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up volumes that their capacity is lower than the low watermark defined in N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 6879791920341324,
+      "layout": { "x": 81, "y": 95, "width": 21, "height": 9 },
+      "definition": {
+        "title": "Volumes above high watermark",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_below_low_watermark_num{$host,$user}",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">=", "palette": "white_on_yellow", "value": 1 },
+              { "comparator": "<", "palette": "white_on_green", "value": 1 }
+            ]
+          }
+        ],
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 1382593931662556,
+      "layout": { "x": 142, "y": 75, "width": 16, "height": 29 },
+      "definition": {
+        "type": "note",
+        "content": "Backed Up Volumes Capacity Data",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 803122310080746,
+      "layout": { "x": 50, "y": 25, "width": 18, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Indicates percentage of DR (Disaster Recovery) backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 1058098339957476,
+      "layout": { "x": 47, "y": 67, "width": 10, "height": 6 },
+      "definition": {
+        "title": "FSx",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 4879977658802298,
+      "layout": { "x": 0, "y": 67, "width": 10, "height": 6 },
+      "definition": {
+        "title": "EFS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_efs_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    }
+  ],
+  "template_variables": [
+    { "name": "host", "default": "*", "prefix": "host" },
+    { "name": "user", "default": "*", "prefix": "cpm" }
+  ],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": []
+}

--- a/n2ws/assets/dashboards/N2WSBackup&Recoveryv4.1-BackupSuccessRates(ColumnGraphs).json
+++ b/n2ws/assets/dashboards/N2WSBackup&Recoveryv4.1-BackupSuccessRates(ColumnGraphs).json
@@ -1,1 +1,961 @@
-{"title":"N2WS Backup & Recovery v4.1 - Backup Success Rates (Column Graphs)","description":"## N2WS Backup & Recovery v4.1 Dashboard\n\nThis dashboard summarizes data that was collected from all N2WS Backup & Recovery v4.0 hosts that are connected to DataDog","widgets":[{"id":2637556285457016,"layout":{"x":63,"y":16,"width":11,"height":8},"definition":{"title":"Accounts","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.azure_accounts_num{$host,$user}+sum:cpm_metric.dashboard_state.accounts_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[{"link":"https://{{host.value}}/ui/dashboard/","label":"Go to host's Dashboard"}],"precision":0}},{"id":1132115760137398,"layout":{"x":63,"y":25,"width":11,"height":8},"definition":{"title":"Policies","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.azure_policies_num{$host,$user}+sum:cpm_metric.dashboard_state.policies_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":6833713613288876,"layout":{"x":12,"y":0,"width":24,"height":6},"definition":{"type":"free_text","text":"N2WS Backup & Recovery  v4.1 Servers Status","color":"#2B13E6","font_size":"56","text_align":"left"}},{"id":3660811894528512,"layout":{"x":0,"y":16,"width":34,"height":26},"definition":{"title":"Available hosts","title_size":"16","title_align":"left","type":"hostmap","requests":{"fill":{"q":"avg:system.cpu.user{*} by {host}"}},"node_type":"host","no_metric_hosts":false,"no_group_hosts":true,"custom_links":[{"link":"https://{{$ip.value}}/ui/dashboard/","label":"Go to host's Dashboard"}],"style":{"palette":"green_to_orange","palette_flip":false}}},{"id":4889683502691186,"layout":{"x":36,"y":16,"width":11,"height":8},"definition":{"title":"Simple Backups","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user}))*100","aggregator":"avg","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":">","palette":"white_on_yellow","value":50},{"comparator":"<","palette":"white_on_yellow","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":4495620089867176,"layout":{"x":36,"y":25,"width":11,"height":8},"definition":{"title":"DR backups","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user}))*100","aggregator":"last","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":"<","palette":"white_on_yellow","value":80},{"comparator":">","palette":"white_on_yellow","value":50}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":7599208437230966,"layout":{"x":36,"y":34,"width":11,"height":8},"definition":{"title":"Backup to S3","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user}))*100","aggregator":"last","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":">","palette":"white_on_yellow","value":50},{"comparator":"<","palette":"white_on_yellow","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":4085517614690048,"layout":{"x":0,"y":0,"width":12,"height":8},"definition":{"type":"image","url":"https://n2ws.com/wp-content/uploads/2018/10/N2WS_Logo-Primary-2.svg","sizing":"fit"}},{"id":2595322878823152,"layout":{"x":119,"y":44,"width":37,"height":25},"definition":{"title":"Total amount of snapshots by type over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"vertical","legend_columns":["value","sum"],"type":"timeseries","requests":[{"formulas":[{"alias":"DynamoDB snapshots ","formula":"query1"},{"alias":"EFS snapshots","formula":"query2"},{"alias":"RDS snapshots","formula":"query3"},{"alias":"DR RDS snapshots","formula":"query4"},{"alias":"Volumes snapshots","formula":"query5"},{"alias":"Aurora snapshots","formula":"query6"},{"alias":"Redshift snapshots","formula":"query7"},{"alias":"DR Volume snapshots","formula":"query8"},{"alias":"DR Aurora snapshots","formula":"query9"},{"alias":"FSx snapshots","formula":"query10"},{"alias":"Azure Disks","formula":"query11"},{"alias":"Only AMI snapshots","formula":"query12"}],"response_format":"timeseries","on_right_yaxis":false,"queries":[{"query":"sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}","data_source":"metrics","name":"query1"},{"query":"sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}","data_source":"metrics","name":"query2"},{"query":"sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}","data_source":"metrics","name":"query3"},{"query":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}","data_source":"metrics","name":"query4"},{"query":"sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}","data_source":"metrics","name":"query5"},{"query":"sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}","data_source":"metrics","name":"query6"},{"query":"sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}","data_source":"metrics","name":"query7"},{"query":"sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}","data_source":"metrics","name":"query8"},{"query":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}","data_source":"metrics","name":"query9"},{"query":"sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}","data_source":"metrics","name":"query10"},{"query":"sum:cpm_metric.dashboard_state.snapshots_disk_num{$host,$user} by {host}","data_source":"metrics","name":"query11"},{"query":"sum:cpm_metric.dashboard_state.snapshots_only_ami_num{$host,$user} by {host}","data_source":"metrics","name":"query12"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]}},{"id":1844247243659372,"layout":{"x":0,"y":44,"width":37,"height":25},"definition":{"title":"AWS Backups success over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}","on_right_yaxis":false,"metadata":[{"expression":"sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}","alias_name":"Successful EBS backups"},{"expression":"sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}","alias_name":"EBS backup failures"},{"expression":"sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}","alias_name":"Partially successful backups"}],"style":{"palette":"warm","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]}},{"id":5584509867253186,"layout":{"x":39,"y":44,"width":38,"height":25},"definition":{"title":"AWS Backups DR success over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} by {cpm}","on_right_yaxis":false,"metadata":[{"expression":"sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} by {cpm}","alias_name":"Successful DR backups"},{"expression":"sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user} by {cpm}","alias_name":"DR backups failure"},{"expression":"sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} by {cpm}","alias_name":"Partially successful DR backups"}],"style":{"palette":"cool","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]}},{"id":614497561179518,"layout":{"x":79,"y":44,"width":38,"height":25},"definition":{"title":"AWS S3 Backups success over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} by {cpm}","on_right_yaxis":false,"metadata":[{"expression":"sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} by {cpm}","alias_name":"Successful S3 backups"},{"expression":"sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user} by {cpm}","alias_name":"S3 backups failure"},{"expression":"sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} by {cpm}","alias_name":"Partially successful S3 backups"}],"style":{"palette":"orange","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]}},{"id":7180936149683416,"layout":{"x":0,"y":71,"width":60,"height":26},"definition":{"title":"Alerts gathering for all hosts","title_size":"16","title_align":"left","type":"event_stream","query":"sources:n2ws hosts:$host cpm:$user","tags_execution":"and","event_size":"l"}},{"id":5945986900303426,"layout":{"x":103,"y":16,"width":9,"height":6},"definition":{"title":"Instances","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_instances_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":4419154600287480,"layout":{"x":123,"y":23,"width":9,"height":6},"definition":{"title":"EFS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_efs_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":1935790075102,"layout":{"x":113,"y":23,"width":9,"height":6},"definition":{"title":"Redshift","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_redshift_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":7971473927039272,"layout":{"x":123,"y":16,"width":9,"height":6},"definition":{"title":"RDS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_rds_db_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":3588851606457020,"layout":{"x":113,"y":16,"width":9,"height":6},"definition":{"title":"Volumes","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_volumes_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":2}},{"id":981117228066646,"layout":{"x":103,"y":23,"width":9,"height":6},"definition":{"title":"Dynamo DB","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_ddb_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":7374759144596838,"layout":{"x":133,"y":16,"width":9,"height":6},"definition":{"title":"Aurora","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_rds_clus_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":6182576205949094,"layout":{"x":0,"y":8,"width":34,"height":7},"definition":{"type":"note","content":"This dashboard summarizes data collected from N2WS Backup & Recovery v4.0 hosts connected to DataDog","background_color":"white","font_size":"14","text_align":"left","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":163195945008220,"layout":{"x":36,"y":8,"width":25,"height":7},"definition":{"type":"note","content":"Success Rate","background_color":"yellow","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":2923528343457910,"layout":{"x":48,"y":16,"width":13,"height":8},"definition":{"type":"note","content":"### Azure & AWS\nIndicates percentage of backups that have succeeded. \nYou can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":8418227565588260,"layout":{"x":48,"y":25,"width":13,"height":8},"definition":{"type":"note","content":"### AWS Only\nIndicates percentage of DR (Disaster Recovery) backups that have succeeded. \nYou can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":8748196710797844,"layout":{"x":48,"y":34,"width":13,"height":8},"definition":{"type":"note","content":"### AWS Only\nIndicates percentage of S3 backups that have succeeded (Glacier backups aren't counted). \nYou can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":2007395944978376,"layout":{"x":63,"y":8,"width":25,"height":7},"definition":{"type":"note","content":"Total Summary","background_color":"yellow","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":3127155320728790,"layout":{"x":75,"y":16,"width":13,"height":8},"definition":{"type":"note","content":"Total number of accounts on all hosts for all clouds","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":7272280144470548,"layout":{"x":75,"y":25,"width":13,"height":8},"definition":{"type":"note","content":"Total number of policies on all hosts for all clouds","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":7845771991582078,"layout":{"x":90,"y":8,"width":66,"height":7},"definition":{"type":"note","content":"How many Entities have you protected?","background_color":"yellow","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":822785988778976,"layout":{"x":143,"y":16,"width":13,"height":27},"definition":{"type":"note","content":"Tracks number of entities covered by policies by all N2WS Backup & Recovery hosts.\n\nPlease note that if an instance, for example, was covered by policies in 2 N2WS hosts, it will be  counted twice.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":7702466249586728,"layout":{"x":61,"y":71,"width":16,"height":26},"definition":{"type":"note","content":"DataDog and N2WS Backup & Recovery hosts alerts","background_color":"yellow","font_size":"24","text_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":6184828882153520,"layout":{"x":79,"y":71,"width":21,"height":8},"definition":{"title":"Average AWS Volume Capacity ","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_usage_percentage_num{$host,$user}","aggregator":"last","conditional_formats":[{"comparator":">","palette":"white_on_red","value":80},{"comparator":"<=","palette":"white_on_yellow","value":20},{"comparator":">","palette":"white_on_green","value":20},{"comparator":"<","palette":"white_on_green","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":5044747906249744,"layout":{"x":79,"y":80,"width":21,"height":8},"definition":{"title":"Volumes Above High Watermark","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_above_high_watermark_num{$host,$user}","aggregator":"last","conditional_formats":[{"comparator":">=","palette":"white_on_red","value":1},{"comparator":"<","palette":"white_on_green","value":1}]}],"text_align":"left","precision":0}},{"id":7142455690032772,"layout":{"x":101,"y":71,"width":38,"height":8},"definition":{"type":"note","content":"The average capacity of AWS volumes that were backed up by N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":6406821361983512,"layout":{"x":101,"y":80,"width":38,"height":8},"definition":{"type":"note","content":"Number of backed up AWS volumes that have capacity higher than the high watermark defined in N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":1223244874390138,"layout":{"x":101,"y":89,"width":38,"height":8},"definition":{"type":"note","content":"Number of backed up AWS volumes that have capacity lower than the low watermark defined in N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":437205163209710,"layout":{"x":79,"y":89,"width":21,"height":8},"definition":{"title":"Volumes Below Low Watermark","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_below_low_watermark_num{$host,$user}","aggregator":"last","conditional_formats":[{"comparator":">=","palette":"white_on_yellow","value":1},{"comparator":"<","palette":"white_on_green","value":1}]}],"text_align":"left","precision":0}},{"id":8357335241437432,"layout":{"x":140,"y":71,"width":16,"height":26},"definition":{"type":"note","content":"Backed Up Volumes Capacity Data","background_color":"yellow","font_size":"24","text_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":5429797099678030,"layout":{"x":133,"y":23,"width":9,"height":6},"definition":{"title":"FSx","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_fsx_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":6393622216634412,"layout":{"x":103,"y":30,"width":9,"height":6},"definition":{"title":"VMs","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_virtual_machines_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":1335830288842960,"layout":{"x":103,"y":37,"width":9,"height":6},"definition":{"title":"Disks","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_disks_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":6343939055837336,"layout":{"x":90,"y":16,"width":12,"height":13},"definition":{"type":"note","content":"AWS","background_color":"vivid_orange","font_size":"24","text_align":"center","vertical_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"right","has_padding":false}},{"id":7126009984198560,"layout":{"x":90,"y":30,"width":12,"height":13},"definition":{"type":"note","content":"Azure","background_color":"blue","font_size":"24","text_align":"center","vertical_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"right","has_padding":true}}],"template_variables":[{"name":"host","default":"*","prefix":"host","available_values":[]},{"name":"user","default":"*","prefix":"cpm","available_values":[]}],"layout_type":"free","is_read_only":false,"notify_list":[],"id":"jzx-fxj-umm"}
+{
+  "title": "N2WS Backup & Recovery v4.1 - Backup Success Rates (Column Graphs)",
+  "description": "## N2WS Backup & Recovery v4.1 Dashboard\n\nThis dashboard summarizes data that was collected from all N2WS Backup & Recovery v4.0 hosts that are connected to DataDog",
+  "widgets": [
+    {
+      "id": 2637556285457016,
+      "layout": { "x": 63, "y": 16, "width": 11, "height": 8 },
+      "definition": {
+        "title": "Accounts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.azure_accounts_num{$host,$user}+sum:cpm_metric.dashboard_state.accounts_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [
+          {
+            "link": "https://{{host.value}}/ui/dashboard/",
+            "label": "Go to host's Dashboard"
+          }
+        ],
+        "precision": 0
+      }
+    },
+    {
+      "id": 1132115760137398,
+      "layout": { "x": 63, "y": 25, "width": 11, "height": 8 },
+      "definition": {
+        "title": "Policies",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.azure_policies_num{$host,$user}+sum:cpm_metric.dashboard_state.policies_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 6833713613288876,
+      "layout": { "x": 12, "y": 0, "width": 24, "height": 6 },
+      "definition": {
+        "type": "free_text",
+        "text": "N2WS Backup & Recovery  v4.1 Servers Status",
+        "color": "#2B13E6",
+        "font_size": "56",
+        "text_align": "left"
+      }
+    },
+    {
+      "id": 3660811894528512,
+      "layout": { "x": 0, "y": 16, "width": 34, "height": 26 },
+      "definition": {
+        "title": "Available hosts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "hostmap",
+        "requests": { "fill": { "q": "avg:system.cpu.user{*} by {host}" } },
+        "node_type": "host",
+        "no_metric_hosts": false,
+        "no_group_hosts": true,
+        "custom_links": [
+          {
+            "link": "https://{{$ip.value}}/ui/dashboard/",
+            "label": "Go to host's Dashboard"
+          }
+        ],
+        "style": { "palette": "green_to_orange", "palette_flip": false }
+      }
+    },
+    {
+      "id": 4889683502691186,
+      "layout": { "x": 36, "y": 16, "width": 11, "height": 8 },
+      "definition": {
+        "title": "Simple Backups",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user}))*100",
+            "aggregator": "avg",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 4495620089867176,
+      "layout": { "x": 36, "y": 25, "width": 11, "height": 8 },
+      "definition": {
+        "title": "DR backups",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user}))*100",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 7599208437230966,
+      "layout": { "x": 36, "y": 34, "width": 11, "height": 8 },
+      "definition": {
+        "title": "Backup to S3",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user}))*100",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 4085517614690048,
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 8 },
+      "definition": {
+        "type": "image",
+        "url": "https://n2ws.com/wp-content/uploads/2018/10/N2WS_Logo-Primary-2.svg",
+        "sizing": "fit"
+      }
+    },
+    {
+      "id": 2595322878823152,
+      "layout": { "x": 119, "y": 44, "width": 37, "height": 25 },
+      "definition": {
+        "title": "Total amount of snapshots by type over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "vertical",
+        "legend_columns": ["value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [
+              { "alias": "DynamoDB snapshots ", "formula": "query1" },
+              { "alias": "EFS snapshots", "formula": "query2" },
+              { "alias": "RDS snapshots", "formula": "query3" },
+              { "alias": "DR RDS snapshots", "formula": "query4" },
+              { "alias": "Volumes snapshots", "formula": "query5" },
+              { "alias": "Aurora snapshots", "formula": "query6" },
+              { "alias": "Redshift snapshots", "formula": "query7" },
+              { "alias": "DR Volume snapshots", "formula": "query8" },
+              { "alias": "DR Aurora snapshots", "formula": "query9" },
+              { "alias": "FSx snapshots", "formula": "query10" },
+              { "alias": "Azure Disks", "formula": "query11" },
+              { "alias": "Only AMI snapshots", "formula": "query12" }
+            ],
+            "response_format": "timeseries",
+            "on_right_yaxis": false,
+            "queries": [
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query1"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query2"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query3"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query4"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query5"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query6"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query7"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query8"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query9"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query10"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_disk_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query11"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_only_ami_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query12"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 1844247243659372,
+      "layout": { "x": 0, "y": 44, "width": 37, "height": 25 },
+      "definition": {
+        "title": "AWS Backups success over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}",
+            "on_right_yaxis": false,
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}",
+                "alias_name": "Successful EBS backups"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}",
+                "alias_name": "EBS backup failures"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}",
+                "alias_name": "Partially successful backups"
+              }
+            ],
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 5584509867253186,
+      "layout": { "x": 39, "y": 44, "width": 38, "height": 25 },
+      "definition": {
+        "title": "AWS Backups DR success over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} by {cpm}",
+            "on_right_yaxis": false,
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} by {cpm}",
+                "alias_name": "Successful DR backups"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user} by {cpm}",
+                "alias_name": "DR backups failure"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} by {cpm}",
+                "alias_name": "Partially successful DR backups"
+              }
+            ],
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 614497561179518,
+      "layout": { "x": 79, "y": 44, "width": 38, "height": 25 },
+      "definition": {
+        "title": "AWS S3 Backups success over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} by {cpm}",
+            "on_right_yaxis": false,
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} by {cpm}",
+                "alias_name": "Successful S3 backups"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user} by {cpm}",
+                "alias_name": "S3 backups failure"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} by {cpm}",
+                "alias_name": "Partially successful S3 backups"
+              }
+            ],
+            "style": {
+              "palette": "orange",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 7180936149683416,
+      "layout": { "x": 0, "y": 71, "width": 60, "height": 26 },
+      "definition": {
+        "title": "Alerts gathering for all hosts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "event_stream",
+        "query": "sources:n2ws hosts:$host cpm:$user",
+        "tags_execution": "and",
+        "event_size": "l"
+      }
+    },
+    {
+      "id": 5945986900303426,
+      "layout": { "x": 103, "y": 16, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Instances",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_instances_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4419154600287480,
+      "layout": { "x": 123, "y": 23, "width": 9, "height": 6 },
+      "definition": {
+        "title": "EFS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_efs_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 1935790075102,
+      "layout": { "x": 113, "y": 23, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Redshift",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_redshift_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 7971473927039272,
+      "layout": { "x": 123, "y": 16, "width": 9, "height": 6 },
+      "definition": {
+        "title": "RDS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_rds_db_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 3588851606457020,
+      "layout": { "x": 113, "y": 16, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Volumes",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_volumes_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 2
+      }
+    },
+    {
+      "id": 981117228066646,
+      "layout": { "x": 103, "y": 23, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Dynamo DB",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_ddb_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 7374759144596838,
+      "layout": { "x": 133, "y": 16, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Aurora",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_rds_clus_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 6182576205949094,
+      "layout": { "x": 0, "y": 8, "width": 34, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "This dashboard summarizes data collected from N2WS Backup & Recovery v4.0 hosts connected to DataDog",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 163195945008220,
+      "layout": { "x": 36, "y": 8, "width": 25, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Success Rate",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 2923528343457910,
+      "layout": { "x": 48, "y": 16, "width": 13, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "### Azure & AWS\nIndicates percentage of backups that have succeeded. \nYou can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 8418227565588260,
+      "layout": { "x": 48, "y": 25, "width": 13, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "### AWS Only\nIndicates percentage of DR (Disaster Recovery) backups that have succeeded. \nYou can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 8748196710797844,
+      "layout": { "x": 48, "y": 34, "width": 13, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "### AWS Only\nIndicates percentage of S3 backups that have succeeded (Glacier backups aren't counted). \nYou can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 2007395944978376,
+      "layout": { "x": 63, "y": 8, "width": 25, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Total Summary",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 3127155320728790,
+      "layout": { "x": 75, "y": 16, "width": 13, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Total number of accounts on all hosts for all clouds",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 7272280144470548,
+      "layout": { "x": 75, "y": 25, "width": 13, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Total number of policies on all hosts for all clouds",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 7845771991582078,
+      "layout": { "x": 90, "y": 8, "width": 66, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "How many Entities have you protected?",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 822785988778976,
+      "layout": { "x": 143, "y": 16, "width": 13, "height": 27 },
+      "definition": {
+        "type": "note",
+        "content": "Tracks number of entities covered by policies by all N2WS Backup & Recovery hosts.\n\nPlease note that if an instance, for example, was covered by policies in 2 N2WS hosts, it will be  counted twice.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 7702466249586728,
+      "layout": { "x": 61, "y": 71, "width": 16, "height": 26 },
+      "definition": {
+        "type": "note",
+        "content": "DataDog and N2WS Backup & Recovery hosts alerts",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 6184828882153520,
+      "layout": { "x": 79, "y": 71, "width": 21, "height": 8 },
+      "definition": {
+        "title": "Average AWS Volume Capacity ",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_usage_percentage_num{$host,$user}",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_red", "value": 80 },
+              { "comparator": "<=", "palette": "white_on_yellow", "value": 20 },
+              { "comparator": ">", "palette": "white_on_green", "value": 20 },
+              { "comparator": "<", "palette": "white_on_green", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 5044747906249744,
+      "layout": { "x": 79, "y": 80, "width": 21, "height": 8 },
+      "definition": {
+        "title": "Volumes Above High Watermark",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_above_high_watermark_num{$host,$user}",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">=", "palette": "white_on_red", "value": 1 },
+              { "comparator": "<", "palette": "white_on_green", "value": 1 }
+            ]
+          }
+        ],
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 7142455690032772,
+      "layout": { "x": 101, "y": 71, "width": 38, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "The average capacity of AWS volumes that were backed up by N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 6406821361983512,
+      "layout": { "x": 101, "y": 80, "width": 38, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up AWS volumes that have capacity higher than the high watermark defined in N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 1223244874390138,
+      "layout": { "x": 101, "y": 89, "width": 38, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up AWS volumes that have capacity lower than the low watermark defined in N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 437205163209710,
+      "layout": { "x": 79, "y": 89, "width": 21, "height": 8 },
+      "definition": {
+        "title": "Volumes Below Low Watermark",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_below_low_watermark_num{$host,$user}",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">=", "palette": "white_on_yellow", "value": 1 },
+              { "comparator": "<", "palette": "white_on_green", "value": 1 }
+            ]
+          }
+        ],
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 8357335241437432,
+      "layout": { "x": 140, "y": 71, "width": 16, "height": 26 },
+      "definition": {
+        "type": "note",
+        "content": "Backed Up Volumes Capacity Data",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 5429797099678030,
+      "layout": { "x": 133, "y": 23, "width": 9, "height": 6 },
+      "definition": {
+        "title": "FSx",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_fsx_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 6393622216634412,
+      "layout": { "x": 103, "y": 30, "width": 9, "height": 6 },
+      "definition": {
+        "title": "VMs",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_virtual_machines_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 1335830288842960,
+      "layout": { "x": 103, "y": 37, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Disks",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_disks_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 6343939055837336,
+      "layout": { "x": 90, "y": 16, "width": 12, "height": 13 },
+      "definition": {
+        "type": "note",
+        "content": "AWS",
+        "background_color": "vivid_orange",
+        "font_size": "24",
+        "text_align": "center",
+        "vertical_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "right",
+        "has_padding": false
+      }
+    },
+    {
+      "id": 7126009984198560,
+      "layout": { "x": 90, "y": 30, "width": 12, "height": 13 },
+      "definition": {
+        "type": "note",
+        "content": "Azure",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "vertical_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "right",
+        "has_padding": true
+      }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "host",
+      "default": "*",
+      "prefix": "host",
+      "available_values": []
+    },
+    { "name": "user", "default": "*", "prefix": "cpm", "available_values": [] }
+  ],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": []
+}

--- a/n2ws/assets/dashboards/N2WSBackup&Recoveryv4.1-EntityTypesDetails.json
+++ b/n2ws/assets/dashboards/N2WSBackup&Recoveryv4.1-EntityTypesDetails.json
@@ -1,1 +1,1098 @@
-{"title":"N2WS Backup & Recovery v4.1 - Entity Types Details","description":"## N2WS Backup & Recovery version 4.1 - Detailed Dashboard by Entity Type \n\nThis dashboard summarizes data that was collected from all N2WS Backup & Recovery hosts that are connected to DataDog, giving more details about entities types","widgets":[{"id":6833713613288876,"layout":{"x":13,"y":0,"width":24,"height":6},"definition":{"type":"free_text","text":"N2WS Backup & Recovery v4.1  Servers Status","color":"#2B13E6","font_size":"56","text_align":"left"}},{"id":4085517614690048,"layout":{"x":0,"y":0,"width":12,"height":8},"definition":{"type":"image","url":"https://n2ws.com/wp-content/uploads/2018/10/N2WS_Logo-Primary-2.svg","sizing":"fit"}},{"id":3059142389457708,"layout":{"x":14,"y":53,"width":10,"height":6},"definition":{"title":"Instances","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_instances_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":4931723730478434,"layout":{"x":25,"y":67,"width":9,"height":6},"definition":{"title":"FSx","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_fsx_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":2428912746970058,"layout":{"x":35,"y":60,"width":9,"height":6},"definition":{"title":"Redshift","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_redshift_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":6882875583965308,"layout":{"x":35,"y":53,"width":9,"height":6},"definition":{"title":"RDS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_rds_db_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":1705799585091706,"layout":{"x":25,"y":53,"width":9,"height":6},"definition":{"title":"Volumes","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_volumes_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":2}},{"id":1828199094188556,"layout":{"x":25,"y":60,"width":9,"height":6},"definition":{"title":"Dynamo DB","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_ddb_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":5138781865653636,"layout":{"x":14,"y":60,"width":10,"height":6},"definition":{"title":"Aurora","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_rds_clus_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":5429842537420874,"layout":{"x":66,"y":60,"width":9,"height":6},"definition":{"title":"EFS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":2150896737699084,"layout":{"x":56,"y":60,"width":9,"height":6},"definition":{"title":"Redshift","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":4378878990717088,"layout":{"x":56,"y":53,"width":9,"height":6},"definition":{"title":"RDS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":1372798678484004,"layout":{"x":46,"y":53,"width":9,"height":6},"definition":{"title":"Volumes","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":2}},{"id":5430267548904274,"layout":{"x":46,"y":60,"width":9,"height":6},"definition":{"title":"Dynamo DB","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":6866015780446286,"layout":{"x":66,"y":53,"width":9,"height":6},"definition":{"title":"Aurora","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":4189990561597372,"layout":{"x":96,"y":53,"width":8,"height":6},"definition":{"title":"EFS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_dr_efs_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":3804091029771224,"layout":{"x":87,"y":53,"width":8,"height":6},"definition":{"title":"RDS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":2376719938053794,"layout":{"x":77,"y":53,"width":9,"height":6},"definition":{"title":"Volumes","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":2595322878823152,"layout":{"x":106,"y":16,"width":54,"height":25},"definition":{"title":"Total amount of snapshots for all hosts by time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"vertical","legend_columns":["value","sum"],"type":"timeseries","requests":[{"formulas":[{"alias":"DynamoDB snapshots ","formula":"query1"},{"alias":"EFS snapshots","formula":"query2"},{"alias":"RDS snapshots","formula":"query3"},{"alias":"DR RDS snapshots","formula":"query4"},{"alias":"Volumes snapshots","formula":"query5"},{"alias":"Aurora snapshots","formula":"query6"},{"alias":"Redshift snapshots","formula":"query7"},{"alias":"DR Volumes snapshots","formula":"query8"},{"alias":"DR Aurora snapshots","formula":"query9"},{"alias":"FSx snapshots","formula":"query10"},{"alias":"Disks snapshots","formula":"query11"},{"alias":"Only AMI","formula":"query12"},{"alias":"Summary","formula":"query1 + query2 + query3 + query4 + query5 + query6 + query7 + query8 + query9 + query10 + query11 + query12"}],"response_format":"timeseries","queries":[{"query":"sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}","data_source":"metrics","name":"query1"},{"query":"sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}","data_source":"metrics","name":"query2"},{"query":"sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}","data_source":"metrics","name":"query3"},{"query":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}","data_source":"metrics","name":"query4"},{"query":"sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}","data_source":"metrics","name":"query5"},{"query":"sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}","data_source":"metrics","name":"query6"},{"query":"sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}","data_source":"metrics","name":"query7"},{"query":"sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}","data_source":"metrics","name":"query8"},{"query":"sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}","data_source":"metrics","name":"query9"},{"query":"sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}","data_source":"metrics","name":"query10"},{"query":"sum:cpm_metric.dashboard_state.snapshots_disk_num{$host,$user} by {host}","data_source":"metrics","name":"query11"},{"query":"sum:cpm_metric.dashboard_state.snapshots_only_ami_num{$host,$user} by {host}","data_source":"metrics","name":"query12"}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]}},{"id":5713746525788918,"layout":{"x":0,"y":81,"width":75,"height":23},"definition":{"title":"Alerts gathering for all hosts","title_size":"16","title_align":"left","type":"event_stream","query":"sources:n2ws hosts:$host cpm:$user","tags_execution":"and","event_size":"l"}},{"id":6784160051087150,"layout":{"x":106,"y":43,"width":54,"height":30},"definition":{"title":"Backups success over time","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"q":"sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}","on_right_yaxis":false,"metadata":[{"expression":"sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}","alias_name":"Successful EBS backups"},{"expression":"sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}","alias_name":"EBS backup failures"},{"expression":"sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}","alias_name":"Partially successful backups"}],"style":{"palette":"warm","line_type":"solid","line_width":"normal"},"display_type":"area"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]}},{"id":208539378395674,"layout":{"x":77,"y":16,"width":12,"height":8},"definition":{"title":"Accounts","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.azure_accounts_num{$host,$user}+sum:cpm_metric.dashboard_state.accounts_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[{"link":"https://{{host.value}}/ui/dashboard/","label":"Go to host's Dashboard"}],"precision":0}},{"id":4250125984175390,"layout":{"x":77,"y":25,"width":12,"height":8},"definition":{"title":"Policies","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.azure_policies_num{$host,$user}+sum:cpm_metric.dashboard_state.policies_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":3509183830204216,"layout":{"x":0,"y":16,"width":44,"height":26},"definition":{"title":"Available hosts","title_size":"16","title_align":"left","type":"hostmap","requests":{"fill":{"q":"avg:system.cpu.user{*} by {host}"}},"node_type":"host","no_metric_hosts":false,"no_group_hosts":true,"custom_links":[{"link":"https://{{$ip.value}}/ui/dashboard/","label":"Go to host's Dashboard"}],"style":{"palette":"green_to_orange","palette_flip":false}}},{"id":3358821477019238,"layout":{"x":46,"y":16,"width":12,"height":8},"definition":{"title":"Simple Backups","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user}))*100","aggregator":"avg","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":">","palette":"white_on_yellow","value":50},{"comparator":"<","palette":"white_on_yellow","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":3053098348251140,"layout":{"x":46,"y":25,"width":12,"height":8},"definition":{"title":"DR backups","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} / (sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} + sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} + sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user})) * 100","aggregator":"last","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":"<","palette":"white_on_yellow","value":80},{"comparator":">","palette":"white_on_yellow","value":50}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":7487526937796298,"layout":{"x":46,"y":34,"width":12,"height":8},"definition":{"title":"Backup to S3","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} / (sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} + sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} + sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user})) * 100","aggregator":"last","conditional_formats":[{"comparator":">","palette":"white_on_green","value":80},{"comparator":"<=","palette":"black_on_light_red","value":50},{"comparator":">","palette":"white_on_yellow","value":50},{"comparator":"<","palette":"white_on_yellow","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":892259706152026,"layout":{"x":0,"y":8,"width":44,"height":7},"definition":{"type":"note","content":"This dashboard summarizes data collected from N2WS Backup & Recovery version 4.1 hosts connected to DataDog","background_color":"white","font_size":"14","text_align":"left","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":776355987885820,"layout":{"x":46,"y":8,"width":29,"height":7},"definition":{"type":"note","content":"Success Rate","background_color":"yellow","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":1332884223536476,"layout":{"x":59,"y":16,"width":16,"height":8},"definition":{"type":"note","content":"### Azure & AWS\nIndicates percentage of backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":1122155945778222,"layout":{"x":59,"y":34,"width":16,"height":8},"definition":{"type":"note","content":"### AWS Only\nIndicates percentage of S3 backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":8947443314726402,"layout":{"x":77,"y":8,"width":27,"height":7},"definition":{"type":"note","content":"Total Summary","background_color":"yellow","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":8276039098984018,"layout":{"x":90,"y":16,"width":14,"height":8},"definition":{"type":"note","content":"Total number of accounts on all hosts and all clouds","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":456777395312592,"layout":{"x":90,"y":25,"width":14,"height":8},"definition":{"type":"note","content":"Total number of policies on all hosts","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":427414507061190,"layout":{"x":14,"y":43,"width":30,"height":9},"definition":{"type":"note","content":"Number of backed up entities by type","background_color":"yellow","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}},{"id":1021831416109504,"layout":{"x":46,"y":43,"width":29,"height":9},"definition":{"type":"note","content":"Number of backed up snapshots by type","background_color":"yellow","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}},{"id":177738093370028,"layout":{"x":77,"y":43,"width":27,"height":9},"definition":{"type":"note","content":"Number of backed up DR snapshots by type","background_color":"yellow","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}},{"id":8191563201835872,"layout":{"x":106,"y":8,"width":54,"height":7},"definition":{"type":"note","content":"Backups over time","background_color":"yellow","font_size":"24","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":6947773291986968,"layout":{"x":77,"y":75,"width":28,"height":9},"definition":{"title":"Average AWS Volume Capacity ","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_usage_percentage_num{$host,$user}","aggregator":"avg","conditional_formats":[{"comparator":">","palette":"white_on_red","value":80},{"comparator":"<=","palette":"white_on_yellow","value":20},{"comparator":">","palette":"white_on_green","value":20},{"comparator":"<","palette":"white_on_green","value":80}]}],"custom_unit":"%","text_align":"left","precision":0}},{"id":3448787702420418,"layout":{"x":77,"y":85,"width":28,"height":9},"definition":{"title":"Volumes Above High Watermark","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_above_high_watermark_num{$host,$user}","aggregator":"last","conditional_formats":[{"comparator":">=","palette":"white_on_red","value":1},{"comparator":"<","palette":"white_on_green","value":1}]}],"text_align":"left","precision":0}},{"id":3674873670941034,"layout":{"x":106,"y":75,"width":37,"height":9},"definition":{"type":"note","content":"The average capacity of AWS volumes that were backed up by N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":2877859327576680,"layout":{"x":106,"y":85,"width":37,"height":9},"definition":{"type":"note","content":"Number of backed up AWS volumes that have capacity higher than the high watermark defined in N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":718476280112238,"layout":{"x":106,"y":95,"width":37,"height":9},"definition":{"type":"note","content":"Number of backed up AWS volumes that have capacity lower than the low watermark defined in N2WS Backup & Recovery","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":6879791920341324,"layout":{"x":77,"y":95,"width":28,"height":9},"definition":{"title":"Volumes Below Low Watermark","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.volumes_below_low_watermark_num{$host,$user}","aggregator":"last","conditional_formats":[{"comparator":">=","palette":"white_on_yellow","value":1},{"comparator":"<","palette":"white_on_green","value":1}]}],"text_align":"left","precision":0}},{"id":1382593931662556,"layout":{"x":144,"y":75,"width":16,"height":29},"definition":{"type":"note","content":"Backed Up Volumes Capacity Data","background_color":"yellow","font_size":"24","text_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":803122310080746,"layout":{"x":59,"y":25,"width":16,"height":8},"definition":{"type":"note","content":"### AWS Only\nIndicates percentage of DR (Disaster Recovery) backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.","background_color":"white","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"left"}},{"id":1058098339957476,"layout":{"x":56,"y":67,"width":9,"height":6},"definition":{"title":"FSx","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":4879977658802298,"layout":{"x":14,"y":67,"width":10,"height":6},"definition":{"title":"EFS","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_efs_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","custom_links":[],"precision":0}},{"id":3832787504859262,"layout":{"x":0,"y":53,"width":12,"height":20},"definition":{"type":"note","content":"AWS","background_color":"vivid_orange","font_size":"24","text_align":"center","vertical_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"right","has_padding":true}},{"id":8106805195027988,"layout":{"x":0,"y":74,"width":12,"height":6},"definition":{"type":"note","content":"Azure","background_color":"blue","font_size":"24","text_align":"center","vertical_align":"center","show_tick":true,"tick_pos":"50%","tick_edge":"right","has_padding":false}},{"id":8799569878928592,"layout":{"x":14,"y":74,"width":10,"height":6},"definition":{"title":"VMs","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_virtual_machines_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":4757252460925168,"layout":{"x":25,"y":74,"width":9,"height":6},"definition":{"title":"Disks","title_size":"13","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.protected_disks_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}},{"id":2210684601100064,"layout":{"x":56,"y":74,"width":9,"height":6},"definition":{"title":"Disks","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"sum:cpm_metric.dashboard_state.snapshots_disk_num{$host,$user}","aggregator":"last"}],"autoscale":true,"text_align":"left","precision":0}}],"template_variables":[{"name":"host","default":"*","prefix":"host","available_values":[]},{"name":"user","default":"*","prefix":"cpm","available_values":[]}],"layout_type":"free","is_read_only":false,"notify_list":[],"id":"v9h-4dp-u3w"}
+{
+  "title": "N2WS Backup & Recovery v4.1 - Entity Types Details",
+  "description": "## N2WS Backup & Recovery version 4.1 - Detailed Dashboard by Entity Type \n\nThis dashboard summarizes data that was collected from all N2WS Backup & Recovery hosts that are connected to DataDog, giving more details about entities types",
+  "widgets": [
+    {
+      "id": 6833713613288876,
+      "layout": { "x": 13, "y": 0, "width": 24, "height": 6 },
+      "definition": {
+        "type": "free_text",
+        "text": "N2WS Backup & Recovery v4.1  Servers Status",
+        "color": "#2B13E6",
+        "font_size": "56",
+        "text_align": "left"
+      }
+    },
+    {
+      "id": 4085517614690048,
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 8 },
+      "definition": {
+        "type": "image",
+        "url": "https://n2ws.com/wp-content/uploads/2018/10/N2WS_Logo-Primary-2.svg",
+        "sizing": "fit"
+      }
+    },
+    {
+      "id": 3059142389457708,
+      "layout": { "x": 14, "y": 53, "width": 10, "height": 6 },
+      "definition": {
+        "title": "Instances",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_instances_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4931723730478434,
+      "layout": { "x": 25, "y": 67, "width": 9, "height": 6 },
+      "definition": {
+        "title": "FSx",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_fsx_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 2428912746970058,
+      "layout": { "x": 35, "y": 60, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Redshift",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_redshift_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 6882875583965308,
+      "layout": { "x": 35, "y": 53, "width": 9, "height": 6 },
+      "definition": {
+        "title": "RDS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_rds_db_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 1705799585091706,
+      "layout": { "x": 25, "y": 53, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Volumes",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_volumes_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 2
+      }
+    },
+    {
+      "id": 1828199094188556,
+      "layout": { "x": 25, "y": 60, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Dynamo DB",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_ddb_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 5138781865653636,
+      "layout": { "x": 14, "y": 60, "width": 10, "height": 6 },
+      "definition": {
+        "title": "Aurora",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_rds_clus_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 5429842537420874,
+      "layout": { "x": 66, "y": 60, "width": 9, "height": 6 },
+      "definition": {
+        "title": "EFS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 2150896737699084,
+      "layout": { "x": 56, "y": 60, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Redshift",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4378878990717088,
+      "layout": { "x": 56, "y": 53, "width": 9, "height": 6 },
+      "definition": {
+        "title": "RDS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 1372798678484004,
+      "layout": { "x": 46, "y": 53, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Volumes",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 2
+      }
+    },
+    {
+      "id": 5430267548904274,
+      "layout": { "x": 46, "y": 60, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Dynamo DB",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 6866015780446286,
+      "layout": { "x": 66, "y": 53, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Aurora",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4189990561597372,
+      "layout": { "x": 96, "y": 53, "width": 8, "height": 6 },
+      "definition": {
+        "title": "EFS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_dr_efs_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 3804091029771224,
+      "layout": { "x": 87, "y": 53, "width": 8, "height": 6 },
+      "definition": {
+        "title": "RDS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 2376719938053794,
+      "layout": { "x": 77, "y": 53, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Volumes",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 2595322878823152,
+      "layout": { "x": 106, "y": 16, "width": 54, "height": 25 },
+      "definition": {
+        "title": "Total amount of snapshots for all hosts by time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "vertical",
+        "legend_columns": ["value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [
+              { "alias": "DynamoDB snapshots ", "formula": "query1" },
+              { "alias": "EFS snapshots", "formula": "query2" },
+              { "alias": "RDS snapshots", "formula": "query3" },
+              { "alias": "DR RDS snapshots", "formula": "query4" },
+              { "alias": "Volumes snapshots", "formula": "query5" },
+              { "alias": "Aurora snapshots", "formula": "query6" },
+              { "alias": "Redshift snapshots", "formula": "query7" },
+              { "alias": "DR Volumes snapshots", "formula": "query8" },
+              { "alias": "DR Aurora snapshots", "formula": "query9" },
+              { "alias": "FSx snapshots", "formula": "query10" },
+              { "alias": "Disks snapshots", "formula": "query11" },
+              { "alias": "Only AMI", "formula": "query12" },
+              {
+                "alias": "Summary",
+                "formula": "query1 + query2 + query3 + query4 + query5 + query6 + query7 + query8 + query9 + query10 + query11 + query12"
+              }
+            ],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_ddb_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query1"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_efs_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query2"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_rds_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query3"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query4"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_volume_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query5"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_rds_clus_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query6"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_redshift_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query7"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_dr_volume_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query8"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_dr_rds_clus_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query9"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query10"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_disk_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query11"
+              },
+              {
+                "query": "sum:cpm_metric.dashboard_state.snapshots_only_ami_num{$host,$user} by {host}",
+                "data_source": "metrics",
+                "name": "query12"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 5713746525788918,
+      "layout": { "x": 0, "y": 81, "width": 75, "height": 23 },
+      "definition": {
+        "title": "Alerts gathering for all hosts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "event_stream",
+        "query": "sources:n2ws hosts:$host cpm:$user",
+        "tags_execution": "and",
+        "event_size": "l"
+      }
+    },
+    {
+      "id": 6784160051087150,
+      "layout": { "x": 106, "y": 43, "width": 54, "height": 30 },
+      "definition": {
+        "title": "Backups success over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}, sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}",
+            "on_right_yaxis": false,
+            "metadata": [
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user} by {cpm}",
+                "alias_name": "Successful EBS backups"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user} by {cpm}",
+                "alias_name": "EBS backup failures"
+              },
+              {
+                "expression": "sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user} by {cpm}",
+                "alias_name": "Partially successful backups"
+              }
+            ],
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "area"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 208539378395674,
+      "layout": { "x": 77, "y": 16, "width": 12, "height": 8 },
+      "definition": {
+        "title": "Accounts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.azure_accounts_num{$host,$user}+sum:cpm_metric.dashboard_state.accounts_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [
+          {
+            "link": "https://{{host.value}}/ui/dashboard/",
+            "label": "Go to host's Dashboard"
+          }
+        ],
+        "precision": 0
+      }
+    },
+    {
+      "id": 4250125984175390,
+      "layout": { "x": 77, "y": 25, "width": 12, "height": 8 },
+      "definition": {
+        "title": "Policies",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.azure_policies_num{$host,$user}+sum:cpm_metric.dashboard_state.policies_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 3509183830204216,
+      "layout": { "x": 0, "y": 16, "width": 44, "height": 26 },
+      "definition": {
+        "title": "Available hosts",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "hostmap",
+        "requests": { "fill": { "q": "avg:system.cpu.user{*} by {host}" } },
+        "node_type": "host",
+        "no_metric_hosts": false,
+        "no_group_hosts": true,
+        "custom_links": [
+          {
+            "link": "https://{{$ip.value}}/ui/dashboard/",
+            "label": "Go to host's Dashboard"
+          }
+        ],
+        "style": { "palette": "green_to_orange", "palette_flip": false }
+      }
+    },
+    {
+      "id": 3358821477019238,
+      "layout": { "x": 46, "y": 16, "width": 12, "height": 8 },
+      "definition": {
+        "title": "Simple Backups",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}/(sum:cpm_metric.dashboard_activity.backup_success_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_partial_num{$host,$user}+sum:cpm_metric.dashboard_activity.backup_fail_num{$host,$user}))*100",
+            "aggregator": "avg",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 3053098348251140,
+      "layout": { "x": 46, "y": 25, "width": 12, "height": 8 },
+      "definition": {
+        "title": "DR backups",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} / (sum:cpm_metric.dashboard_activity.backup_dr_success_num{$host,$user} + sum:cpm_metric.dashboard_activity.backup_dr_partial_num{$host,$user} + sum:cpm_metric.dashboard_activity.backup_dr_fail_num{$host,$user})) * 100",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 7487526937796298,
+      "layout": { "x": 46, "y": 34, "width": 12, "height": 8 },
+      "definition": {
+        "title": "Backup to S3",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} / (sum:cpm_metric.dashboard_activity.backup_s3_success_num{$host,$user} + sum:cpm_metric.dashboard_activity.backup_s3_partial_num{$host,$user} + sum:cpm_metric.dashboard_activity.backup_s3_fail_num{$host,$user})) * 100",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_green", "value": 80 },
+              {
+                "comparator": "<=",
+                "palette": "black_on_light_red",
+                "value": 50
+              },
+              { "comparator": ">", "palette": "white_on_yellow", "value": 50 },
+              { "comparator": "<", "palette": "white_on_yellow", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 892259706152026,
+      "layout": { "x": 0, "y": 8, "width": 44, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "This dashboard summarizes data collected from N2WS Backup & Recovery version 4.1 hosts connected to DataDog",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 776355987885820,
+      "layout": { "x": 46, "y": 8, "width": 29, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Success Rate",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 1332884223536476,
+      "layout": { "x": 59, "y": 16, "width": 16, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "### Azure & AWS\nIndicates percentage of backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 1122155945778222,
+      "layout": { "x": 59, "y": 34, "width": 16, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "### AWS Only\nIndicates percentage of S3 backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 8947443314726402,
+      "layout": { "x": 77, "y": 8, "width": 27, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Total Summary",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 8276039098984018,
+      "layout": { "x": 90, "y": 16, "width": 14, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Total number of accounts on all hosts and all clouds",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 456777395312592,
+      "layout": { "x": 90, "y": 25, "width": 14, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "Total number of policies on all hosts",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 427414507061190,
+      "layout": { "x": 14, "y": 43, "width": 30, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up entities by type",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 1021831416109504,
+      "layout": { "x": 46, "y": 43, "width": 29, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up snapshots by type",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 177738093370028,
+      "layout": { "x": 77, "y": 43, "width": 27, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up DR snapshots by type",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 8191563201835872,
+      "layout": { "x": 106, "y": 8, "width": 54, "height": 7 },
+      "definition": {
+        "type": "note",
+        "content": "Backups over time",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 6947773291986968,
+      "layout": { "x": 77, "y": 75, "width": 28, "height": 9 },
+      "definition": {
+        "title": "Average AWS Volume Capacity ",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_usage_percentage_num{$host,$user}",
+            "aggregator": "avg",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_red", "value": 80 },
+              { "comparator": "<=", "palette": "white_on_yellow", "value": 20 },
+              { "comparator": ">", "palette": "white_on_green", "value": 20 },
+              { "comparator": "<", "palette": "white_on_green", "value": 80 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 3448787702420418,
+      "layout": { "x": 77, "y": 85, "width": 28, "height": 9 },
+      "definition": {
+        "title": "Volumes Above High Watermark",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_above_high_watermark_num{$host,$user}",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">=", "palette": "white_on_red", "value": 1 },
+              { "comparator": "<", "palette": "white_on_green", "value": 1 }
+            ]
+          }
+        ],
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 3674873670941034,
+      "layout": { "x": 106, "y": 75, "width": 37, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "The average capacity of AWS volumes that were backed up by N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 2877859327576680,
+      "layout": { "x": 106, "y": 85, "width": 37, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up AWS volumes that have capacity higher than the high watermark defined in N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 718476280112238,
+      "layout": { "x": 106, "y": 95, "width": 37, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Number of backed up AWS volumes that have capacity lower than the low watermark defined in N2WS Backup & Recovery",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 6879791920341324,
+      "layout": { "x": 77, "y": 95, "width": 28, "height": 9 },
+      "definition": {
+        "title": "Volumes Below Low Watermark",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.volumes_below_low_watermark_num{$host,$user}",
+            "aggregator": "last",
+            "conditional_formats": [
+              { "comparator": ">=", "palette": "white_on_yellow", "value": 1 },
+              { "comparator": "<", "palette": "white_on_green", "value": 1 }
+            ]
+          }
+        ],
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 1382593931662556,
+      "layout": { "x": 144, "y": 75, "width": 16, "height": 29 },
+      "definition": {
+        "type": "note",
+        "content": "Backed Up Volumes Capacity Data",
+        "background_color": "yellow",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 803122310080746,
+      "layout": { "x": 59, "y": 25, "width": 16, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "### AWS Only\nIndicates percentage of DR (Disaster Recovery) backups that have succeeded. You can view all backup logs in the Backup Monitor to investigate failures further.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 1058098339957476,
+      "layout": { "x": 56, "y": 67, "width": 9, "height": 6 },
+      "definition": {
+        "title": "FSx",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_fsx_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 4879977658802298,
+      "layout": { "x": 14, "y": 67, "width": 10, "height": 6 },
+      "definition": {
+        "title": "EFS",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_efs_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "custom_links": [],
+        "precision": 0
+      }
+    },
+    {
+      "id": 3832787504859262,
+      "layout": { "x": 0, "y": 53, "width": 12, "height": 20 },
+      "definition": {
+        "type": "note",
+        "content": "AWS",
+        "background_color": "vivid_orange",
+        "font_size": "24",
+        "text_align": "center",
+        "vertical_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "right",
+        "has_padding": true
+      }
+    },
+    {
+      "id": 8106805195027988,
+      "layout": { "x": 0, "y": 74, "width": 12, "height": 6 },
+      "definition": {
+        "type": "note",
+        "content": "Azure",
+        "background_color": "blue",
+        "font_size": "24",
+        "text_align": "center",
+        "vertical_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "right",
+        "has_padding": false
+      }
+    },
+    {
+      "id": 8799569878928592,
+      "layout": { "x": 14, "y": 74, "width": 10, "height": 6 },
+      "definition": {
+        "title": "VMs",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_virtual_machines_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 4757252460925168,
+      "layout": { "x": 25, "y": 74, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Disks",
+        "title_size": "13",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.protected_disks_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    },
+    {
+      "id": 2210684601100064,
+      "layout": { "x": 56, "y": 74, "width": 9, "height": 6 },
+      "definition": {
+        "title": "Disks",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:cpm_metric.dashboard_state.snapshots_disk_num{$host,$user}",
+            "aggregator": "last"
+          }
+        ],
+        "autoscale": true,
+        "text_align": "left",
+        "precision": 0
+      }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "host",
+      "default": "*",
+      "prefix": "host",
+      "available_values": []
+    },
+    { "name": "user", "default": "*", "prefix": "cpm", "available_values": [] }
+  ],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": []
+}

--- a/open_policy_agent/assets/dashboards/open_policy_agent_overview.json
+++ b/open_policy_agent/assets/dashboards/open_policy_agent_overview.json
@@ -1,1 +1,250 @@
-{"title":"Open Policy Agent - Overview","description":"","widgets":[{"id":2525687926129783,"layout":{"x":0,"y":0,"width":29,"height":12},"definition":{"type":"image","url":"/static/images/logos/open-policy-agent_large.svg","sizing":"zoom"}},{"id":2373762142354972,"layout":{"x":96,"y":19,"width":47,"height":36},"definition":{"title":"Decision Logs","title_size":"16","title_align":"left","type":"log_stream","indexes":[],"query":"source:opa @msg:\"Decision Log\"","sort":{"column":"time","order":"desc"},"columns":["core_host","core_service"],"show_date_column":true,"show_message_column":true,"message_display":"expanded-md"}},{"id":8795394413575891,"layout":{"x":0,"y":13,"width":47,"height":5},"definition":{"type":"note","content":"OPA Decisions","background_color":"gray","font_size":"18","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}},{"id":2485976784376809,"layout":{"x":0,"y":19,"width":47,"height":15},"definition":{"title":"OPA decisions by result (allowed / not allowed)","title_size":"16","title_align":"left","show_legend":false,"type":"timeseries","requests":[{"q":"sum:opa.decisions{*} by {result.response.allowed}.as_count()","on_right_yaxis":false,"style":{"palette":"cool","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"},"markers":[]}},{"id":7368957134060938,"layout":{"x":0,"y":35,"width":47,"height":15},"definition":{"title":"OPA decisions by Kubernetes object kind","title_size":"16","title_align":"left","show_legend":false,"type":"timeseries","requests":[{"q":"sum:opa.decisions{*} by {input.request.kind.kind}.as_count()","on_right_yaxis":false,"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"},"markers":[]}},{"id":6829868450502189,"layout":{"x":48,"y":13,"width":47,"height":5},"definition":{"type":"note","content":"Requests to OPA","background_color":"gray","font_size":"18","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}},{"id":7137085095709307,"layout":{"x":48,"y":19,"width":47,"height":15},"definition":{"title":"Avg latency for OPA requests","title_size":"16","title_align":"left","show_legend":false,"time":{},"type":"timeseries","requests":[{"q":"avg:open_policy_agent.request.duration.sum{*}.as_count()/avg:open_policy_agent.request.duration.count{*}.as_count()","on_right_yaxis":false,"style":{"palette":"warm","line_type":"solid","line_width":"normal"},"display_type":"line"}],"yaxis":{"include_zero":false,"min":"0"},"markers":[]}},{"id":2789367939595781,"layout":{"x":30,"y":0,"width":15,"height":12},"definition":{"title":"OPA Service Status","title_size":"16","title_align":"center","type":"check_status","check":"open_policy_agent.health","grouping":"cluster","group_by":[],"tags":[]}},{"id":4443578023844538,"layout":{"x":48,"y":35,"width":47,"height":15},"definition":{"title":"Requests to OPA by response code","title_size":"16","title_align":"left","show_legend":false,"time":{},"type":"timeseries","requests":[{"q":"avg:open_policy_agent.request.duration.count{short_image:opa} by {code}.as_count()","on_right_yaxis":false,"style":{"palette":"warm","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"yaxis":{"include_zero":false,"min":"0"},"markers":[]}},{"id":7199015011541054,"layout":{"x":46,"y":0,"width":15,"height":12},"definition":{"title":"Plugins Status","title_size":"16","title_align":"center","type":"check_status","check":"open_policy_agent.plugins_health","grouping":"cluster","group_by":[],"tags":[]}},{"id":1056262233020773,"layout":{"x":62,"y":0,"width":15,"height":12},"definition":{"title":"Bundles Status","title_size":"16","title_align":"center","type":"check_status","check":"open_policy_agent.bundles_health","grouping":"cluster","group_by":[],"tags":[]}},{"id":1293226715483882,"layout":{"x":78,"y":0,"width":15,"height":12},"definition":{"title":"# loaded policies","title_size":"16","title_align":"left","time":{},"type":"query_value","requests":[{"q":"avg:open_policy_agent.policies{*}","aggregator":"last"}],"autoscale":true,"precision":0}},{"id":2005458748746522,"layout":{"x":96,"y":13,"width":47,"height":5},"definition":{"type":"note","content":"Decision Logs","background_color":"gray","font_size":"18","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}}],"template_variables":[],"layout_type":"free","is_read_only":false,"notify_list":[],"id":"2t5-k8k-89y"}
+{
+  "title": "Open Policy Agent - Overview",
+  "description": "",
+  "widgets": [
+    {
+      "id": 2525687926129783,
+      "layout": { "x": 0, "y": 0, "width": 29, "height": 12 },
+      "definition": {
+        "type": "image",
+        "url": "/static/images/logos/open-policy-agent_large.svg",
+        "sizing": "zoom"
+      }
+    },
+    {
+      "id": 2373762142354972,
+      "layout": { "x": 96, "y": 19, "width": 47, "height": 36 },
+      "definition": {
+        "title": "Decision Logs",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "log_stream",
+        "indexes": [],
+        "query": "source:opa @msg:\"Decision Log\"",
+        "sort": { "column": "time", "order": "desc" },
+        "columns": ["core_host", "core_service"],
+        "show_date_column": true,
+        "show_message_column": true,
+        "message_display": "expanded-md"
+      }
+    },
+    {
+      "id": 8795394413575891,
+      "layout": { "x": 0, "y": 13, "width": 47, "height": 5 },
+      "definition": {
+        "type": "note",
+        "content": "OPA Decisions",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 2485976784376809,
+      "layout": { "x": 0, "y": 19, "width": 47, "height": 15 },
+      "definition": {
+        "title": "OPA decisions by result (allowed / not allowed)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:opa.decisions{*} by {result.response.allowed}.as_count()",
+            "on_right_yaxis": false,
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 7368957134060938,
+      "layout": { "x": 0, "y": 35, "width": 47, "height": 15 },
+      "definition": {
+        "title": "OPA decisions by Kubernetes object kind",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:opa.decisions{*} by {input.request.kind.kind}.as_count()",
+            "on_right_yaxis": false,
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        },
+        "markers": []
+      }
+    },
+    {
+      "id": 6829868450502189,
+      "layout": { "x": 48, "y": 13, "width": 47, "height": 5 },
+      "definition": {
+        "type": "note",
+        "content": "Requests to OPA",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 7137085095709307,
+      "layout": { "x": 48, "y": 19, "width": 47, "height": 15 },
+      "definition": {
+        "title": "Avg latency for OPA requests",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:open_policy_agent.request.duration.sum{*}.as_count()/avg:open_policy_agent.request.duration.count{*}.as_count()",
+            "on_right_yaxis": false,
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": { "include_zero": false, "min": "0" },
+        "markers": []
+      }
+    },
+    {
+      "id": 2789367939595781,
+      "layout": { "x": 30, "y": 0, "width": 15, "height": 12 },
+      "definition": {
+        "title": "OPA Service Status",
+        "title_size": "16",
+        "title_align": "center",
+        "type": "check_status",
+        "check": "open_policy_agent.health",
+        "grouping": "cluster",
+        "group_by": [],
+        "tags": []
+      }
+    },
+    {
+      "id": 4443578023844538,
+      "layout": { "x": 48, "y": 35, "width": 47, "height": 15 },
+      "definition": {
+        "title": "Requests to OPA by response code",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:open_policy_agent.request.duration.count{short_image:opa} by {code}.as_count()",
+            "on_right_yaxis": false,
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": { "include_zero": false, "min": "0" },
+        "markers": []
+      }
+    },
+    {
+      "id": 7199015011541054,
+      "layout": { "x": 46, "y": 0, "width": 15, "height": 12 },
+      "definition": {
+        "title": "Plugins Status",
+        "title_size": "16",
+        "title_align": "center",
+        "type": "check_status",
+        "check": "open_policy_agent.plugins_health",
+        "grouping": "cluster",
+        "group_by": [],
+        "tags": []
+      }
+    },
+    {
+      "id": 1056262233020773,
+      "layout": { "x": 62, "y": 0, "width": 15, "height": 12 },
+      "definition": {
+        "title": "Bundles Status",
+        "title_size": "16",
+        "title_align": "center",
+        "type": "check_status",
+        "check": "open_policy_agent.bundles_health",
+        "grouping": "cluster",
+        "group_by": [],
+        "tags": []
+      }
+    },
+    {
+      "id": 1293226715483882,
+      "layout": { "x": 78, "y": 0, "width": 15, "height": 12 },
+      "definition": {
+        "title": "# loaded policies",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "type": "query_value",
+        "requests": [
+          { "q": "avg:open_policy_agent.policies{*}", "aggregator": "last" }
+        ],
+        "autoscale": true,
+        "precision": 0
+      }
+    },
+    {
+      "id": 2005458748746522,
+      "layout": { "x": 96, "y": 13, "width": 47, "height": 5 },
+      "definition": {
+        "type": "note",
+        "content": "Decision Logs",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": []
+}

--- a/purefb/assets/dashboards/purefb_overview.json
+++ b/purefb/assets/dashboards/purefb_overview.json
@@ -83,7 +83,7 @@
                      {
                         "alias":"Array Capacity",
                         "conditional_formats":[
-                           
+
                         ],
                         "cell_display_mode":"number",
                         "formula":"query7"
@@ -246,7 +246,7 @@
                      {
                         "alias":"Total Alerts",
                         "conditional_formats":[
-                           
+
                         ],
                         "cell_display_mode":"number",
                         "formula":"query4"
@@ -431,7 +431,7 @@
                "max":"auto"
             },
             "markers":[
-               
+
             ]
          },
          "layout":{
@@ -488,7 +488,7 @@
                "max":"auto"
             },
             "markers":[
-               
+
             ]
          },
          "layout":{
@@ -545,7 +545,7 @@
                "max":"auto"
             },
             "markers":[
-               
+
             ]
          },
          "layout":{
@@ -602,7 +602,7 @@
                "max":"auto"
             },
             "markers":[
-               
+
             ]
          },
          "layout":{
@@ -659,7 +659,7 @@
                "max":"auto"
             },
             "markers":[
-               
+
             ]
          },
          "layout":{
@@ -866,7 +866,7 @@
          "default":"*",
          "prefix":"env",
          "available_values":[
-            
+
          ]
       },
       {
@@ -874,7 +874,7 @@
          "default":"*",
          "prefix":"fb_array_name",
          "available_values":[
-            
+
          ]
       },
       {
@@ -893,8 +893,7 @@
    "layout_type":"ordered",
    "is_read_only":false,
    "notify_list":[
-      
+
    ],
-   "reflow_type":"fixed",
-   "id":"v2n-bmb-e2u"
+   "reflow_type":"fixed"
 }

--- a/retool/assets/dashboards/retool_retool_overview.json
+++ b/retool/assets/dashboards/retool_retool_overview.json
@@ -1,1 +1,491 @@
-{"title":"Retool + Datadog: ElasticSearch Action Console","description":"This dashboard provides a high-level overview of your Elasticsearch clusters, so you can track health status, search and indexing performance, and resource utilization metrics from all your nodes and be better prepared to address potential issues. Further reading on Elasticsearch monitoring:\n\n- [Datadog's guide to key Elasticsearch metrics](https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics/)\n\n- [How to collect Elasticsearch metrics with native and open source tools](https://www.datadoghq.com/blog/collect-elasticsearch-metrics/)\n\n- [How to monitor Elasticsearch with Datadog](https://www.datadoghq.com/blog/monitor-elasticsearch-datadog/)\n\n- [How to solve 5 Elasticsearch performance and scaling problems](https://www.datadoghq.com/blog/elasticsearch-performance-scaling-problems/)\n\n- [How to resolve unassigned shards in Elasticsearch](https://www.datadoghq.com/blog/elasticsearch-unassigned-shards/)\n\n- [Datadog's Elasticsearch integration docs](https://docs.datadoghq.com/integrations/elastic/)\n\nClone this template dashboard to make changes and add your own graph widgets. (cloned)","widgets":[{"id":0,"layout":{"x":0,"y":0,"width":29,"height":12},"definition":{"type":"image","url":"/static/images/logos/elasticsearch_large.svg","sizing":"zoom"}},{"id":1,"layout":{"x":0,"y":26,"width":29,"height":51},"definition":{"type":"note","content":"Retool is a no-code platform for writing applications, that includes a native integration with Datadog for using any Datadog API in your Retool apps.  In this example, the Retool application can be connected to your on-prem or hosted Elasticsearch clusters, your s3 account for snapshotting, and your Datadog account.\n\nThe embedded Retool Elasticsearch Management Template, to the right, helps you manage your ES clusters.  If you see slow queries to one of your ES Indexes, move shards to different hosts on the cluster, to alleviate resource contention!  Before you move a shard to a new host, make sure there is enough disk space on that host for the shard to grow, so that you are not constantly rebalancing!\n\nThis ES template is just one of the many ways Retool can be used to create internal applications for dev teams by using Datadog queries.  See our blog post (link TK) for more detail.\n\nIn this app, you will be able to create and move indicies and shards, manage which nodes each are assigned to, and backup and restore snapshots of the database.\n","background_color":"white","font_size":"14","text_align":"left","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":2,"layout":{"x":94,"y":0,"width":31,"height":5},"definition":{"type":"note","content":"Overview","background_color":"vivid_blue","font_size":"18","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"bottom"}},{"id":4,"layout":{"x":110,"y":6,"width":15,"height":10},"definition":{"title":"Nodes by cluster status","title_size":"13","title_align":"center","type":"check_status","check":"elasticsearch.cluster_health","grouping":"cluster","group_by":[],"tags":[]}},{"id":5,"layout":{"x":127,"y":6,"width":31,"height":14},"definition":{"title":"Avg query and fetch latency over $elastic_cluster","title_size":"16","title_align":"left","show_legend":false,"legend_size":"0","type":"timeseries","requests":[{"q":"(sum:elasticsearch.search.query.time{$elastic_cluster}/sum:elasticsearch.search.query.total{$elastic_cluster})","style":{"palette":"green","line_type":"solid","line_width":"normal"},"display_type":"line"},{"q":"(sum:elasticsearch.search.fetch.time{$elastic_cluster}/sum:elasticsearch.search.fetch.total{$elastic_cluster})","style":{"palette":"green","line_type":"solid","line_width":"normal"},"display_type":"line"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"}}},{"id":6,"layout":{"x":127,"y":0,"width":63,"height":5},"definition":{"type":"note","content":"Cluster Performance","background_color":"blue","font_size":"18","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":8,"layout":{"x":94,"y":52,"width":15,"height":10},"definition":{"title":"Active shards over $elastic_cluster","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"max:elasticsearch.active_shards{$elastic_cluster}","aggregator":"max"}],"autoscale":true,"precision":0}},{"id":9,"layout":{"x":110,"y":52,"width":15,"height":10},"definition":{"title":"Initializing shards","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"max:elasticsearch.initializing_shards{$elastic_cluster}","aggregator":"max","conditional_formats":[{"comparator":">","palette":"red_on_white","value":0},{"comparator":">=","palette":"green_on_white","value":0}]}],"autoscale":false,"custom_unit":"","precision":0}},{"id":10,"layout":{"x":126,"y":52,"width":15,"height":10},"definition":{"title":"Relocating shards","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"max:elasticsearch.relocating_shards{$elastic_cluster}","aggregator":"max","conditional_formats":[{"comparator":">","palette":"red_on_white","value":0},{"comparator":"<=","palette":"green_on_white","value":0}]}],"autoscale":true,"precision":0}},{"id":11,"layout":{"x":142,"y":52,"width":15,"height":10},"definition":{"title":"Unassigned shards","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"max:elasticsearch.unassigned_shards{$elastic_cluster}","aggregator":"max","conditional_formats":[{"comparator":">","palette":"red_on_white","value":0},{"comparator":">=","palette":"green_on_white","value":0}]}],"autoscale":true,"precision":0}},{"id":12,"layout":{"x":94,"y":63,"width":31,"height":14},"definition":{"title":"Active shards (total and primary) over $elastic_cluster","title_size":"16","title_align":"left","show_legend":false,"legend_size":"0","type":"timeseries","requests":[{"q":"max:elasticsearch.active_shards{$elastic_cluster}","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"},{"q":"max:elasticsearch.active_primary_shards{$elastic_cluster}","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"}}},{"id":13,"layout":{"x":94,"y":46,"width":63,"height":5},"definition":{"type":"note","content":"Shards","background_color":"blue","font_size":"18","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":14,"layout":{"x":126,"y":63,"width":31,"height":14},"definition":{"title":"Shards initializing, relocating, unassigned over $elastic_cluster","title_size":"16","title_align":"left","show_legend":false,"legend_size":"0","type":"timeseries","requests":[{"q":"max:elasticsearch.initializing_shards{$elastic_cluster}","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"},{"q":"max:elasticsearch.unassigned_shards{$elastic_cluster}","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"},{"q":"max:elasticsearch.relocating_shards{$elastic_cluster}","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"}}},{"id":15,"layout":{"x":127,"y":21,"width":31,"height":14},"definition":{"title":"Nodes of $elastic_cluster with most indexing activity (top 10 hosts)","title_size":"16","title_align":"left","type":"toplist","requests":[{"q":"top(diff(avg:elasticsearch.indexing.index.total{$elastic_cluster} by {host}), 10, 'sum', 'desc')"}]}},{"id":16,"layout":{"x":158,"y":52,"width":32,"height":44},"definition":{"type":"log_stream","indexes":[],"query":"source:elasticsearch $elastic_cluster","sort":{"column":"time","order":"desc"},"columns":["core_host","core_service"],"show_date_column":true,"show_message_column":true,"message_display":"expanded-lg"}},{"id":20,"layout":{"x":158,"y":46,"width":32,"height":5},"definition":{"type":"note","content":"Elasticsearch logs","background_color":"blue","font_size":"18","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":21,"layout":{"x":159,"y":21,"width":31,"height":14},"definition":{"title":"Nodes of $elastic_cluster with most queries (top 10 hosts)","title_size":"16","title_align":"left","type":"toplist","requests":[{"q":"top(diff(avg:elasticsearch.search.query.total{$elastic_cluster} by {host}), 10, 'sum', 'desc')"}]}},{"id":22,"layout":{"x":94,"y":6,"width":15,"height":10},"definition":{"title":"Disk space used","title_size":"16","title_align":"left","type":"query_value","requests":[{"q":"(1-(sum:elasticsearch.fs.total.available_in_bytes{$elastic_cluster} by {host}/sum:elasticsearch.fs.total.total_in_bytes{$elastic_cluster} by {host}))*100","aggregator":"avg","conditional_formats":[{"comparator":"<","palette":"green_on_white","value":80},{"comparator":">","palette":"yellow_on_white","value":80},{"comparator":">","palette":"red_on_white","value":90}]}],"custom_unit":"%","precision":1}},{"id":23,"layout":{"x":159,"y":6,"width":31,"height":14},"definition":{"title":"Total number of pending task in $elastic_cluster","title_size":"16","title_align":"left","show_legend":false,"legend_size":"0","type":"timeseries","requests":[{"q":"sum:elasticsearch.pending_tasks_total{$elastic_cluster}","style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}],"yaxis":{"scale":"linear","label":"","include_zero":true,"min":"auto","max":"auto"}}},{"id":27,"layout":{"x":94,"y":78,"width":63,"height":18},"definition":{"type":"note","content":"If the number of unassigned shard is not 0, it often means that an action should be taken. Among the possible source of error, the two main ones are the following.\n\nIt is possible that the shard allocation is purposefully delayed, in that case a logs with the message `delaying allocation for [54] unassigned shards, next check in [1m]` should appear too.\n\nOther possibility is that there are too many shards for not enough nodes. In that case, make sure that every index in your cluster is initialized with fewer replicas per primary shard than the number of nodes in your cluster.\n","background_color":"gray","font_size":"14","text_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left"}},{"id":30,"layout":{"x":94,"y":18,"width":31,"height":10},"definition":{"type":"note","content":"If disk space for the entire cluster is limited, or the cluster is in a \"yellow\" or \"red\" health state, you might need to add more nodes to the cluster, and quickly!","background_color":"gray","font_size":"14","text_align":"left","show_tick":true,"tick_pos":"50%","tick_edge":"top"}},{"id":2327440509042346,"layout":{"x":30,"y":0,"width":63,"height":96},"definition":{"type":"iframe","url":"https://mikezvi.retool.com/apps/Datadog%20Elasticsearch%20Template%20V%202.0%20(Launch%201)"}},{"id":2441766761924720,"layout":{"x":0,"y":13,"width":29,"height":12},"definition":{"type":"image","url":"https://retool.com/logo.png","sizing":"cover"}},{"id":5898267523188546,"layout":{"x":127,"y":36,"width":63,"height":9},"definition":{"type":"note","content":"Query performance directly impacts customers;  if this is over an acceptable threshold, re-balance indexes.\n\nIf the number of pending tasks are too high, move shard from nodes with the most queries to nodes with fewer.","background_color":"gray","font_size":"14","text_align":"left","vertical_align":"top","show_tick":true,"tick_pos":"50%","tick_edge":"top","has_padding":true}},{"id":8603829269002102,"layout":{"x":0,"y":78,"width":29,"height":18},"definition":{"type":"note","content":"\nFor other Elasticsearch monitoring resources that will help inform the way you manage your clusters with this app, the following guides are also available:\n\n- [Datadog's guide to key Elasticsearch metrics](https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics/)\n\n- [How to collect Elasticsearch metrics with native and open source tools](https://www.datadoghq.com/blog/collect-elasticsearch-metrics/)\n\n- [How to monitor Elasticsearch with Datadog](https://www.datadoghq.com/blog/monitor-elasticsearch-datadog/)\n\n- [How to solve 5 Elasticsearch performance and scaling problems](https://www.datadoghq.com/blog/elasticsearch-performance-scaling-problems/)\n\n- [How to resolve unassigned shards in Elasticsearch](https://www.datadoghq.com/blog/elasticsearch-unassigned-shards/)\n\n- [Datadog's Elasticsearch integration docs](https://docs.datadoghq.com/integrations/elastic/)","background_color":"white","font_size":"14","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true}}],"template_variables":[{"name":"elastic_cluster","default":"*","prefix":"elastic_cluster"},{"name":"node_name","default":"*","prefix":"node_name"}],"layout_type":"free","is_read_only":true,"notify_list":[],"id":"828-d8e-68s"}
+{
+  "title": "Retool + Datadog: ElasticSearch Action Console",
+  "description": "This dashboard provides a high-level overview of your Elasticsearch clusters, so you can track health status, search and indexing performance, and resource utilization metrics from all your nodes and be better prepared to address potential issues. Further reading on Elasticsearch monitoring:\n\n- [Datadog's guide to key Elasticsearch metrics](https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics/)\n\n- [How to collect Elasticsearch metrics with native and open source tools](https://www.datadoghq.com/blog/collect-elasticsearch-metrics/)\n\n- [How to monitor Elasticsearch with Datadog](https://www.datadoghq.com/blog/monitor-elasticsearch-datadog/)\n\n- [How to solve 5 Elasticsearch performance and scaling problems](https://www.datadoghq.com/blog/elasticsearch-performance-scaling-problems/)\n\n- [How to resolve unassigned shards in Elasticsearch](https://www.datadoghq.com/blog/elasticsearch-unassigned-shards/)\n\n- [Datadog's Elasticsearch integration docs](https://docs.datadoghq.com/integrations/elastic/)\n\nClone this template dashboard to make changes and add your own graph widgets. (cloned)",
+  "widgets": [
+    {
+      "id": 0,
+      "layout": { "x": 0, "y": 0, "width": 29, "height": 12 },
+      "definition": {
+        "type": "image",
+        "url": "/static/images/logos/elasticsearch_large.svg",
+        "sizing": "zoom"
+      }
+    },
+    {
+      "id": 1,
+      "layout": { "x": 0, "y": 26, "width": 29, "height": 51 },
+      "definition": {
+        "type": "note",
+        "content": "Retool is a no-code platform for writing applications, that includes a native integration with Datadog for using any Datadog API in your Retool apps.  In this example, the Retool application can be connected to your on-prem or hosted Elasticsearch clusters, your s3 account for snapshotting, and your Datadog account.\n\nThe embedded Retool Elasticsearch Management Template, to the right, helps you manage your ES clusters.  If you see slow queries to one of your ES Indexes, move shards to different hosts on the cluster, to alleviate resource contention!  Before you move a shard to a new host, make sure there is enough disk space on that host for the shard to grow, so that you are not constantly rebalancing!\n\nThis ES template is just one of the many ways Retool can be used to create internal applications for dev teams by using Datadog queries.  See our blog post (link TK) for more detail.\n\nIn this app, you will be able to create and move indicies and shards, manage which nodes each are assigned to, and backup and restore snapshots of the database.\n",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 2,
+      "layout": { "x": 94, "y": 0, "width": 31, "height": 5 },
+      "definition": {
+        "type": "note",
+        "content": "Overview",
+        "background_color": "vivid_blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 4,
+      "layout": { "x": 110, "y": 6, "width": 15, "height": 10 },
+      "definition": {
+        "title": "Nodes by cluster status",
+        "title_size": "13",
+        "title_align": "center",
+        "type": "check_status",
+        "check": "elasticsearch.cluster_health",
+        "grouping": "cluster",
+        "group_by": [],
+        "tags": []
+      }
+    },
+    {
+      "id": 5,
+      "layout": { "x": 127, "y": 6, "width": 31, "height": 14 },
+      "definition": {
+        "title": "Avg query and fetch latency over $elastic_cluster",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "(sum:elasticsearch.search.query.time{$elastic_cluster}/sum:elasticsearch.search.query.total{$elastic_cluster})",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          },
+          {
+            "q": "(sum:elasticsearch.search.fetch.time{$elastic_cluster}/sum:elasticsearch.search.fetch.total{$elastic_cluster})",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "layout": { "x": 127, "y": 0, "width": 63, "height": 5 },
+      "definition": {
+        "type": "note",
+        "content": "Cluster Performance",
+        "background_color": "blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 8,
+      "layout": { "x": 94, "y": 52, "width": 15, "height": 10 },
+      "definition": {
+        "title": "Active shards over $elastic_cluster",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "max:elasticsearch.active_shards{$elastic_cluster}",
+            "aggregator": "max"
+          }
+        ],
+        "autoscale": true,
+        "precision": 0
+      }
+    },
+    {
+      "id": 9,
+      "layout": { "x": 110, "y": 52, "width": 15, "height": 10 },
+      "definition": {
+        "title": "Initializing shards",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "max:elasticsearch.initializing_shards{$elastic_cluster}",
+            "aggregator": "max",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "red_on_white", "value": 0 },
+              { "comparator": ">=", "palette": "green_on_white", "value": 0 }
+            ]
+          }
+        ],
+        "autoscale": false,
+        "custom_unit": "",
+        "precision": 0
+      }
+    },
+    {
+      "id": 10,
+      "layout": { "x": 126, "y": 52, "width": 15, "height": 10 },
+      "definition": {
+        "title": "Relocating shards",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "max:elasticsearch.relocating_shards{$elastic_cluster}",
+            "aggregator": "max",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "red_on_white", "value": 0 },
+              { "comparator": "<=", "palette": "green_on_white", "value": 0 }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 0
+      }
+    },
+    {
+      "id": 11,
+      "layout": { "x": 142, "y": 52, "width": 15, "height": 10 },
+      "definition": {
+        "title": "Unassigned shards",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "max:elasticsearch.unassigned_shards{$elastic_cluster}",
+            "aggregator": "max",
+            "conditional_formats": [
+              { "comparator": ">", "palette": "red_on_white", "value": 0 },
+              { "comparator": ">=", "palette": "green_on_white", "value": 0 }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 0
+      }
+    },
+    {
+      "id": 12,
+      "layout": { "x": 94, "y": 63, "width": 31, "height": 14 },
+      "definition": {
+        "title": "Active shards (total and primary) over $elastic_cluster",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "max:elasticsearch.active_shards{$elastic_cluster}",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          },
+          {
+            "q": "max:elasticsearch.active_primary_shards{$elastic_cluster}",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      }
+    },
+    {
+      "id": 13,
+      "layout": { "x": 94, "y": 46, "width": 63, "height": 5 },
+      "definition": {
+        "type": "note",
+        "content": "Shards",
+        "background_color": "blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 14,
+      "layout": { "x": 126, "y": 63, "width": 31, "height": 14 },
+      "definition": {
+        "title": "Shards initializing, relocating, unassigned over $elastic_cluster",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "max:elasticsearch.initializing_shards{$elastic_cluster}",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          },
+          {
+            "q": "max:elasticsearch.unassigned_shards{$elastic_cluster}",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          },
+          {
+            "q": "max:elasticsearch.relocating_shards{$elastic_cluster}",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      }
+    },
+    {
+      "id": 15,
+      "layout": { "x": 127, "y": 21, "width": 31, "height": 14 },
+      "definition": {
+        "title": "Nodes of $elastic_cluster with most indexing activity (top 10 hosts)",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "toplist",
+        "requests": [
+          {
+            "q": "top(diff(avg:elasticsearch.indexing.index.total{$elastic_cluster} by {host}), 10, 'sum', 'desc')"
+          }
+        ]
+      }
+    },
+    {
+      "id": 16,
+      "layout": { "x": 158, "y": 52, "width": 32, "height": 44 },
+      "definition": {
+        "type": "log_stream",
+        "indexes": [],
+        "query": "source:elasticsearch $elastic_cluster",
+        "sort": { "column": "time", "order": "desc" },
+        "columns": ["core_host", "core_service"],
+        "show_date_column": true,
+        "show_message_column": true,
+        "message_display": "expanded-lg"
+      }
+    },
+    {
+      "id": 20,
+      "layout": { "x": 158, "y": 46, "width": 32, "height": 5 },
+      "definition": {
+        "type": "note",
+        "content": "Elasticsearch logs",
+        "background_color": "blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 21,
+      "layout": { "x": 159, "y": 21, "width": 31, "height": 14 },
+      "definition": {
+        "title": "Nodes of $elastic_cluster with most queries (top 10 hosts)",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "toplist",
+        "requests": [
+          {
+            "q": "top(diff(avg:elasticsearch.search.query.total{$elastic_cluster} by {host}), 10, 'sum', 'desc')"
+          }
+        ]
+      }
+    },
+    {
+      "id": 22,
+      "layout": { "x": 94, "y": 6, "width": 15, "height": 10 },
+      "definition": {
+        "title": "Disk space used",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(1-(sum:elasticsearch.fs.total.available_in_bytes{$elastic_cluster} by {host}/sum:elasticsearch.fs.total.total_in_bytes{$elastic_cluster} by {host}))*100",
+            "aggregator": "avg",
+            "conditional_formats": [
+              { "comparator": "<", "palette": "green_on_white", "value": 80 },
+              { "comparator": ">", "palette": "yellow_on_white", "value": 80 },
+              { "comparator": ">", "palette": "red_on_white", "value": 90 }
+            ]
+          }
+        ],
+        "custom_unit": "%",
+        "precision": 1
+      }
+    },
+    {
+      "id": 23,
+      "layout": { "x": 159, "y": 6, "width": 31, "height": 14 },
+      "definition": {
+        "title": "Total number of pending task in $elastic_cluster",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:elasticsearch.pending_tasks_total{$elastic_cluster}",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear",
+          "label": "",
+          "include_zero": true,
+          "min": "auto",
+          "max": "auto"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "layout": { "x": 94, "y": 78, "width": 63, "height": 18 },
+      "definition": {
+        "type": "note",
+        "content": "If the number of unassigned shard is not 0, it often means that an action should be taken. Among the possible source of error, the two main ones are the following.\n\nIt is possible that the shard allocation is purposefully delayed, in that case a logs with the message `delaying allocation for [54] unassigned shards, next check in [1m]` should appear too.\n\nOther possibility is that there are too many shards for not enough nodes. In that case, make sure that every index in your cluster is initialized with fewer replicas per primary shard than the number of nodes in your cluster.\n",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      }
+    },
+    {
+      "id": 30,
+      "layout": { "x": 94, "y": 18, "width": 31, "height": 10 },
+      "definition": {
+        "type": "note",
+        "content": "If disk space for the entire cluster is limited, or the cluster is in a \"yellow\" or \"red\" health state, you might need to add more nodes to the cluster, and quickly!",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "top"
+      }
+    },
+    {
+      "id": 2327440509042346,
+      "layout": { "x": 30, "y": 0, "width": 63, "height": 96 },
+      "definition": {
+        "type": "iframe",
+        "url": "https://mikezvi.retool.com/apps/Datadog%20Elasticsearch%20Template%20V%202.0%20(Launch%201)"
+      }
+    },
+    {
+      "id": 2441766761924720,
+      "layout": { "x": 0, "y": 13, "width": 29, "height": 12 },
+      "definition": {
+        "type": "image",
+        "url": "https://retool.com/logo.png",
+        "sizing": "cover"
+      }
+    },
+    {
+      "id": 5898267523188546,
+      "layout": { "x": 127, "y": 36, "width": 63, "height": 9 },
+      "definition": {
+        "type": "note",
+        "content": "Query performance directly impacts customers;  if this is over an acceptable threshold, re-balance indexes.\n\nIf the number of pending tasks are too high, move shard from nodes with the most queries to nodes with fewer.",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "left",
+        "vertical_align": "top",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "top",
+        "has_padding": true
+      }
+    },
+    {
+      "id": 8603829269002102,
+      "layout": { "x": 0, "y": 78, "width": 29, "height": 18 },
+      "definition": {
+        "type": "note",
+        "content": "\nFor other Elasticsearch monitoring resources that will help inform the way you manage your clusters with this app, the following guides are also available:\n\n- [Datadog's guide to key Elasticsearch metrics](https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics/)\n\n- [How to collect Elasticsearch metrics with native and open source tools](https://www.datadoghq.com/blog/collect-elasticsearch-metrics/)\n\n- [How to monitor Elasticsearch with Datadog](https://www.datadoghq.com/blog/monitor-elasticsearch-datadog/)\n\n- [How to solve 5 Elasticsearch performance and scaling problems](https://www.datadoghq.com/blog/elasticsearch-performance-scaling-problems/)\n\n- [How to resolve unassigned shards in Elasticsearch](https://www.datadoghq.com/blog/elasticsearch-unassigned-shards/)\n\n- [Datadog's Elasticsearch integration docs](https://docs.datadoghq.com/integrations/elastic/)",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "vertical_align": "top",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      }
+    }
+  ],
+  "template_variables": [
+    { "name": "elastic_cluster", "default": "*", "prefix": "elastic_cluster" },
+    { "name": "node_name", "default": "*", "prefix": "node_name" }
+  ],
+  "layout_type": "free",
+  "is_read_only": true,
+  "notify_list": []
+}

--- a/scalr/assets/dashboards/scalr_overview.json
+++ b/scalr/assets/dashboards/scalr_overview.json
@@ -343,6 +343,5 @@
    "notify_list":[
 
    ],
-   "reflow_type":"fixed",
-   "id":"z5z-whu-m6g"
+   "reflow_type":"fixed"
 }

--- a/sosivio/assets/dashboards/sosivio_overview.json
+++ b/sosivio/assets/dashboards/sosivio_overview.json
@@ -1,1 +1,198 @@
-{"title":"Sosivio's Dashboard","description":"","widgets":[{"id":7900475766407956,"definition":{"type":"image","url":"https://sosivio-public.s3.us-west-2.amazonaws.com/sosivio.jpg","sizing":"contain","margin":"md","has_background":false,"has_border":false,"vertical_align":"center","horizontal_align":"center"},"layout":{"x":0,"y":0,"width":2,"height":2}},{"id":3909204963873384,"definition":{"title":"Sosivio Health Checks","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"response_format":"timeseries","queries":[{"query":"avg:sosivio.healthchecks{*} by {healthchecks}","data_source":"metrics","name":"query1"}],"style":{"palette":"dog_classic","line_type":"dotted","line_width":"thick"},"display_type":"line"}],"yaxis":{"include_zero":false,"max":"100"}},"layout":{"x":2,"y":0,"width":6,"height":3}},{"id":6065212021411182,"definition":{"title":"Failure Count","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"conditional_formats":[{"comparator":">","palette":"white_on_red","value":-1}],"response_format":"scalar","queries":[{"search":{"query":"status:error source:sosivio"},"data_source":"events","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[]}]}],"autoscale":true,"custom_unit":"Failures","precision":0},"layout":{"x":8,"y":0,"width":4,"height":3}},{"id":3326770570753924,"definition":{"type":"free_text","text":"Get Answers. \nNot Data.","color":"#2B13E6","font_size":"auto","text_align":"center"},"layout":{"x":0,"y":2,"width":2,"height":1}},{"id":2852834368054450,"definition":{"title":"Performance Recommendations ","type":"group","background_color":"blue","show_title":true,"layout_type":"ordered","widgets":[{"id":647922936126806,"definition":{"title":"Failure","title_size":"16","title_align":"left","type":"event_stream","query":"status:error source:sosivio","event_size":"l"},"layout":{"x":0,"y":0,"width":7,"height":3}}]},"layout":{"x":0,"y":0,"width":7,"height":4,"is_column_break":true}},{"id":6255765703217050,"definition":{"title":"Alerts Split By Namespace","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"query":"sum:sosivio.actions{*} by {namespace}.as_count().rollup(sum, 1)","data_source":"metrics","name":"query1","aggregator":"sum"}]}],"type":"sunburst"},"layout":{"x":7,"y":0,"width":4,"height":4}},{"id":3513924791806908,"definition":{"title":"Alerts Split By What Happened","title_size":"16","title_align":"left","type":"query_table","requests":[{"formulas":[{"alias":"count","limit":{"count":500,"order":"desc"},"formula":"query1"}],"response_format":"scalar","queries":[{"query":"sum:sosivio.actions{*} by {whathappened}.as_count().rollup(sum, 1)","data_source":"metrics","name":"query1","aggregator":"sum"}]}]},"layout":{"x":0,"y":0,"width":11,"height":3}},{"id":8580008620217814,"definition":{"title":"Alerts Rate","title_size":"16","title_align":"left","type":"event_timeline","query":"source:sosivio","tags_execution":"and"},"layout":{"x":0,"y":3,"width":11,"height":4}}],"template_variables":[],"layout_type":"ordered","is_read_only":false,"notify_list":[],"reflow_type":"fixed","id":"dtw-5vi-brf"}
+{
+  "title": "Sosivio's Dashboard",
+  "description": "",
+  "widgets": [
+    {
+      "id": 7900475766407956,
+      "definition": {
+        "type": "image",
+        "url": "https://sosivio-public.s3.us-west-2.amazonaws.com/sosivio.jpg",
+        "sizing": "contain",
+        "margin": "md",
+        "has_background": false,
+        "has_border": false,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      },
+      "layout": { "x": 0, "y": 0, "width": 2, "height": 2 }
+    },
+    {
+      "id": 3909204963873384,
+      "definition": {
+        "title": "Sosivio Health Checks",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "query": "avg:sosivio.healthchecks{*} by {healthchecks}",
+                "data_source": "metrics",
+                "name": "query1"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "dotted",
+              "line_width": "thick"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": { "include_zero": false, "max": "100" }
+      },
+      "layout": { "x": 2, "y": 0, "width": 6, "height": 3 }
+    },
+    {
+      "id": 6065212021411182,
+      "definition": {
+        "title": "Failure Count",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "conditional_formats": [
+              { "comparator": ">", "palette": "white_on_red", "value": -1 }
+            ],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "status:error source:sosivio" },
+                "data_source": "events",
+                "compute": { "aggregation": "count" },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": []
+              }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "custom_unit": "Failures",
+        "precision": 0
+      },
+      "layout": { "x": 8, "y": 0, "width": 4, "height": 3 }
+    },
+    {
+      "id": 3326770570753924,
+      "definition": {
+        "type": "free_text",
+        "text": "Get Answers. \nNot Data.",
+        "color": "#2B13E6",
+        "font_size": "auto",
+        "text_align": "center"
+      },
+      "layout": { "x": 0, "y": 2, "width": 2, "height": 1 }
+    },
+    {
+      "id": 2852834368054450,
+      "definition": {
+        "title": "Performance Recommendations ",
+        "type": "group",
+        "background_color": "blue",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 647922936126806,
+            "definition": {
+              "title": "Failure",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "event_stream",
+              "query": "status:error source:sosivio",
+              "event_size": "l"
+            },
+            "layout": { "x": 0, "y": 0, "width": 7, "height": 3 }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 7,
+        "height": 4,
+        "is_column_break": true
+      }
+    },
+    {
+      "id": 6255765703217050,
+      "definition": {
+        "title": "Alerts Split By Namespace",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "query": "sum:sosivio.actions{*} by {namespace}.as_count().rollup(sum, 1)",
+                "data_source": "metrics",
+                "name": "query1",
+                "aggregator": "sum"
+              }
+            ]
+          }
+        ],
+        "type": "sunburst"
+      },
+      "layout": { "x": 7, "y": 0, "width": 4, "height": 4 }
+    },
+    {
+      "id": 3513924791806908,
+      "definition": {
+        "title": "Alerts Split By What Happened",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_table",
+        "requests": [
+          {
+            "formulas": [
+              {
+                "alias": "count",
+                "limit": { "count": 500, "order": "desc" },
+                "formula": "query1"
+              }
+            ],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "query": "sum:sosivio.actions{*} by {whathappened}.as_count().rollup(sum, 1)",
+                "data_source": "metrics",
+                "name": "query1",
+                "aggregator": "sum"
+              }
+            ]
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 0, "width": 11, "height": 3 }
+    },
+    {
+      "id": 8580008620217814,
+      "definition": {
+        "title": "Alerts Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "event_timeline",
+        "query": "source:sosivio",
+        "tags_execution": "and"
+      },
+      "layout": { "x": 0, "y": 3, "width": 11, "height": 4 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/speedscale/assets/dashboards/SpeedscaleOverview.json
+++ b/speedscale/assets/dashboards/SpeedscaleOverview.json
@@ -1,1 +1,52 @@
-{"title":"Speedscale Overview","description":"","widgets":[{"id":1245841300908556,"definition":{"type":"note","content":"## Overview\n\nThis integration publishes traffic replay results from [Speedscale](https://docs.speedscale.com/reference/integrations/datadog/) into Datadog. This lets you combine your observability data from Datadog with the results of a particular Speedscale replay to investigate the root cause of poor performance.\n\n![logo](https://speedscale.com/wp-content/uploads/2020/05/Landscape-1.svg)","background_color":"white","font_size":"14","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":0,"y":0,"width":4,"height":4}},{"id":4002061279594076,"definition":{"title":"","title_size":"16","title_align":"left","type":"event_stream","query":"source:speedscale","tags_execution":"and","event_size":"s"},"layout":{"x":4,"y":0,"width":4,"height":4}},{"id":2427201979903764,"definition":{"title":"","title_size":"16","title_align":"left","type":"event_timeline","query":"source:speedscale","tags_execution":"and"},"layout":{"x":0,"y":4,"width":8,"height":2}}],"template_variables":[],"layout_type":"ordered","is_read_only":false,"notify_list":[],"reflow_type":"fixed","id":"pb4-v54-h4h"}
+{
+  "title": "Speedscale Overview",
+  "description": "",
+  "widgets": [
+    {
+      "id": 1245841300908556,
+      "definition": {
+        "type": "note",
+        "content": "## Overview\n\nThis integration publishes traffic replay results from [Speedscale](https://docs.speedscale.com/reference/integrations/datadog/) into Datadog. This lets you combine your observability data from Datadog with the results of a particular Speedscale replay to investigate the root cause of poor performance.\n\n![logo](https://speedscale.com/wp-content/uploads/2020/05/Landscape-1.svg)",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "vertical_align": "top",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      },
+      "layout": { "x": 0, "y": 0, "width": 4, "height": 4 }
+    },
+    {
+      "id": 4002061279594076,
+      "definition": {
+        "title": "",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "event_stream",
+        "query": "source:speedscale",
+        "tags_execution": "and",
+        "event_size": "s"
+      },
+      "layout": { "x": 4, "y": 0, "width": 4, "height": 4 }
+    },
+    {
+      "id": 2427201979903764,
+      "definition": {
+        "title": "",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "event_timeline",
+        "query": "source:speedscale",
+        "tags_execution": "and"
+      },
+      "layout": { "x": 0, "y": 4, "width": 8, "height": 2 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/sqreen/assets/dashboards/overview.json
+++ b/sqreen/assets/dashboards/overview.json
@@ -1049,7 +1049,6 @@
           ]
        }
     ],
-    "reflow_type":"fixed",
-    "id":"wjc-ehj-2vm"
+    "reflow_type":"fixed"
  }
 

--- a/stackpulse/assets/dashboards/stackpulse_overview.json
+++ b/stackpulse/assets/dashboards/stackpulse_overview.json
@@ -1,1 +1,84 @@
-{"title":"StackPulse","description":"### Track all execution events posted from StackPulse playbooks in one dashboard.\n\n### Use tags on events to separate events by environments, services and applications and build out different dashboards. \n\n###For full visibility into your StackPulse playbooks executions got to [the StackPulse app](https//app.stackpulse.com)","widgets":[{"id":2147516070905912,"layout":{"x":30,"y":19,"width":96,"height":50},"definition":{"title":"StackPulse Activity Stream","title_size":"16","title_align":"left","time":{"live_span":"1w"},"type":"event_stream","query":"sources:stackpulse","tags_execution":"and","event_size":"s"}},{"id":6137349677227188,"layout":{"x":30,"y":8,"width":96,"height":9},"definition":{"title":"StackPulse Activity Timeline","title_size":"16","title_align":"left","time":{"live_span":"1w"},"type":"event_timeline","query":"sources:stackpulse","tags_execution":"and"}},{"id":4444164082222724,"layout":{"x":5,"y":0,"width":18,"height":15},"definition":{"type":"image","url":"https://raw.githubusercontent.com/stackpulse/integrations-extras/stackpulse-integration/stackpulse/assets/logos/stackpulse_green_grey_vertical.png","url_dark_theme":"https://raw.githubusercontent.com/stackpulse/integrations-extras/stackpulse-integration/stackpulse/assets/logos/stackpulse_green_white_vertical.png","sizing":"contain","margin":"sm","has_background":false,"has_border":false,"vertical_align":"center","horizontal_align":"center"}},{"id":2622851012825320,"layout":{"x":0,"y":15,"width":30,"height":42},"definition":{"type":"note","content":"### About StackPulse\n\n[StackPulse](https://stackpulse.com) keeps software services reliable, from alert to resolution. Intuitive incident response and powerful playbook orchestration help you automate your incident process to mitigate and remediate faster.\n\n### Using this dashboard\n\nIn the dashboard you can track StackPulse originated events though a timeline and event stream. These events are produced by the [Datadog Post Event step](https://github.com/stackpulse/steps/tree/master/steps/datadog/post-event) in StackPulse playbooks running in the [StackPulse App](https://app.stackpulse.com). \n\nYou can use these events to keep track of playbook executions, send back status updates or even share enriched data collected by your playbooks back to Datadog. ","background_color":"white","font_size":"14","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true}},{"id":3352112108208662,"layout":{"x":30,"y":0,"width":96,"height":8},"definition":{"type":"note","content":"# StackPulse Events","background_color":"vivid_blue","font_size":"14","text_align":"center","vertical_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true}}],"template_variables":[],"layout_type":"free","is_read_only":false,"notify_list":[],"id":"4tm-v9h-xfh"}
+{
+  "title": "StackPulse",
+  "description": "### Track all execution events posted from StackPulse playbooks in one dashboard.\n\n### Use tags on events to separate events by environments, services and applications and build out different dashboards. \n\n###For full visibility into your StackPulse playbooks executions got to [the StackPulse app](https//app.stackpulse.com)",
+  "widgets": [
+    {
+      "id": 2147516070905912,
+      "layout": { "x": 30, "y": 19, "width": 96, "height": 50 },
+      "definition": {
+        "title": "StackPulse Activity Stream",
+        "title_size": "16",
+        "title_align": "left",
+        "time": { "live_span": "1w" },
+        "type": "event_stream",
+        "query": "sources:stackpulse",
+        "tags_execution": "and",
+        "event_size": "s"
+      }
+    },
+    {
+      "id": 6137349677227188,
+      "layout": { "x": 30, "y": 8, "width": 96, "height": 9 },
+      "definition": {
+        "title": "StackPulse Activity Timeline",
+        "title_size": "16",
+        "title_align": "left",
+        "time": { "live_span": "1w" },
+        "type": "event_timeline",
+        "query": "sources:stackpulse",
+        "tags_execution": "and"
+      }
+    },
+    {
+      "id": 4444164082222724,
+      "layout": { "x": 5, "y": 0, "width": 18, "height": 15 },
+      "definition": {
+        "type": "image",
+        "url": "https://raw.githubusercontent.com/stackpulse/integrations-extras/stackpulse-integration/stackpulse/assets/logos/stackpulse_green_grey_vertical.png",
+        "url_dark_theme": "https://raw.githubusercontent.com/stackpulse/integrations-extras/stackpulse-integration/stackpulse/assets/logos/stackpulse_green_white_vertical.png",
+        "sizing": "contain",
+        "margin": "sm",
+        "has_background": false,
+        "has_border": false,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      }
+    },
+    {
+      "id": 2622851012825320,
+      "layout": { "x": 0, "y": 15, "width": 30, "height": 42 },
+      "definition": {
+        "type": "note",
+        "content": "### About StackPulse\n\n[StackPulse](https://stackpulse.com) keeps software services reliable, from alert to resolution. Intuitive incident response and powerful playbook orchestration help you automate your incident process to mitigate and remediate faster.\n\n### Using this dashboard\n\nIn the dashboard you can track StackPulse originated events though a timeline and event stream. These events are produced by the [Datadog Post Event step](https://github.com/stackpulse/steps/tree/master/steps/datadog/post-event) in StackPulse playbooks running in the [StackPulse App](https://app.stackpulse.com). \n\nYou can use these events to keep track of playbook executions, send back status updates or even share enriched data collected by your playbooks back to Datadog. ",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "vertical_align": "top",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      }
+    },
+    {
+      "id": 3352112108208662,
+      "layout": { "x": 30, "y": 0, "width": 96, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "# StackPulse Events",
+        "background_color": "vivid_blue",
+        "font_size": "14",
+        "text_align": "center",
+        "vertical_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": []
+}

--- a/superwise/assets/dashboards/superwise.json
+++ b/superwise/assets/dashboards/superwise.json
@@ -1,1 +1,301 @@
-{"title":"Superwise","description":"## superwise overview dashboard\n\nThe model observability dashboard gives you out-of-the-box information for your active models, including activity statuses, drift levels, and open incidents detected for specific time intervals or filters. In addition, you can add any custom metrics or incidents to monitor for your specific use cases.\n\n- [https://docs.superwise.ai/docs](#docs)","widgets":[{"id":418963368099752,"definition":{"title":"Superwise","type":"group","background_color":"vivid_purple","show_title":true,"layout_type":"ordered","widgets":[{"id":6935498210192224,"definition":{"type":"note","content":"#### Model observability powered by\n![superwise](https://uploads-ssl.webflow.com/5f3245942591962669e600b0/61c6f497348387036a45152f_Superwise%20A%20logo%20black%20Small.png).  \nThe model observability dashboard gives you out-of-the-box information for your active models, including activity statuses, drift levels, and open incidents detected for specific time intervals or filters. In addition, you can add custom metrics and incidents to monitor your specific use cases.\n\nModel activity - Overview of model activity including the number of active models (models that had some production data during the filtered time), their activity (predictions) over time, and the total number of predictions during the filtered timeframe.\n\nDrift detection - Superwise's drift measures enable users to detect the model drift level in production relative to the baseline, for example, training dataset. The drift measure is scaled between 0-100 and is based on Superwise’s unique drift metric. Using the model input drift chart, users can identify which models are drifting and may require retraining.\n\nIncidents - Using incident widgets, users can easily see how many models currently have open incidents (violations of any monitoring policy configured), how incidents are being distributed among the different models, and drill down into the model incident details. The incidents that are included in this dashboard are only the ones configured explicitly to be sent to Datadog. [For further dashboard customizations, see our integration documentation](https://docs.superwise.ai)","background_color":"white","font_size":"14","text_align":"left","vertical_align":"top","show_tick":false,"has_padding":true},"layout":{"x":0,"y":0,"width":4,"height":6}}]},"layout":{"x":0,"y":0,"width":4,"height":7}},{"id":3345130583082,"definition":{"title":"Incidents","type":"group","background_color":"vivid_purple","show_title":true,"layout_type":"ordered","widgets":[{"id":819512417324588,"definition":{"title":"Number of incidents opened since last resolution","title_size":"16","title_align":"left","time":{},"type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"conditional_formats":[{"comparator":">","palette":"white_on_red","value":5},{"comparator":">=","palette":"white_on_yellow","value":1},{"comparator":"<","palette":"white_on_green","value":1}],"response_format":"scalar","queries":[{"search":{"query":"severity:SEV-2"},"data_source":"incident_analytics","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2},"layout":{"x":0,"y":0,"width":4,"height":3}},{"id":7223627866769632,"definition":{"title":"Incidents - Trend","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"horizontal","legend_columns":["avg","min","max","value","sum"],"time":{"live_span":"1w"},"type":"timeseries","requests":[{"formulas":[{"alias":"Models with Incidents","formula":"query1"}],"response_format":"timeseries","queries":[{"search":{"query":""},"data_source":"incident_analytics","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[]}],"style":{"palette":"purple","line_type":"solid","line_width":"normal"},"display_type":"line"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]},"layout":{"x":0,"y":3,"width":4,"height":3}}]},"layout":{"x":4,"y":0,"width":4,"height":7}},{"id":5132323858991144,"definition":{"title":"Metrics","type":"group","background_color":"vivid_purple","show_title":true,"layout_type":"ordered","widgets":[{"id":2728068484701532,"definition":{"title":"Total # of Predictions","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"query":"sum:superwise.metric.overall.quantity{*}","data_source":"metrics","name":"query1","aggregator":"sum"}]}],"autoscale":true,"precision":0},"layout":{"x":0,"y":0,"width":2,"height":3}},{"id":2448869580205054,"definition":{"title":"Active Models","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"count_not_null(query1)"}],"conditional_formats":[{"comparator":">","palette":"white_on_green","value":1}],"response_format":"scalar","queries":[{"query":"sum:superwise.metric.overall.data_drift{*} by {model_name}","data_source":"metrics","name":"query1","aggregator":"avg"}]}],"autoscale":true,"precision":2},"layout":{"x":2,"y":0,"width":2,"height":3}},{"id":7366254108548012,"definition":{"title":"Models Input Drift From Baseline","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":5,"order":"desc"}}],"conditional_formats":[{"comparator":"<","palette":"white_on_green","value":50},{"comparator":">=","palette":"white_on_red","value":80},{"comparator":">=","palette":"white_on_yellow","value":50}],"response_format":"scalar","queries":[{"query":"max:superwise.metric.overall.data_drift{*} by {model_name}","data_source":"metrics","name":"query1","aggregator":"last"}]}]},"layout":{"x":0,"y":3,"width":4,"height":3}},{"id":1954347328001564,"definition":{"title":"Total # of Predictions - Trend","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"horizontal","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"response_format":"timeseries","queries":[{"query":"max:superwise.metric.overall.quantity{*} by {model_name}","data_source":"metrics","name":"query1"}],"style":{"palette":"warm","line_type":"solid","line_width":"normal"},"display_type":"area"}],"yaxis":{"include_zero":true,"scale":"linear","label":"","min":"auto","max":"auto"},"markers":[]},"layout":{"x":0,"y":6,"width":4,"height":3}}]},"layout":{"x":8,"y":0,"width":4,"height":10}}],"template_variables":[],"layout_type":"ordered","is_read_only":false,"notify_list":[],"reflow_type":"fixed","id":"3rs-pu9-3be"}
+{
+  "title": "Superwise",
+  "description": "## superwise overview dashboard\n\nThe model observability dashboard gives you out-of-the-box information for your active models, including activity statuses, drift levels, and open incidents detected for specific time intervals or filters. In addition, you can add any custom metrics or incidents to monitor for your specific use cases.\n\n- [https://docs.superwise.ai/docs](#docs)",
+  "widgets": [
+    {
+      "id": 418963368099752,
+      "definition": {
+        "title": "Superwise",
+        "type": "group",
+        "background_color": "vivid_purple",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 6935498210192224,
+            "definition": {
+              "type": "note",
+              "content": "#### Model observability powered by\n![superwise](https://uploads-ssl.webflow.com/5f3245942591962669e600b0/61c6f497348387036a45152f_Superwise%20A%20logo%20black%20Small.png).  \nThe model observability dashboard gives you out-of-the-box information for your active models, including activity statuses, drift levels, and open incidents detected for specific time intervals or filters. In addition, you can add custom metrics and incidents to monitor your specific use cases.\n\nModel activity - Overview of model activity including the number of active models (models that had some production data during the filtered time), their activity (predictions) over time, and the total number of predictions during the filtered timeframe.\n\nDrift detection - Superwise's drift measures enable users to detect the model drift level in production relative to the baseline, for example, training dataset. The drift measure is scaled between 0-100 and is based on Superwise’s unique drift metric. Using the model input drift chart, users can identify which models are drifting and may require retraining.\n\nIncidents - Using incident widgets, users can easily see how many models currently have open incidents (violations of any monitoring policy configured), how incidents are being distributed among the different models, and drill down into the model incident details. The incidents that are included in this dashboard are only the ones configured explicitly to be sent to Datadog. [For further dashboard customizations, see our integration documentation](https://docs.superwise.ai)",
+              "background_color": "white",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "has_padding": true
+            },
+            "layout": { "x": 0, "y": 0, "width": 4, "height": 6 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 0, "width": 4, "height": 7 }
+    },
+    {
+      "id": 3345130583082,
+      "definition": {
+        "title": "Incidents",
+        "type": "group",
+        "background_color": "vivid_purple",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 819512417324588,
+            "definition": {
+              "title": "Number of incidents opened since last resolution",
+              "title_size": "16",
+              "title_align": "left",
+              "time": {},
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">",
+                      "palette": "white_on_red",
+                      "value": 5
+                    },
+                    {
+                      "comparator": ">=",
+                      "palette": "white_on_yellow",
+                      "value": 1
+                    },
+                    {
+                      "comparator": "<",
+                      "palette": "white_on_green",
+                      "value": 1
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": { "query": "severity:SEV-2" },
+                      "data_source": "incident_analytics",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2
+            },
+            "layout": { "x": 0, "y": 0, "width": 4, "height": 3 }
+          },
+          {
+            "id": 7223627866769632,
+            "definition": {
+              "title": "Incidents - Trend",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "horizontal",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "time": { "live_span": "1w" },
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "alias": "Models with Incidents", "formula": "query1" }
+                  ],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "search": { "query": "" },
+                      "data_source": "incident_analytics",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ],
+                  "style": {
+                    "palette": "purple",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear",
+                "label": "",
+                "min": "auto",
+                "max": "auto"
+              },
+              "markers": []
+            },
+            "layout": { "x": 0, "y": 3, "width": 4, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 4, "y": 0, "width": 4, "height": 7 }
+    },
+    {
+      "id": 5132323858991144,
+      "definition": {
+        "title": "Metrics",
+        "type": "group",
+        "background_color": "vivid_purple",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 2728068484701532,
+            "definition": {
+              "title": "Total # of Predictions",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "sum:superwise.metric.overall.quantity{*}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "sum"
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            },
+            "layout": { "x": 0, "y": 0, "width": 2, "height": 3 }
+          },
+          {
+            "id": 2448869580205054,
+            "definition": {
+              "title": "Active Models",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "count_not_null(query1)" }],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">",
+                      "palette": "white_on_green",
+                      "value": 1
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "sum:superwise.metric.overall.data_drift{*} by {model_name}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "avg"
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2
+            },
+            "layout": { "x": 2, "y": 0, "width": 2, "height": 3 }
+          },
+          {
+            "id": 7366254108548012,
+            "definition": {
+              "title": "Models Input Drift From Baseline",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 5, "order": "desc" }
+                    }
+                  ],
+                  "conditional_formats": [
+                    {
+                      "comparator": "<",
+                      "palette": "white_on_green",
+                      "value": 50
+                    },
+                    {
+                      "comparator": ">=",
+                      "palette": "white_on_red",
+                      "value": 80
+                    },
+                    {
+                      "comparator": ">=",
+                      "palette": "white_on_yellow",
+                      "value": 50
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "max:superwise.metric.overall.data_drift{*} by {model_name}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "last"
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 3, "width": 4, "height": 3 }
+          },
+          {
+            "id": 1954347328001564,
+            "definition": {
+              "title": "Total # of Predictions - Trend",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "horizontal",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "query": "max:superwise.metric.overall.quantity{*} by {model_name}",
+                      "data_source": "metrics",
+                      "name": "query1"
+                    }
+                  ],
+                  "style": {
+                    "palette": "warm",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "area"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear",
+                "label": "",
+                "min": "auto",
+                "max": "auto"
+              },
+              "markers": []
+            },
+            "layout": { "x": 0, "y": 6, "width": 4, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 8, "y": 0, "width": 4, "height": 10 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/torq/assets/dashboards/torq_overview.json
+++ b/torq/assets/dashboards/torq_overview.json
@@ -1,1 +1,84 @@
-{"title":"Torq","description":"### Track all execution events posted from Torq workflows in one dashboard.\n\n### Use tags on events to separate events by environments, services, and applications. Or, build out dashboards. \n\n###For full visibility into your Torq workflow runs, go to [the Torq app](https//app.torq.io).","widgets":[{"id":2147516070905912,"layout":{"x":30,"y":19,"width":96,"height":50},"definition":{"title":"Torq Activity Stream","title_size":"16","title_align":"left","time":{"live_span":"1w"},"type":"event_stream","query":"sources:torq","tags_execution":"and","event_size":"s"}},{"id":6137349677227188,"layout":{"x":30,"y":8,"width":96,"height":9},"definition":{"title":"Torq Activity Timeline","title_size":"16","title_align":"left","time":{"live_span":"1w"},"type":"event_timeline","query":"sources:torq","tags_execution":"and"}},{"id":4444164082222724,"layout":{"x":5,"y":0,"width":18,"height":15},"definition":{"type":"image","url":"https://raw.githubusercontent.com/DataDog/integrations-extras/master/torq/assets/logos/torq-black-horizontal.png","url_dark_theme":"https://raw.githubusercontent.com/DataDog/integrations-extras/master/torq/assets/logos/torq-white-horizontal.png","sizing":"contain","margin":"sm","has_background":false,"has_border":false,"vertical_align":"center","horizontal_align":"center"}},{"id":2622851012825320,"layout":{"x":0,"y":15,"width":30,"height":42},"definition":{"type":"note","content":"### About Torq\n\n[Torq](https://torq.io) is a no-code automation platform for security and operations teams\n\n### Using this dashboard\n\nIn the dashboard, you can track Torq originated events though a timeline and event stream. These events are produced by the Datadog Post Event step in Torq workflows running in the [Torq App](https://app.torq.io). \n\nYou can use these events to keep track of workflow runs, send back status updates, or share enriched data collected by your workflows back to Datadog. ","background_color":"white","font_size":"14","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true}},{"id":3352112108208662,"layout":{"x":30,"y":0,"width":96,"height":8},"definition":{"type":"note","content":"# Torq Events","background_color":"vivid_blue","font_size":"14","text_align":"center","vertical_align":"center","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true}}],"template_variables":[],"layout_type":"free","is_read_only":false,"notify_list":[],"id":"4tm-v9h-xfh"}
+{
+  "title": "Torq",
+  "description": "### Track all execution events posted from Torq workflows in one dashboard.\n\n### Use tags on events to separate events by environments, services, and applications. Or, build out dashboards. \n\n###For full visibility into your Torq workflow runs, go to [the Torq app](https//app.torq.io).",
+  "widgets": [
+    {
+      "id": 2147516070905912,
+      "layout": { "x": 30, "y": 19, "width": 96, "height": 50 },
+      "definition": {
+        "title": "Torq Activity Stream",
+        "title_size": "16",
+        "title_align": "left",
+        "time": { "live_span": "1w" },
+        "type": "event_stream",
+        "query": "sources:torq",
+        "tags_execution": "and",
+        "event_size": "s"
+      }
+    },
+    {
+      "id": 6137349677227188,
+      "layout": { "x": 30, "y": 8, "width": 96, "height": 9 },
+      "definition": {
+        "title": "Torq Activity Timeline",
+        "title_size": "16",
+        "title_align": "left",
+        "time": { "live_span": "1w" },
+        "type": "event_timeline",
+        "query": "sources:torq",
+        "tags_execution": "and"
+      }
+    },
+    {
+      "id": 4444164082222724,
+      "layout": { "x": 5, "y": 0, "width": 18, "height": 15 },
+      "definition": {
+        "type": "image",
+        "url": "https://raw.githubusercontent.com/DataDog/integrations-extras/master/torq/assets/logos/torq-black-horizontal.png",
+        "url_dark_theme": "https://raw.githubusercontent.com/DataDog/integrations-extras/master/torq/assets/logos/torq-white-horizontal.png",
+        "sizing": "contain",
+        "margin": "sm",
+        "has_background": false,
+        "has_border": false,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      }
+    },
+    {
+      "id": 2622851012825320,
+      "layout": { "x": 0, "y": 15, "width": 30, "height": 42 },
+      "definition": {
+        "type": "note",
+        "content": "### About Torq\n\n[Torq](https://torq.io) is a no-code automation platform for security and operations teams\n\n### Using this dashboard\n\nIn the dashboard, you can track Torq originated events though a timeline and event stream. These events are produced by the Datadog Post Event step in Torq workflows running in the [Torq App](https://app.torq.io). \n\nYou can use these events to keep track of workflow runs, send back status updates, or share enriched data collected by your workflows back to Datadog. ",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "vertical_align": "top",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      }
+    },
+    {
+      "id": 3352112108208662,
+      "layout": { "x": 30, "y": 0, "width": 96, "height": 8 },
+      "definition": {
+        "type": "note",
+        "content": "# Torq Events",
+        "background_color": "vivid_blue",
+        "font_size": "14",
+        "text_align": "center",
+        "vertical_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": []
+}

--- a/twingate/assets/dashboards/twingate_overview.json
+++ b/twingate/assets/dashboards/twingate_overview.json
@@ -1,1 +1,260 @@
-{"title":"Twingate Analytics","description":"## Twingate Analytics Dashboard\n\nThis dashboard allows organizations to monitor a user's resource access activities in real-time.\n\n- [How to setup](https://github.com/Twingate-Labs/datadog-integrations-extras/blob/master/twingate/README.md)","widgets":[{"id":7925098150197694,"definition":{"type":"image","url":"https://raw.githubusercontent.com/Twingate-Labs/datadog-integrations-extras/master/twingate/images/Twingate%20Logo%20-%20Wide.png","sizing":"contain","margin":"md","has_background":false,"has_border":false,"vertical_align":"center","horizontal_align":"center"},"layout":{"x":0,"y":0,"width":2,"height":2}},{"id":3025898482716718,"definition":{"title":"Total Data Received","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"service:\"Twingate Connection\""},"data_source":"logs","compute":{"metric":"@network.bytes_written","aggregation":"sum"},"name":"query1","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2},"layout":{"x":2,"y":0,"width":2,"height":2}},{"id":3068862536238648,"definition":{"title":"Total Data Sent","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"service:\"Twingate Connection\""},"data_source":"logs","compute":{"metric":"@network.bytes_read","aggregation":"sum"},"name":"query1","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2},"layout":{"x":4,"y":0,"width":2,"height":2}},{"id":3807551524115118,"definition":{"title":"Total Number of Users","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"service:\"Twingate Connection\""},"data_source":"logs","compute":{"metric":"@usr.email","aggregation":"cardinality"},"name":"query1","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2},"layout":{"x":6,"y":0,"width":2,"height":2}},{"id":3966737983833756,"definition":{"title":"Total Unique Resources","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":""},"data_source":"logs","compute":{"metric":"@resource.address","aggregation":"cardinality"},"name":"query1","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2},"layout":{"x":8,"y":0,"width":2,"height":2}},{"id":3901523089872658,"definition":{"title":"Twingate Event","title_size":"16","title_align":"left","requests":[{"query":{"query_string":"service:\"Twingate Connection\"","sort":{"column":"timestamp","order":"desc"},"data_source":"logs_stream","storage":"hot","indexes":[]},"response_format":"event_list","columns":[{"field":"status_line","width":"auto"},{"field":"timestamp","width":"auto"},{"field":"@usr.email","width":"auto"},{"field":"@connector.name","width":"auto"},{"field":"@network.client.ip","width":"auto"},{"field":"@resource.address","width":"auto"},{"field":"@resource.applied_rule","width":"auto"},{"field":"@evt.name","width":"auto"},{"field":"@network.transport","width":"auto"},{"field":"@connection.resource_port","width":"auto"},{"field":"@network.bytes_written","width":"auto"},{"field":"@network.bytes_read","width":"auto"},{"field":"@error.message","width":"auto"}]}],"type":"list_stream"},"layout":{"x":0,"y":2,"width":12,"height":2}},{"id":2155501656188746,"definition":{"title":"Client Geo Map","title_size":"16","title_align":"left","time":{"live_span":"1mo"},"type":"geomap","requests":[{"formulas":[{"formula":"query1","limit":{"count":1000,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":""},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@network.client.geoip.country.iso_code","sort":{"aggregation":"count","order":"desc"},"limit":1000}]}]}],"style":{"palette":"YlOrRd","palette_flip":false},"view":{"focus":"WORLD"}},"layout":{"x":0,"y":4,"width":6,"height":4}},{"id":8069716489194750,"definition":{"title":"Most Common Resources","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1","limit":{"order":"desc"}}],"style":{"palette":"datadog16"},"response_format":"scalar","queries":[{"search":{"query":"service:\"Twingate Connection\""},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@resource.address","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst","legend":{"type":"automatic"}},"layout":{"x":6,"y":4,"width":6,"height":4}}],"template_variables":[],"layout_type":"ordered","is_read_only":false,"notify_list":[],"reflow_type":"fixed","id":"ax9-977-v6d"}
+{
+  "title": "Twingate Analytics",
+  "description": "## Twingate Analytics Dashboard\n\nThis dashboard allows organizations to monitor a user's resource access activities in real-time.\n\n- [How to setup](https://github.com/Twingate-Labs/datadog-integrations-extras/blob/master/twingate/README.md)",
+  "widgets": [
+    {
+      "id": 7925098150197694,
+      "definition": {
+        "type": "image",
+        "url": "https://raw.githubusercontent.com/Twingate-Labs/datadog-integrations-extras/master/twingate/images/Twingate%20Logo%20-%20Wide.png",
+        "sizing": "contain",
+        "margin": "md",
+        "has_background": false,
+        "has_border": false,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      },
+      "layout": { "x": 0, "y": 0, "width": 2, "height": 2 }
+    },
+    {
+      "id": 3025898482716718,
+      "definition": {
+        "title": "Total Data Received",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "service:\"Twingate Connection\"" },
+                "data_source": "logs",
+                "compute": {
+                  "metric": "@network.bytes_written",
+                  "aggregation": "sum"
+                },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": []
+              }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": { "x": 2, "y": 0, "width": 2, "height": 2 }
+    },
+    {
+      "id": 3068862536238648,
+      "definition": {
+        "title": "Total Data Sent",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "service:\"Twingate Connection\"" },
+                "data_source": "logs",
+                "compute": {
+                  "metric": "@network.bytes_read",
+                  "aggregation": "sum"
+                },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": []
+              }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": { "x": 4, "y": 0, "width": 2, "height": 2 }
+    },
+    {
+      "id": 3807551524115118,
+      "definition": {
+        "title": "Total Number of Users",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "service:\"Twingate Connection\"" },
+                "data_source": "logs",
+                "compute": {
+                  "metric": "@usr.email",
+                  "aggregation": "cardinality"
+                },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": []
+              }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": { "x": 6, "y": 0, "width": 2, "height": 2 }
+    },
+    {
+      "id": 3966737983833756,
+      "definition": {
+        "title": "Total Unique Resources",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "" },
+                "data_source": "logs",
+                "compute": {
+                  "metric": "@resource.address",
+                  "aggregation": "cardinality"
+                },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": []
+              }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": { "x": 8, "y": 0, "width": 2, "height": 2 }
+    },
+    {
+      "id": 3901523089872658,
+      "definition": {
+        "title": "Twingate Event",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "query": {
+              "query_string": "service:\"Twingate Connection\"",
+              "sort": { "column": "timestamp", "order": "desc" },
+              "data_source": "logs_stream",
+              "storage": "hot",
+              "indexes": []
+            },
+            "response_format": "event_list",
+            "columns": [
+              { "field": "status_line", "width": "auto" },
+              { "field": "timestamp", "width": "auto" },
+              { "field": "@usr.email", "width": "auto" },
+              { "field": "@connector.name", "width": "auto" },
+              { "field": "@network.client.ip", "width": "auto" },
+              { "field": "@resource.address", "width": "auto" },
+              { "field": "@resource.applied_rule", "width": "auto" },
+              { "field": "@evt.name", "width": "auto" },
+              { "field": "@network.transport", "width": "auto" },
+              { "field": "@connection.resource_port", "width": "auto" },
+              { "field": "@network.bytes_written", "width": "auto" },
+              { "field": "@network.bytes_read", "width": "auto" },
+              { "field": "@error.message", "width": "auto" }
+            ]
+          }
+        ],
+        "type": "list_stream"
+      },
+      "layout": { "x": 0, "y": 2, "width": 12, "height": 2 }
+    },
+    {
+      "id": 2155501656188746,
+      "definition": {
+        "title": "Client Geo Map",
+        "title_size": "16",
+        "title_align": "left",
+        "time": { "live_span": "1mo" },
+        "type": "geomap",
+        "requests": [
+          {
+            "formulas": [
+              {
+                "formula": "query1",
+                "limit": { "count": 1000, "order": "desc" }
+              }
+            ],
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "" },
+                "data_source": "logs",
+                "compute": { "aggregation": "count" },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@network.client.geoip.country.iso_code",
+                    "sort": { "aggregation": "count", "order": "desc" },
+                    "limit": 1000
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "style": { "palette": "YlOrRd", "palette_flip": false },
+        "view": { "focus": "WORLD" }
+      },
+      "layout": { "x": 0, "y": 4, "width": 6, "height": 4 }
+    },
+    {
+      "id": 8069716489194750,
+      "definition": {
+        "title": "Most Common Resources",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1", "limit": { "order": "desc" } }],
+            "style": { "palette": "datadog16" },
+            "response_format": "scalar",
+            "queries": [
+              {
+                "search": { "query": "service:\"Twingate Connection\"" },
+                "data_source": "logs",
+                "compute": { "aggregation": "count" },
+                "name": "query1",
+                "indexes": ["*"],
+                "group_by": [
+                  {
+                    "facet": "@resource.address",
+                    "sort": { "aggregation": "count", "order": "desc" },
+                    "limit": 10
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "type": "sunburst",
+        "legend": { "type": "automatic" }
+      },
+      "layout": { "x": 6, "y": 4, "width": 6, "height": 4 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/typingdna_activelock/assets/dashboards/TypingDNAActiveLock.json
+++ b/typingdna_activelock/assets/dashboards/TypingDNAActiveLock.json
@@ -1,1 +1,916 @@
-{"title":"TypingDNA ActiveLock 2.2","description":"TypingDNA\n\nMonitor your organization computers that have TypingDNA ActiveLock installed. \nBest viewed with High Density Mode ON.\n\n![TypingDNA ActiveLock logo](https://www.typingdna.com/assets/images/logos/typingdna-activelock-logo.svg)","widgets":[{"id":3464202846327882,"definition":{"title":"Users and Apps","background_color":"vivid_blue","show_title":true,"type":"group","layout_type":"ordered","widgets":[{"id":5501809594424360,"definition":{"title":"Users","title_size":"16","title_align":"left","type":"query_table","requests":[{"formulas":[{"alias":"Avg score","formula":"query1"},{"alias":"Avg speed","formula":"query2"},{"alias":"Verifications","conditional_formats":[{"palette":"yellow_on_white","value":100,"comparator":"<"}],"limit":{"count":900,"order":"asc"},"cell_display_mode":"bar","formula":"query3"},{"alias":"Failed","conditional_formats":[{"palette":"red_on_white","value":0,"comparator":">"}],"cell_display_mode":"number","formula":"query4"},{"alias":"Training","conditional_formats":[{"palette":"green_on_white","value":500,"comparator":">"}],"cell_display_mode":"bar","formula":"query5"}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock)"},"data_source":"logs","compute":{"metric":"@typingdna.score","aggregation":"avg"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[{"facet":"host","sort":{"aggregation":"count","order":"desc"},"limit":10},{"facet":"@typingdna.username","sort":{"aggregation":"count","order":"desc"},"limit":10}]},{"search":{"query":"(source:typingdna service:activelock)"},"data_source":"logs","compute":{"metric":"@typingdna.speed","aggregation":"avg"},"name":"query2","storage":"hot","indexes":["*"],"group_by":[{"facet":"host","sort":{"aggregation":"count","order":"desc"},"limit":10},{"facet":"@typingdna.username","sort":{"aggregation":"count","order":"desc"},"limit":10}]},{"search":{"query":"(source:typingdna service:activelock) @action:verify"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query3","storage":"hot","indexes":["*"],"group_by":[{"facet":"host","sort":{"aggregation":"count","order":"asc"},"limit":30},{"facet":"@typingdna.username","sort":{"aggregation":"count","order":"asc"},"limit":30}]},{"search":{"query":"(source:typingdna service:activelock) @typingdna.result:FAIL"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query4","storage":"hot","indexes":["*"],"group_by":[{"facet":"host","sort":{"aggregation":"count","order":"desc"},"limit":30},{"facet":"@typingdna.username","sort":{"aggregation":"count","order":"desc"},"limit":30}]},{"search":{"query":"(source:typingdna service:activelock)"},"data_source":"logs","compute":{"metric":"@training_strength","aggregation":"max"},"name":"query5","storage":"hot","indexes":["*"],"group_by":[{"facet":"host","sort":{"aggregation":"count","order":"desc"},"limit":30},{"facet":"@typingdna.username","sort":{"aggregation":"count","order":"desc"},"limit":30}]}]}],"has_search_bar":"always"},"layout":{"x":0,"y":0,"width":12,"height":4}},{"id":768850866843830,"definition":{"title":"Main apps","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1","limit":{"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock) @action:verify $username $installID $host"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[{"facet":"@main_app","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst","legend":{"type":"automatic"}},"layout":{"x":0,"y":4,"width":12,"height":5}},{"id":2766821940862888,"definition":{"title":"Verified unique user hours","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"alias":"Unique user hours","formula":"query1"}],"response_format":"timeseries","queries":[{"search":{"query":"(source:typingdna service:activelock) @action:verify $username $installID $host"},"data_source":"logs","compute":{"metric":"@installID","interval":3600000,"aggregation":"cardinality"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"bars"}]},"layout":{"x":0,"y":9,"width":12,"height":3}},{"id":2041409487515276,"definition":{"title":"User speed vs score","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"alias":"Speed","formula":"query1"}],"response_format":"timeseries","on_right_yaxis":true,"queries":[{"search":{"query":"(source:typingdna service:activelock) $username $installID $host"},"data_source":"logs","compute":{"metric":"@typingdna.speed","aggregation":"avg"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"},{"formulas":[{"alias":"Score","formula":"query0"}],"response_format":"timeseries","queries":[{"search":{"query":"(source:typingdna service:activelock) $username $installID $host"},"data_source":"logs","compute":{"metric":"@typingdna.score","aggregation":"avg"},"name":"query0","storage":"hot","indexes":["*"],"group_by":[]}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"}],"markers":[{"value":"y = 50","display_type":"error dashed"}]},"layout":{"x":0,"y":12,"width":12,"height":3}},{"id":7315209466351582,"definition":{"title":"Alerts","title_size":"16","title_align":"left","requests":[{"query":{"query_string":"@evt.name:\"ActiveLock Alert\" $host","data_source":"event_stream","event_size":"s"},"response_format":"event_list","columns":[]}],"type":"list_stream"},"layout":{"x":0,"y":15,"width":12,"height":3}}]},"layout":{"x":0,"y":0,"width":12,"height":19}},{"id":6008050990181690,"definition":{"title":"Stats","background_color":"vivid_blue","show_title":true,"type":"group","layout_type":"ordered","widgets":[{"id":7440366630578144,"definition":{"title":"Unique users","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock) $username $installID $host"},"data_source":"logs","compute":{"metric":"@installID","aggregation":"cardinality"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2,"timeseries_background":{"type":"bars"}},"layout":{"x":0,"y":0,"width":2,"height":1}},{"id":5253790999056998,"definition":{"title":"Total verifications","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock) @action:verify $username $installID $host"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2,"timeseries_background":{"type":"bars"}},"layout":{"x":2,"y":0,"width":2,"height":1}},{"id":855011522934808,"definition":{"title":"Avg score","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock) $username $installID $host"},"data_source":"logs","compute":{"metric":"@typingdna.score","aggregation":"avg"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":0,"timeseries_background":{"type":"area","yaxis":{"include_zero":true}}},"layout":{"x":4,"y":0,"width":2,"height":1}},{"id":7564433300804826,"definition":{"title":"Unique apps","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock) $username $installID $host"},"data_source":"logs","compute":{"metric":"@main_app","aggregation":"cardinality"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2,"timeseries_background":{"type":"bars"}},"layout":{"x":6,"y":0,"width":2,"height":1}},{"id":3455960258791906,"definition":{"type":"image","url":"https://www.typingdna.com/assets/images/logos/typingdna-activelock-logo.svg","sizing":"contain","margin":"lg","has_background":true,"has_border":true,"vertical_align":"center","horizontal_align":"center"},"layout":{"x":8,"y":0,"width":4,"height":2}},{"id":8044139745836166,"definition":{"title":"Total logs","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock) $username $installID $host"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2,"timeseries_background":{"type":"bars"}},"layout":{"x":0,"y":1,"width":2,"height":1}},{"id":524055337737790,"definition":{"title":"Failed verifications","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"conditional_formats":[{"comparator":">","palette":"red_on_white","value":10}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock) @typingdna.result:FAIL $username $installID $host"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":2},"layout":{"x":2,"y":1,"width":2,"height":1}},{"id":2579038111246226,"definition":{"title":"Min score","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock) $username $installID $host"},"data_source":"logs","compute":{"metric":"@typingdna.score","aggregation":"min"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":0,"timeseries_background":{"type":"area","yaxis":{"include_zero":true}}},"layout":{"x":4,"y":1,"width":2,"height":1}},{"id":2761686154859484,"definition":{"title":"Avg speed","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"(source:typingdna service:activelock) $username $installID $host"},"data_source":"logs","compute":{"metric":"@typingdna.speed","aggregation":"avg"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}]}],"autoscale":true,"precision":0,"timeseries_background":{"type":"area"}},"layout":{"x":6,"y":1,"width":2,"height":1}},{"id":4070263098830900,"definition":{"title":"Verifications","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"alias":"All logs","style":{"palette_index":4,"palette":"classic"},"formula":"query0"}],"response_format":"timeseries","queries":[{"search":{"query":"(source:typingdna service:activelock) $username $installID $host"},"data_source":"logs","compute":{"interval":3600000,"aggregation":"count"},"name":"query0","storage":"hot","indexes":["*"],"group_by":[]}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"line"},{"formulas":[{"alias":"Verified","style":{"palette_index":1,"palette":"classic"},"formula":"query0"},{"alias":"Failed","style":{"palette_index":5,"palette":"warm"},"formula":"query1"}],"response_format":"timeseries","on_right_yaxis":true,"queries":[{"search":{"query":"(source:typingdna service:activelock) @action:verify $username $installID $host"},"data_source":"logs","compute":{"interval":3600000,"aggregation":"count"},"name":"query0","storage":"hot","indexes":["*"],"group_by":[]},{"search":{"query":"(source:typingdna service:activelock) @action:verify @typingdna.result:FAIL $username $installID $host"},"data_source":"logs","compute":{"interval":3600000,"aggregation":"count"},"name":"query1","storage":"hot","indexes":["*"],"group_by":[]}],"style":{"palette":"dog_classic","line_type":"solid","line_width":"normal"},"display_type":"bars"}],"markers":[{"value":"y = 0","display_type":"error dashed"}]},"layout":{"x":0,"y":2,"width":12,"height":5}}]},"layout":{"x":0,"y":0,"width":12,"height":8,"is_column_break":true}},{"id":5211189094564926,"definition":{"title":"Logs","background_color":"vivid_blue","show_title":true,"type":"group","layout_type":"ordered","widgets":[{"id":7960437102152068,"definition":{"title":"Verify logs","title_size":"16","title_align":"left","requests":[{"query":{"query_string":"(source:typingdna service:activelock) @action:verify $username $installID $host","data_source":"logs_stream","indexes":[]},"response_format":"event_list","columns":[{"field":"status_line","width":"auto"},{"field":"timestamp","width":"auto"},{"field":"host","width":"auto"},{"field":"@typingdna.username","width":"auto"},{"field":"@typingdna.result","width":"auto"},{"field":"@typingdna.score","width":"auto"},{"field":"@main_app","width":"auto"},{"field":"@typingdna.speed","width":"auto"},{"field":"@training_strength","width":"auto"},{"field":"@keyboard_id","width":"auto"}]}],"type":"list_stream"},"layout":{"x":0,"y":0,"width":12,"height":4}},{"id":8005509614804508,"definition":{"title":"Failed logs to investigate","title_size":"16","title_align":"left","requests":[{"query":{"query_string":"(source:typingdna service:activelock) @typingdna.result:FAIL $username $installID $host","data_source":"logs_stream","indexes":[]},"columns":[{"field":"status_line","width":"auto"},{"field":"timestamp","width":"auto"},{"field":"host","width":"auto"},{"field":"@typingdna.username","width":"auto"},{"field":"@typingdna.score","width":"auto"},{"field":"@main_app","width":"auto"},{"field":"@typingdna.speed","width":"auto"},{"field":"@training_strength","width":"auto"},{"field":"@keyboard_id","width":"auto"}],"response_format":"event_list"}],"type":"list_stream"},"layout":{"x":0,"y":4,"width":12,"height":2}},{"id":2676265118007168,"definition":{"title":"All logs","title_size":"16","title_align":"left","requests":[{"query":{"query_string":"(source:typingdna service:activelock) $username $installID $host","sort":{"column":"timestamp","order":"desc"},"data_source":"logs_stream","storage":"hot","indexes":[]},"columns":[{"field":"status_line","width":"auto"},{"field":"timestamp","width":"auto"},{"field":"host","width":"auto"},{"field":"content","width":"compact"},{"field":"@typingdna.username","width":"auto"},{"field":"@typingdna.result","width":"auto"},{"field":"@typingdna.score","width":"auto"},{"field":"@main_app","width":"auto"}],"response_format":"event_list"}],"type":"list_stream"},"layout":{"x":0,"y":6,"width":12,"height":4}}]},"layout":{"x":0,"y":8,"width":12,"height":11}}],"template_variables":[{"name":"host","prefix":"host","available_values":[],"default":"*"},{"name":"username","prefix":"@typingdna.username","available_values":[],"default":"*"},{"name":"installID","prefix":"@installID","available_values":[],"default":"*"}],"layout_type":"ordered","notify_list":[],"reflow_type":"fixed","id":"c4x-fc6-xbe"}
+{
+  "title": "TypingDNA ActiveLock 2.2",
+  "description": "TypingDNA\n\nMonitor your organization computers that have TypingDNA ActiveLock installed. \nBest viewed with High Density Mode ON.\n\n![TypingDNA ActiveLock logo](https://www.typingdna.com/assets/images/logos/typingdna-activelock-logo.svg)",
+  "widgets": [
+    {
+      "id": 3464202846327882,
+      "definition": {
+        "title": "Users and Apps",
+        "background_color": "vivid_blue",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 5501809594424360,
+            "definition": {
+              "title": "Users",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_table",
+              "requests": [
+                {
+                  "formulas": [
+                    { "alias": "Avg score", "formula": "query1" },
+                    { "alias": "Avg speed", "formula": "query2" },
+                    {
+                      "alias": "Verifications",
+                      "conditional_formats": [
+                        {
+                          "palette": "yellow_on_white",
+                          "value": 100,
+                          "comparator": "<"
+                        }
+                      ],
+                      "limit": { "count": 900, "order": "asc" },
+                      "cell_display_mode": "bar",
+                      "formula": "query3"
+                    },
+                    {
+                      "alias": "Failed",
+                      "conditional_formats": [
+                        {
+                          "palette": "red_on_white",
+                          "value": 0,
+                          "comparator": ">"
+                        }
+                      ],
+                      "cell_display_mode": "number",
+                      "formula": "query4"
+                    },
+                    {
+                      "alias": "Training",
+                      "conditional_formats": [
+                        {
+                          "palette": "green_on_white",
+                          "value": 500,
+                          "comparator": ">"
+                        }
+                      ],
+                      "cell_display_mode": "bar",
+                      "formula": "query5"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock)"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@typingdna.score",
+                        "aggregation": "avg"
+                      },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "host",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        },
+                        {
+                          "facet": "@typingdna.username",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    },
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock)"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@typingdna.speed",
+                        "aggregation": "avg"
+                      },
+                      "name": "query2",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "host",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        },
+                        {
+                          "facet": "@typingdna.username",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    },
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) @action:verify"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query3",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "host",
+                          "sort": { "aggregation": "count", "order": "asc" },
+                          "limit": 30
+                        },
+                        {
+                          "facet": "@typingdna.username",
+                          "sort": { "aggregation": "count", "order": "asc" },
+                          "limit": 30
+                        }
+                      ]
+                    },
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) @typingdna.result:FAIL"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query4",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "host",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 30
+                        },
+                        {
+                          "facet": "@typingdna.username",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 30
+                        }
+                      ]
+                    },
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock)"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@training_strength",
+                        "aggregation": "max"
+                      },
+                      "name": "query5",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "host",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 30
+                        },
+                        {
+                          "facet": "@typingdna.username",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 30
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "has_search_bar": "always"
+            },
+            "layout": { "x": 0, "y": 0, "width": 12, "height": 4 }
+          },
+          {
+            "id": 768850866843830,
+            "definition": {
+              "title": "Main apps",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "formulas": [
+                    { "formula": "query1", "limit": { "order": "desc" } }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) @action:verify $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@main_app",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "type": "sunburst",
+              "legend": { "type": "automatic" }
+            },
+            "layout": { "x": 0, "y": 4, "width": 12, "height": 5 }
+          },
+          {
+            "id": 2766821940862888,
+            "definition": {
+              "title": "Verified unique user hours",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "alias": "Unique user hours", "formula": "query1" }
+                  ],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) @action:verify $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@installID",
+                        "interval": 3600000,
+                        "aggregation": "cardinality"
+                      },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "bars"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 9, "width": 12, "height": 3 }
+          },
+          {
+            "id": 2041409487515276,
+            "definition": {
+              "title": "User speed vs score",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "alias": "Speed", "formula": "query1" }],
+                  "response_format": "timeseries",
+                  "on_right_yaxis": true,
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@typingdna.speed",
+                        "aggregation": "avg"
+                      },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                },
+                {
+                  "formulas": [{ "alias": "Score", "formula": "query0" }],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@typingdna.score",
+                        "aggregation": "avg"
+                      },
+                      "name": "query0",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "markers": [{ "value": "y = 50", "display_type": "error dashed" }]
+            },
+            "layout": { "x": 0, "y": 12, "width": 12, "height": 3 }
+          },
+          {
+            "id": 7315209466351582,
+            "definition": {
+              "title": "Alerts",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "query": {
+                    "query_string": "@evt.name:\"ActiveLock Alert\" $host",
+                    "data_source": "event_stream",
+                    "event_size": "s"
+                  },
+                  "response_format": "event_list",
+                  "columns": []
+                }
+              ],
+              "type": "list_stream"
+            },
+            "layout": { "x": 0, "y": 15, "width": 12, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 19 }
+    },
+    {
+      "id": 6008050990181690,
+      "definition": {
+        "title": "Stats",
+        "background_color": "vivid_blue",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 7440366630578144,
+            "definition": {
+              "title": "Unique users",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@installID",
+                        "aggregation": "cardinality"
+                      },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2,
+              "timeseries_background": { "type": "bars" }
+            },
+            "layout": { "x": 0, "y": 0, "width": 2, "height": 1 }
+          },
+          {
+            "id": 5253790999056998,
+            "definition": {
+              "title": "Total verifications",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) @action:verify $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2,
+              "timeseries_background": { "type": "bars" }
+            },
+            "layout": { "x": 2, "y": 0, "width": 2, "height": 1 }
+          },
+          {
+            "id": 855011522934808,
+            "definition": {
+              "title": "Avg score",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@typingdna.score",
+                        "aggregation": "avg"
+                      },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 0,
+              "timeseries_background": {
+                "type": "area",
+                "yaxis": { "include_zero": true }
+              }
+            },
+            "layout": { "x": 4, "y": 0, "width": 2, "height": 1 }
+          },
+          {
+            "id": 7564433300804826,
+            "definition": {
+              "title": "Unique apps",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@main_app",
+                        "aggregation": "cardinality"
+                      },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2,
+              "timeseries_background": { "type": "bars" }
+            },
+            "layout": { "x": 6, "y": 0, "width": 2, "height": 1 }
+          },
+          {
+            "id": 3455960258791906,
+            "definition": {
+              "type": "image",
+              "url": "https://www.typingdna.com/assets/images/logos/typingdna-activelock-logo.svg",
+              "sizing": "contain",
+              "margin": "lg",
+              "has_background": true,
+              "has_border": true,
+              "vertical_align": "center",
+              "horizontal_align": "center"
+            },
+            "layout": { "x": 8, "y": 0, "width": 4, "height": 2 }
+          },
+          {
+            "id": 8044139745836166,
+            "definition": {
+              "title": "Total logs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2,
+              "timeseries_background": { "type": "bars" }
+            },
+            "layout": { "x": 0, "y": 1, "width": 2, "height": 1 }
+          },
+          {
+            "id": 524055337737790,
+            "definition": {
+              "title": "Failed verifications",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">",
+                      "palette": "red_on_white",
+                      "value": 10
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) @typingdna.result:FAIL $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 2
+            },
+            "layout": { "x": 2, "y": 1, "width": 2, "height": 1 }
+          },
+          {
+            "id": 2579038111246226,
+            "definition": {
+              "title": "Min score",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@typingdna.score",
+                        "aggregation": "min"
+                      },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 0,
+              "timeseries_background": {
+                "type": "area",
+                "yaxis": { "include_zero": true }
+              }
+            },
+            "layout": { "x": 4, "y": 1, "width": 2, "height": 1 }
+          },
+          {
+            "id": 2761686154859484,
+            "definition": {
+              "title": "Avg speed",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "metric": "@typingdna.speed",
+                        "aggregation": "avg"
+                      },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "precision": 0,
+              "timeseries_background": { "type": "area" }
+            },
+            "layout": { "x": 6, "y": 1, "width": 2, "height": 1 }
+          },
+          {
+            "id": 4070263098830900,
+            "definition": {
+              "title": "Verifications",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "alias": "All logs",
+                      "style": { "palette_index": 4, "palette": "classic" },
+                      "formula": "query0"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "interval": 3600000,
+                        "aggregation": "count"
+                      },
+                      "name": "query0",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                },
+                {
+                  "formulas": [
+                    {
+                      "alias": "Verified",
+                      "style": { "palette_index": 1, "palette": "classic" },
+                      "formula": "query0"
+                    },
+                    {
+                      "alias": "Failed",
+                      "style": { "palette_index": 5, "palette": "warm" },
+                      "formula": "query1"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "on_right_yaxis": true,
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) @action:verify $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "interval": 3600000,
+                        "aggregation": "count"
+                      },
+                      "name": "query0",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    },
+                    {
+                      "search": {
+                        "query": "(source:typingdna service:activelock) @action:verify @typingdna.result:FAIL $username $installID $host"
+                      },
+                      "data_source": "logs",
+                      "compute": {
+                        "interval": 3600000,
+                        "aggregation": "count"
+                      },
+                      "name": "query1",
+                      "storage": "hot",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "bars"
+                }
+              ],
+              "markers": [{ "value": "y = 0", "display_type": "error dashed" }]
+            },
+            "layout": { "x": 0, "y": 2, "width": 12, "height": 5 }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 12,
+        "height": 8,
+        "is_column_break": true
+      }
+    },
+    {
+      "id": 5211189094564926,
+      "definition": {
+        "title": "Logs",
+        "background_color": "vivid_blue",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 7960437102152068,
+            "definition": {
+              "title": "Verify logs",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "query": {
+                    "query_string": "(source:typingdna service:activelock) @action:verify $username $installID $host",
+                    "data_source": "logs_stream",
+                    "indexes": []
+                  },
+                  "response_format": "event_list",
+                  "columns": [
+                    { "field": "status_line", "width": "auto" },
+                    { "field": "timestamp", "width": "auto" },
+                    { "field": "host", "width": "auto" },
+                    { "field": "@typingdna.username", "width": "auto" },
+                    { "field": "@typingdna.result", "width": "auto" },
+                    { "field": "@typingdna.score", "width": "auto" },
+                    { "field": "@main_app", "width": "auto" },
+                    { "field": "@typingdna.speed", "width": "auto" },
+                    { "field": "@training_strength", "width": "auto" },
+                    { "field": "@keyboard_id", "width": "auto" }
+                  ]
+                }
+              ],
+              "type": "list_stream"
+            },
+            "layout": { "x": 0, "y": 0, "width": 12, "height": 4 }
+          },
+          {
+            "id": 8005509614804508,
+            "definition": {
+              "title": "Failed logs to investigate",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "query": {
+                    "query_string": "(source:typingdna service:activelock) @typingdna.result:FAIL $username $installID $host",
+                    "data_source": "logs_stream",
+                    "indexes": []
+                  },
+                  "columns": [
+                    { "field": "status_line", "width": "auto" },
+                    { "field": "timestamp", "width": "auto" },
+                    { "field": "host", "width": "auto" },
+                    { "field": "@typingdna.username", "width": "auto" },
+                    { "field": "@typingdna.score", "width": "auto" },
+                    { "field": "@main_app", "width": "auto" },
+                    { "field": "@typingdna.speed", "width": "auto" },
+                    { "field": "@training_strength", "width": "auto" },
+                    { "field": "@keyboard_id", "width": "auto" }
+                  ],
+                  "response_format": "event_list"
+                }
+              ],
+              "type": "list_stream"
+            },
+            "layout": { "x": 0, "y": 4, "width": 12, "height": 2 }
+          },
+          {
+            "id": 2676265118007168,
+            "definition": {
+              "title": "All logs",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "query": {
+                    "query_string": "(source:typingdna service:activelock) $username $installID $host",
+                    "sort": { "column": "timestamp", "order": "desc" },
+                    "data_source": "logs_stream",
+                    "storage": "hot",
+                    "indexes": []
+                  },
+                  "columns": [
+                    { "field": "status_line", "width": "auto" },
+                    { "field": "timestamp", "width": "auto" },
+                    { "field": "host", "width": "auto" },
+                    { "field": "content", "width": "compact" },
+                    { "field": "@typingdna.username", "width": "auto" },
+                    { "field": "@typingdna.result", "width": "auto" },
+                    { "field": "@typingdna.score", "width": "auto" },
+                    { "field": "@main_app", "width": "auto" }
+                  ],
+                  "response_format": "event_list"
+                }
+              ],
+              "type": "list_stream"
+            },
+            "layout": { "x": 0, "y": 6, "width": 12, "height": 4 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 8, "width": 12, "height": 11 }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "host",
+      "prefix": "host",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "username",
+      "prefix": "@typingdna.username",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "installID",
+      "prefix": "@installID",
+      "available_values": [],
+      "default": "*"
+    }
+  ],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/unitq/assets/dashboards/unitq_overview.json
+++ b/unitq/assets/dashboards/unitq_overview.json
@@ -1,1 +1,73 @@
-{"title":"unitQ Feedback Overview","description":"## unitQ Feedback Overview\n\nunitQ Monitor gives you visibility into customer feedback trends so you can continuously improve product quality.\n\nFor more information, see the unitQ help center:\n- [https://unitq.zendesk.com/hc/en-us/articles/9384022598803](#)","widgets":[{"id":1565057974780236,"definition":{"type":"image","url":"https://blog.unitq.com/wp-content/uploads/2020/12/xcropped-logo-2.png.pagespeed.ic.tHJJGpNFwi.webp","sizing":"contain","margin":"md","has_background":false,"has_border":true,"vertical_align":"center","horizontal_align":"center"},"layout":{"x":0,"y":0,"width":4,"height":3}},{"id":1073161555072138,"definition":{"title":"User Feedback Volume by Hour","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"auto","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"formula":"query1"}],"response_format":"timeseries","queries":[{"query":"sum:unitq.user_feedback{*}.as_count().rollup(sum, 3600)","data_source":"metrics","name":"query1"}],"style":{"palette":"blue","line_type":"solid","line_width":"normal"},"display_type":"bars"}]},"layout":{"x":4,"y":0,"width":7,"height":5}},{"id":4736819734656270,"definition":{"type":"note","content":"unitQ Monitor gives you visibility into customer feedback trends so you can continuously improve product quality.","background_color":"white","font_size":"16","text_align":"center","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":0,"y":3,"width":4,"height":2}}],"template_variables":[],"layout_type":"ordered","is_read_only":false,"notify_list":[],"reflow_type":"fixed","id":"qni-utb-aqq"}
+{
+  "title": "unitQ Feedback Overview",
+  "description": "## unitQ Feedback Overview\n\nunitQ Monitor gives you visibility into customer feedback trends so you can continuously improve product quality.\n\nFor more information, see the unitQ help center:\n- [https://unitq.zendesk.com/hc/en-us/articles/9384022598803](#)",
+  "widgets": [
+    {
+      "id": 1565057974780236,
+      "definition": {
+        "type": "image",
+        "url": "https://blog.unitq.com/wp-content/uploads/2020/12/xcropped-logo-2.png.pagespeed.ic.tHJJGpNFwi.webp",
+        "sizing": "contain",
+        "margin": "md",
+        "has_background": false,
+        "has_border": true,
+        "vertical_align": "center",
+        "horizontal_align": "center"
+      },
+      "layout": { "x": 0, "y": 0, "width": 4, "height": 3 }
+    },
+    {
+      "id": 1073161555072138,
+      "definition": {
+        "title": "User Feedback Volume by Hour",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "query": "sum:unitq.user_feedback{*}.as_count().rollup(sum, 3600)",
+                "data_source": "metrics",
+                "name": "query1"
+              }
+            ],
+            "style": {
+              "palette": "blue",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "bars"
+          }
+        ]
+      },
+      "layout": { "x": 4, "y": 0, "width": 7, "height": 5 }
+    },
+    {
+      "id": 4736819734656270,
+      "definition": {
+        "type": "note",
+        "content": "unitQ Monitor gives you visibility into customer feedback trends so you can continuously improve product quality.",
+        "background_color": "white",
+        "font_size": "16",
+        "text_align": "center",
+        "vertical_align": "top",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      },
+      "layout": { "x": 0, "y": 3, "width": 4, "height": 2 }
+    }
+  ],
+  "template_variables": [],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}

--- a/zscaler/assets/dashboards/zscaler_overview.json
+++ b/zscaler/assets/dashboards/zscaler_overview.json
@@ -1,1 +1,1614 @@
-{"title":"Zscaler Overview","description":"## Zscaler\n\nThe Zscaler dashboard gives you broad visibility into your Zscaler Internet Access (ZIA) logs.","widgets":[{"id":238398177864352,"definition":{"title":"About Zscaler","title_align":"center","type":"group","banner_img":"/static/images/integration_dashboard/zscaler_hero_1.png","show_title":false,"layout_type":"ordered","widgets":[{"id":1824612587503156,"definition":{"type":"note","content":"### Our Zscaler dashboard gives you broad visibility into your Zscaler Internet Access (ZIA) logs. You can use the template variables to investigate your users' activity.\n\n","background_color":"transparent","font_size":"16","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":0,"y":0,"width":3,"height":2}},{"id":7227575384129866,"definition":{"type":"note","content":"[Datadog installation docs&nbsp;↗](https://docs.datadoghq.com/integrations/zscaler/)\n\n[Zscaler About Log forwarding&nbsp;↗](https://help.zscaler.com/cloud-connector/about-log-and-control-forwarding)\n\n[Zscaler Configuring Log forwarding&nbsp;↗](https://help.zscaler.com/cloud-connector/configuring-log-and-control-forwarding-rule)\n","background_color":"transparent","font_size":"16","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":3,"y":0,"width":3,"height":2}}]},"layout":{"x":0,"y":0,"width":6,"height":5}},{"id":2447777735404102,"definition":{"title":"Overview","type":"group","background_color":"blue","show_title":true,"layout_type":"ordered","widgets":[{"id":5482263142089764,"definition":{"title":"% Request Blocked","title_size":"16","title_align":"left","type":"query_value","requests":[{"formulas":[{"formula":"(1 - (query2 / query1)) * 100"}],"conditional_formats":[{"comparator":">","palette":"white_on_red","value":15},{"comparator":">=","palette":"white_on_yellow","value":10},{"comparator":"<=","palette":"white_on_green","value":5}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[]},{"search":{"query":"source:zscaler @sourcetype:zscalernss-web @evt.outcome:Allowed $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query2","indexes":["*"],"group_by":[]}]}],"autoscale":true,"custom_unit":"%","precision":2},"layout":{"x":0,"y":0,"width":2,"height":2}},{"id":8803858889684562,"definition":{"title":"Threat Name","title_size":"16","title_align":"left","type":"query_table","requests":[{"formulas":[{"alias":"Count","cell_display_mode":"bar","limit":{"count":10,"order":"desc"},"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName -@zscaler.threatname:None"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.threatname","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":2,"y":0,"width":4,"height":4}},{"id":584169620390518,"definition":{"type":"note","content":"The summary provides a list of the top threats identified in your account. For more information on the threats, visit the [Threat library&nbsp;↗](https://threatlibrary.zscaler.com/)\n\n","background_color":"purple","font_size":"14","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":0,"y":2,"width":2,"height":2}}]},"layout":{"x":6,"y":0,"width":6,"height":5}},{"id":7327598776764860,"definition":{"title":"Log Overview","type":"group","background_color":"green","show_title":true,"layout_type":"ordered","widgets":[{"id":3094723728897140,"definition":{"title":"Traffic","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"horizontal","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"alias":"Outcome","formula":"query1"}],"response_format":"timeseries","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@evt.outcome","sort":{"aggregation":"count","order":"desc"},"limit":10}]}],"style":{"palette":"red","line_type":"solid","line_width":"normal"},"display_type":"area"}]},"layout":{"x":0,"y":0,"width":6,"height":3}},{"id":7166972782319442,"definition":{"title":"Outcome","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@evt.outcome","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst"},"layout":{"x":0,"y":3,"width":3,"height":3}},{"id":8237161245752714,"definition":{"title":"Zscaler Log Types","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@sourcetype","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst"},"layout":{"x":3,"y":3,"width":3,"height":3}}]},"layout":{"x":0,"y":0,"width":6,"height":7}},{"id":4308588107320554,"definition":{"title":"IP Information","title_align":"center","type":"group","background_color":"green","show_title":true,"layout_type":"ordered","widgets":[{"id":1946662551304792,"definition":{"title":"Client IPs","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@network.client.ip","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"custom_links":[{"link":"/screen/integration/security-monitoring-ip-investigation?tpl_var_network.client.ip={{@network.client.ip.value}}","label":"Explore in IP Investigation dashboard"}]},"layout":{"x":0,"y":0,"width":3,"height":3}},{"id":8444029491969190,"definition":{"title":"Client Geo IPs","title_size":"16","title_align":"left","type":"geomap","requests":[{"formulas":[{"formula":"query1","limit":{"count":250,"order":"asc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@network.client.geoip.country.iso_code","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"style":{"palette":"hostmap_blues","palette_flip":false},"view":{"focus":"WORLD"}},"layout":{"x":3,"y":0,"width":3,"height":3}},{"id":3650274739830186,"definition":{"title":"Destination IPs","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@network.destination.ip","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"custom_links":[{"link":"/screen/integration/security-monitoring-ip-investigation?tpl_var_network.client.ip={{@network.client.ip.value}}","label":"Explore in IP Investigation dashboard"}]},"layout":{"x":0,"y":3,"width":3,"height":3}},{"id":7774255153068396,"definition":{"title":"Destination Geo IP Data","title_size":"16","title_align":"left","type":"geomap","requests":[{"formulas":[{"formula":"query1","limit":{"count":250,"order":"asc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@network.destination.geoip.country.iso_code","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"style":{"palette":"hostmap_blues","palette_flip":false},"view":{"focus":"WORLD"}},"layout":{"x":3,"y":3,"width":3,"height":3}}]},"layout":{"x":6,"y":0,"width":6,"height":7}},{"id":4033176697418068,"definition":{"title":"Web Logs","type":"group","background_color":"green","show_title":true,"layout_type":"ordered","widgets":[{"id":5529815589549788,"definition":{"type":"note","content":"Web Logs: View which URLs were requested, Page Risk Index score for each, the number of bytes sent and received, and more. For more information on the fields available, check out [Zscaler documentation](https://help.zscaler.com/zia/web-insights-logs-columns)\n","background_color":"purple","font_size":"16","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":0,"y":0,"width":12,"height":1}},{"id":7006286125768150,"definition":{"title":"Zscaler Web Logs","title_size":"16","title_align":"left","type":"log_stream","indexes":[],"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName","sort":{"column":"time","order":"desc"},"columns":["@usr.id","@http.status_code","@zscaler.protocol","@http.url_details.host","@http.url_details.path","@evt.outcome","@zscaler.appclass","@network.destination.ip"],"show_date_column":true,"show_message_column":false,"message_display":"inline"},"layout":{"x":0,"y":1,"width":12,"height":4}}]},"layout":{"x":0,"y":12,"width":12,"height":6}},{"id":3485485445195226,"definition":{"title":"Clients","type":"group","background_color":"vivid_green","show_title":true,"layout_type":"ordered","widgets":[{"id":7858634414942258,"definition":{"title":"User IDs","title_size":"16","title_align":"left","type":"query_table","requests":[{"formulas":[{"alias":"Count","cell_display_mode":"bar","limit":{"count":10,"order":"desc"},"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@usr.id","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":0,"y":0,"width":4,"height":2}},{"id":1533144615531518,"definition":{"title":"User Agent Browser","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@http.useragent_details.browser.family","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":0,"y":2,"width":4,"height":2}},{"id":2075838375292588,"definition":{"title":"User Agent Device Category","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@http.useragent_details.device.category","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst"},"layout":{"x":0,"y":4,"width":4,"height":3}},{"id":5690008231978388,"definition":{"title":"User Agent OS","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@http.useragent_details.os.family","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst"},"layout":{"x":0,"y":7,"width":4,"height":3}}]},"layout":{"x":0,"y":0,"width":4,"height":11}},{"id":2131573647207158,"definition":{"title":"Connection","type":"group","background_color":"vivid_green","show_title":true,"layout_type":"ordered","widgets":[{"id":7858508788470362,"definition":{"title":"Blocked Reason","title_size":"16","title_align":"left","type":"query_table","requests":[{"formulas":[{"alias":"Blocked Count","limit":{"count":25,"order":"desc"},"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName -@zscaler.reason:Allowed"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.reason","sort":{"aggregation":"count","order":"desc"},"limit":25}]}]}]},"layout":{"x":0,"y":0,"width":5,"height":3}},{"id":7664664148694272,"definition":{"type":"note","content":"Requests are blocked based on policy rules. You can learn more about Policy reasons [here &nbsp;↗](https://help.zscaler.com/zia/policy-reasons)\n\n","background_color":"purple","font_size":"16","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":5,"y":0,"width":3,"height":2}},{"id":6800442493828026,"definition":{"title":"HTTP Host","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@http.url_details.host","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":5,"y":2,"width":3,"height":5}},{"id":3663205031183960,"definition":{"title":"App Class","type":"treemap","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.appclass","sort":{"aggregation":"count","order":"desc"},"limit":5}]}]}]},"layout":{"x":0,"y":3,"width":5,"height":3}},{"id":796061034744538,"definition":{"title":"File Types","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.filetype","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":0,"y":6,"width":5,"height":2}},{"id":4757003018049670,"definition":{"title":"Protocol","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.protocol","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst"},"layout":{"x":5,"y":7,"width":3,"height":3}},{"id":4822311045805642,"definition":{"title":"Content Type","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.contenttype","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":0,"y":8,"width":5,"height":2}}]},"layout":{"x":4,"y":0,"width":8,"height":11}},{"id":8483481151008012,"definition":{"title":"Firewall Logs","type":"group","background_color":"green","show_title":true,"layout_type":"ordered","widgets":[{"id":4914632857697106,"definition":{"title":"IP Categories","type":"treemap","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.ipcat","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":0,"y":0,"width":9,"height":4}},{"id":5422308923349676,"definition":{"title":"Outcomes","title_size":"16","title_align":"left","type":"query_table","requests":[{"formulas":[{"alias":"Count","cell_display_mode":"bar","limit":{"count":10,"order":"desc"},"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName -@evt.outcome:Allow"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@evt.outcome","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":9,"y":0,"width":3,"height":4}},{"id":3155036118196264,"definition":{"title":"Zscaler Firewall Logs","title_size":"16","title_align":"left","type":"log_stream","indexes":[],"query":"source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName","sort":{"column":"time","order":"desc"},"columns":["@usr.id","@zscaler.ipcat","@evt.outcome","@zscaler.cdip","@zscaler.cdport","@zscaler.csip","@zscaler.csport","@zscaler.sdport","@zscaler.ssip","@zscaler.tsip","@zscaler.tuntype"],"show_date_column":true,"show_message_column":false,"message_display":"inline"},"layout":{"x":0,"y":4,"width":7,"height":5}},{"id":5673146697583932,"definition":{"type":"note","content":"Firewall logs: View details such as the rule that was applied, the client and server details, and the network services and applications. For more information on the fields available, check out [Zscaler documentation](https://help.zscaler.com/zia/firewall-insights-logs-columns)\n","background_color":"purple","font_size":"16","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":7,"y":4,"width":5,"height":2}},{"id":3207506830430132,"definition":{"title":"Outcomes","title_size":"16","title_align":"left","show_legend":true,"legend_layout":"horizontal","legend_columns":["avg","min","max","value","sum"],"type":"timeseries","requests":[{"formulas":[{"alias":"Blocks","formula":"query1"},{"alias":"Allows","formula":"query2"}],"response_format":"timeseries","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName -@evt.outcome:Allow"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[]},{"search":{"query":"source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName @evt.outcome:Allow*"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query2","indexes":["*"],"group_by":[]}],"style":{"palette":"orange","line_type":"solid","line_width":"normal"},"display_type":"area"}]},"layout":{"x":7,"y":6,"width":5,"height":3}}]},"layout":{"x":0,"y":0,"width":12,"height":10,"is_column_break":true}},{"id":5680906160760548,"definition":{"title":"DNS Logs","type":"group","background_color":"green","show_title":true,"layout_type":"ordered","widgets":[{"id":2095928842075854,"definition":{"title":"Domain Categories","type":"treemap","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.category","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":0,"y":0,"width":9,"height":3}},{"id":6464814959931842,"definition":{"title":"DNS Request Types","title_size":"16","title_align":"left","requests":[{"formulas":[{"formula":"query1"}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.dns_reqtype","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}],"type":"sunburst","legend":{"type":"inline"}},"layout":{"x":9,"y":0,"width":3,"height":3}},{"id":6409609686012188,"definition":{"title":"Zscaler DNS Logs","title_size":"16","title_align":"left","type":"log_stream","indexes":[],"query":"source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName","sort":{"column":"time","order":"desc"},"columns":["@usr.id","@zscaler.dns_req","@network.destination.ip","@zscaler.dns_reqtype","@zscaler.category","@zscaler.reqrulelabel","@zscaler.resrulelabel"],"show_date_column":true,"show_message_column":false,"message_display":"inline"},"layout":{"x":0,"y":3,"width":12,"height":3}},{"id":8260593589800880,"definition":{"title":"Response Rule Labels","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.resrulelabel","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":0,"y":6,"width":5,"height":2}},{"id":4819985639268670,"definition":{"title":"Resolved IPs","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@network.destination.ip","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":5,"y":6,"width":4,"height":2}},{"id":2426215030361964,"definition":{"type":"note","content":"DNS logs: View data, such as the DNS request and response details. For more information on the fields available, check out [Zscaler documentation](https://help.zscaler.com/zia/dns-insights-logs-columns)\n","background_color":"purple","font_size":"16","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":9,"y":6,"width":3,"height":2}},{"id":8477711285123078,"definition":{"title":"Request Rule Labels","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.reqrulelabel","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":0,"y":8,"width":5,"height":2}},{"id":161142555916574,"definition":{"title":"DNS Requests","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.dns_req","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":5,"y":8,"width":7,"height":2}}]},"layout":{"x":0,"y":10,"width":12,"height":11}},{"id":3684424770580902,"definition":{"title":"Tunnel Logs","type":"group","background_color":"green","show_title":true,"layout_type":"ordered","widgets":[{"id":2256935659852146,"definition":{"title":"Record Types","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-tunnel $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.Recordtype","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":0,"y":0,"width":4,"height":2}},{"id":6845510121838372,"definition":{"title":"Tunnel Types","title_size":"16","title_align":"left","type":"toplist","requests":[{"formulas":[{"formula":"query1","limit":{"count":10,"order":"desc"}}],"response_format":"scalar","queries":[{"search":{"query":"source:zscaler @sourcetype:zscalernss-tunnel $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"},"data_source":"logs","compute":{"aggregation":"count"},"name":"query1","indexes":["*"],"group_by":[{"facet":"@zscaler.tunneltype","sort":{"aggregation":"count","order":"desc"},"limit":10}]}]}]},"layout":{"x":4,"y":0,"width":4,"height":2}},{"id":1331890568880528,"definition":{"type":"note","content":"Tunnel logs: View data about GRE and IPSec tunnels, such as their health, status, and authentication and encryption algorithms. For more information on the fields available, check out [Zscaler documentation](https://help.zscaler.com/zia/tunnel-insights-logs-columns)\n","background_color":"purple","font_size":"16","text_align":"left","vertical_align":"top","show_tick":false,"tick_pos":"50%","tick_edge":"left","has_padding":true},"layout":{"x":8,"y":0,"width":4,"height":2}},{"id":7464658587878514,"definition":{"title":"Zscaler Tunnel Logs","title_size":"16","title_align":"left","type":"log_stream","indexes":[],"query":"source:zscaler @sourcetype:zscalernss-tunnel $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName","sort":{"column":"time","order":"desc"},"columns":["@usr.id","@zscaler.Recordtype","@zscaler.tunneltype","@network.destination.ip","@network.client.ip","@network.client.port","@zscaler.rxbytes"],"show_date_column":true,"show_message_column":false,"message_display":"inline"},"layout":{"x":0,"y":2,"width":12,"height":3}}]},"layout":{"x":0,"y":21,"width":12,"height":6}}],"template_variables":[{"name":"ClientIP","default":"*","prefix":"@network.client.ip","available_values":[]},{"name":"DestinationIP","default":"*","prefix":"@network.destination.ip","available_values":[]},{"name":"UserID","default":"*","prefix":"@usr.id","available_values":[]},{"name":"HTTPHost","default":"*","prefix":"@http.url_details.host","available_values":[]},{"name":"HTTPProtocol","default":"*","prefix":"@zscaler.protocol","available_values":[]},{"name":"HTTPContentType","default":"*","prefix":"@zscaler.contenttype","available_values":[]},{"name":"ZscalerAppClass","default":"*","prefix":"@zscaler.appclass","available_values":[]},{"name":"Outcome","default":"*","prefix":"@evt.outcome","available_values":[]},{"name":"DNSRequestName","default":"*","prefix":"@zscaler.dns_req","available_values":[]}],"layout_type":"ordered","is_read_only":false,"notify_list":[],"reflow_type":"fixed","id":"8ds-q5a-jqd"}
+{
+  "title": "Zscaler Overview",
+  "description": "## Zscaler\n\nThe Zscaler dashboard gives you broad visibility into your Zscaler Internet Access (ZIA) logs.",
+  "widgets": [
+    {
+      "id": 238398177864352,
+      "definition": {
+        "title": "About Zscaler",
+        "title_align": "center",
+        "type": "group",
+        "banner_img": "/static/images/integration_dashboard/zscaler_hero_1.png",
+        "show_title": false,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 1824612587503156,
+            "definition": {
+              "type": "note",
+              "content": "### Our Zscaler dashboard gives you broad visibility into your Zscaler Internet Access (ZIA) logs. You can use the template variables to investigate your users' activity.\n\n",
+              "background_color": "transparent",
+              "font_size": "16",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 0, "y": 0, "width": 3, "height": 2 }
+          },
+          {
+            "id": 7227575384129866,
+            "definition": {
+              "type": "note",
+              "content": "[Datadog installation docs&nbsp;↗](https://docs.datadoghq.com/integrations/zscaler/)\n\n[Zscaler About Log forwarding&nbsp;↗](https://help.zscaler.com/cloud-connector/about-log-and-control-forwarding)\n\n[Zscaler Configuring Log forwarding&nbsp;↗](https://help.zscaler.com/cloud-connector/configuring-log-and-control-forwarding-rule)\n",
+              "background_color": "transparent",
+              "font_size": "16",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 3, "y": 0, "width": 3, "height": 2 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 0, "width": 6, "height": 5 }
+    },
+    {
+      "id": 2447777735404102,
+      "definition": {
+        "title": "Overview",
+        "type": "group",
+        "background_color": "blue",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 5482263142089764,
+            "definition": {
+              "title": "% Request Blocked",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "(1 - (query2 / query1)) * 100" }],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">",
+                      "palette": "white_on_red",
+                      "value": 15
+                    },
+                    {
+                      "comparator": ">=",
+                      "palette": "white_on_yellow",
+                      "value": 10
+                    },
+                    {
+                      "comparator": "<=",
+                      "palette": "white_on_green",
+                      "value": 5
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": []
+                    },
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web @evt.outcome:Allowed $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query2",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "custom_unit": "%",
+              "precision": 2
+            },
+            "layout": { "x": 0, "y": 0, "width": 2, "height": 2 }
+          },
+          {
+            "id": 8803858889684562,
+            "definition": {
+              "title": "Threat Name",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_table",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "alias": "Count",
+                      "cell_display_mode": "bar",
+                      "limit": { "count": 10, "order": "desc" },
+                      "formula": "query1"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName -@zscaler.threatname:None"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.threatname",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 2, "y": 0, "width": 4, "height": 4 }
+          },
+          {
+            "id": 584169620390518,
+            "definition": {
+              "type": "note",
+              "content": "The summary provides a list of the top threats identified in your account. For more information on the threats, visit the [Threat library&nbsp;↗](https://threatlibrary.zscaler.com/)\n\n",
+              "background_color": "purple",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 0, "y": 2, "width": 2, "height": 2 }
+          }
+        ]
+      },
+      "layout": { "x": 6, "y": 0, "width": 6, "height": 5 }
+    },
+    {
+      "id": 7327598776764860,
+      "definition": {
+        "title": "Log Overview",
+        "type": "group",
+        "background_color": "green",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 3094723728897140,
+            "definition": {
+              "title": "Traffic",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "horizontal",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [{ "alias": "Outcome", "formula": "query1" }],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@evt.outcome",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ],
+                  "style": {
+                    "palette": "red",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "area"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 0, "width": 6, "height": 3 }
+          },
+          {
+            "id": 7166972782319442,
+            "definition": {
+              "title": "Outcome",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@evt.outcome",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "type": "sunburst"
+            },
+            "layout": { "x": 0, "y": 3, "width": 3, "height": 3 }
+          },
+          {
+            "id": 8237161245752714,
+            "definition": {
+              "title": "Zscaler Log Types",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@sourcetype",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "type": "sunburst"
+            },
+            "layout": { "x": 3, "y": 3, "width": 3, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 0, "width": 6, "height": 7 }
+    },
+    {
+      "id": 4308588107320554,
+      "definition": {
+        "title": "IP Information",
+        "title_align": "center",
+        "type": "group",
+        "background_color": "green",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 1946662551304792,
+            "definition": {
+              "title": "Client IPs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@network.client.ip",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "custom_links": [
+                {
+                  "link": "/screen/integration/security-monitoring-ip-investigation?tpl_var_network.client.ip={{@network.client.ip.value}}",
+                  "label": "Explore in IP Investigation dashboard"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 0, "width": 3, "height": 3 }
+          },
+          {
+            "id": 8444029491969190,
+            "definition": {
+              "title": "Client Geo IPs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "geomap",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 250, "order": "asc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@network.client.geoip.country.iso_code",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "style": { "palette": "hostmap_blues", "palette_flip": false },
+              "view": { "focus": "WORLD" }
+            },
+            "layout": { "x": 3, "y": 0, "width": 3, "height": 3 }
+          },
+          {
+            "id": 3650274739830186,
+            "definition": {
+              "title": "Destination IPs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@network.destination.ip",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "custom_links": [
+                {
+                  "link": "/screen/integration/security-monitoring-ip-investigation?tpl_var_network.client.ip={{@network.client.ip.value}}",
+                  "label": "Explore in IP Investigation dashboard"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 3, "width": 3, "height": 3 }
+          },
+          {
+            "id": 7774255153068396,
+            "definition": {
+              "title": "Destination Geo IP Data",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "geomap",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 250, "order": "asc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@network.destination.geoip.country.iso_code",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "style": { "palette": "hostmap_blues", "palette_flip": false },
+              "view": { "focus": "WORLD" }
+            },
+            "layout": { "x": 3, "y": 3, "width": 3, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 6, "y": 0, "width": 6, "height": 7 }
+    },
+    {
+      "id": 4033176697418068,
+      "definition": {
+        "title": "Web Logs",
+        "type": "group",
+        "background_color": "green",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 5529815589549788,
+            "definition": {
+              "type": "note",
+              "content": "Web Logs: View which URLs were requested, Page Risk Index score for each, the number of bytes sent and received, and more. For more information on the fields available, check out [Zscaler documentation](https://help.zscaler.com/zia/web-insights-logs-columns)\n",
+              "background_color": "purple",
+              "font_size": "16",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 0, "y": 0, "width": 12, "height": 1 }
+          },
+          {
+            "id": 7006286125768150,
+            "definition": {
+              "title": "Zscaler Web Logs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "log_stream",
+              "indexes": [],
+              "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName",
+              "sort": { "column": "time", "order": "desc" },
+              "columns": [
+                "@usr.id",
+                "@http.status_code",
+                "@zscaler.protocol",
+                "@http.url_details.host",
+                "@http.url_details.path",
+                "@evt.outcome",
+                "@zscaler.appclass",
+                "@network.destination.ip"
+              ],
+              "show_date_column": true,
+              "show_message_column": false,
+              "message_display": "inline"
+            },
+            "layout": { "x": 0, "y": 1, "width": 12, "height": 4 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 12, "width": 12, "height": 6 }
+    },
+    {
+      "id": 3485485445195226,
+      "definition": {
+        "title": "Clients",
+        "type": "group",
+        "background_color": "vivid_green",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 7858634414942258,
+            "definition": {
+              "title": "User IDs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_table",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "alias": "Count",
+                      "cell_display_mode": "bar",
+                      "limit": { "count": 10, "order": "desc" },
+                      "formula": "query1"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@usr.id",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 0, "width": 4, "height": 2 }
+          },
+          {
+            "id": 1533144615531518,
+            "definition": {
+              "title": "User Agent Browser",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@http.useragent_details.browser.family",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 2, "width": 4, "height": 2 }
+          },
+          {
+            "id": 2075838375292588,
+            "definition": {
+              "title": "User Agent Device Category",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@http.useragent_details.device.category",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "type": "sunburst"
+            },
+            "layout": { "x": 0, "y": 4, "width": 4, "height": 3 }
+          },
+          {
+            "id": 5690008231978388,
+            "definition": {
+              "title": "User Agent OS",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@http.useragent_details.os.family",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "type": "sunburst"
+            },
+            "layout": { "x": 0, "y": 7, "width": 4, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 0, "width": 4, "height": 11 }
+    },
+    {
+      "id": 2131573647207158,
+      "definition": {
+        "title": "Connection",
+        "type": "group",
+        "background_color": "vivid_green",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 7858508788470362,
+            "definition": {
+              "title": "Blocked Reason",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_table",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "alias": "Blocked Count",
+                      "limit": { "count": 25, "order": "desc" },
+                      "formula": "query1"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName -@zscaler.reason:Allowed"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.reason",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 25
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 0, "width": 5, "height": 3 }
+          },
+          {
+            "id": 7664664148694272,
+            "definition": {
+              "type": "note",
+              "content": "Requests are blocked based on policy rules. You can learn more about Policy reasons [here &nbsp;↗](https://help.zscaler.com/zia/policy-reasons)\n\n",
+              "background_color": "purple",
+              "font_size": "16",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 5, "y": 0, "width": 3, "height": 2 }
+          },
+          {
+            "id": 6800442493828026,
+            "definition": {
+              "title": "HTTP Host",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@http.url_details.host",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 5, "y": 2, "width": 3, "height": 5 }
+          },
+          {
+            "id": 3663205031183960,
+            "definition": {
+              "title": "App Class",
+              "type": "treemap",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.appclass",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 5
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 3, "width": 5, "height": 3 }
+          },
+          {
+            "id": 796061034744538,
+            "definition": {
+              "title": "File Types",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.filetype",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 6, "width": 5, "height": 2 }
+          },
+          {
+            "id": 4757003018049670,
+            "definition": {
+              "title": "Protocol",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.protocol",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "type": "sunburst"
+            },
+            "layout": { "x": 5, "y": 7, "width": 3, "height": 3 }
+          },
+          {
+            "id": 4822311045805642,
+            "definition": {
+              "title": "Content Type",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-web $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.contenttype",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 8, "width": 5, "height": 2 }
+          }
+        ]
+      },
+      "layout": { "x": 4, "y": 0, "width": 8, "height": 11 }
+    },
+    {
+      "id": 8483481151008012,
+      "definition": {
+        "title": "Firewall Logs",
+        "type": "group",
+        "background_color": "green",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 4914632857697106,
+            "definition": {
+              "title": "IP Categories",
+              "type": "treemap",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.ipcat",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 0, "width": 9, "height": 4 }
+          },
+          {
+            "id": 5422308923349676,
+            "definition": {
+              "title": "Outcomes",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_table",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "alias": "Count",
+                      "cell_display_mode": "bar",
+                      "limit": { "count": 10, "order": "desc" },
+                      "formula": "query1"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName -@evt.outcome:Allow"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@evt.outcome",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 9, "y": 0, "width": 3, "height": 4 }
+          },
+          {
+            "id": 3155036118196264,
+            "definition": {
+              "title": "Zscaler Firewall Logs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "log_stream",
+              "indexes": [],
+              "query": "source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName",
+              "sort": { "column": "time", "order": "desc" },
+              "columns": [
+                "@usr.id",
+                "@zscaler.ipcat",
+                "@evt.outcome",
+                "@zscaler.cdip",
+                "@zscaler.cdport",
+                "@zscaler.csip",
+                "@zscaler.csport",
+                "@zscaler.sdport",
+                "@zscaler.ssip",
+                "@zscaler.tsip",
+                "@zscaler.tuntype"
+              ],
+              "show_date_column": true,
+              "show_message_column": false,
+              "message_display": "inline"
+            },
+            "layout": { "x": 0, "y": 4, "width": 7, "height": 5 }
+          },
+          {
+            "id": 5673146697583932,
+            "definition": {
+              "type": "note",
+              "content": "Firewall logs: View details such as the rule that was applied, the client and server details, and the network services and applications. For more information on the fields available, check out [Zscaler documentation](https://help.zscaler.com/zia/firewall-insights-logs-columns)\n",
+              "background_color": "purple",
+              "font_size": "16",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 7, "y": 4, "width": 5, "height": 2 }
+          },
+          {
+            "id": 3207506830430132,
+            "definition": {
+              "title": "Outcomes",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "horizontal",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "alias": "Blocks", "formula": "query1" },
+                    { "alias": "Allows", "formula": "query2" }
+                  ],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName -@evt.outcome:Allow"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": []
+                    },
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-fw $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName @evt.outcome:Allow*"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query2",
+                      "indexes": ["*"],
+                      "group_by": []
+                    }
+                  ],
+                  "style": {
+                    "palette": "orange",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "area"
+                }
+              ]
+            },
+            "layout": { "x": 7, "y": 6, "width": 5, "height": 3 }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 12,
+        "height": 10,
+        "is_column_break": true
+      }
+    },
+    {
+      "id": 5680906160760548,
+      "definition": {
+        "title": "DNS Logs",
+        "type": "group",
+        "background_color": "green",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 2095928842075854,
+            "definition": {
+              "title": "Domain Categories",
+              "type": "treemap",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.category",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 0, "width": 9, "height": 3 }
+          },
+          {
+            "id": 6464814959931842,
+            "definition": {
+              "title": "DNS Request Types",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "query1" }],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.dns_reqtype",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "type": "sunburst",
+              "legend": { "type": "inline" }
+            },
+            "layout": { "x": 9, "y": 0, "width": 3, "height": 3 }
+          },
+          {
+            "id": 6409609686012188,
+            "definition": {
+              "title": "Zscaler DNS Logs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "log_stream",
+              "indexes": [],
+              "query": "source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName",
+              "sort": { "column": "time", "order": "desc" },
+              "columns": [
+                "@usr.id",
+                "@zscaler.dns_req",
+                "@network.destination.ip",
+                "@zscaler.dns_reqtype",
+                "@zscaler.category",
+                "@zscaler.reqrulelabel",
+                "@zscaler.resrulelabel"
+              ],
+              "show_date_column": true,
+              "show_message_column": false,
+              "message_display": "inline"
+            },
+            "layout": { "x": 0, "y": 3, "width": 12, "height": 3 }
+          },
+          {
+            "id": 8260593589800880,
+            "definition": {
+              "title": "Response Rule Labels",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.resrulelabel",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 6, "width": 5, "height": 2 }
+          },
+          {
+            "id": 4819985639268670,
+            "definition": {
+              "title": "Resolved IPs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@network.destination.ip",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 5, "y": 6, "width": 4, "height": 2 }
+          },
+          {
+            "id": 2426215030361964,
+            "definition": {
+              "type": "note",
+              "content": "DNS logs: View data, such as the DNS request and response details. For more information on the fields available, check out [Zscaler documentation](https://help.zscaler.com/zia/dns-insights-logs-columns)\n",
+              "background_color": "purple",
+              "font_size": "16",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 9, "y": 6, "width": 3, "height": 2 }
+          },
+          {
+            "id": 8477711285123078,
+            "definition": {
+              "title": "Request Rule Labels",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.reqrulelabel",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 8, "width": 5, "height": 2 }
+          },
+          {
+            "id": 161142555916574,
+            "definition": {
+              "title": "DNS Requests",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-dns $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.dns_req",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 5, "y": 8, "width": 7, "height": 2 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 10, "width": 12, "height": 11 }
+    },
+    {
+      "id": 3684424770580902,
+      "definition": {
+        "title": "Tunnel Logs",
+        "type": "group",
+        "background_color": "green",
+        "show_title": true,
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 2256935659852146,
+            "definition": {
+              "title": "Record Types",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-tunnel $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.Recordtype",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 0, "width": 4, "height": 2 }
+          },
+          {
+            "id": 6845510121838372,
+            "definition": {
+              "title": "Tunnel Types",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "toplist",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "limit": { "count": 10, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "search": {
+                        "query": "source:zscaler @sourcetype:zscalernss-tunnel $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName"
+                      },
+                      "data_source": "logs",
+                      "compute": { "aggregation": "count" },
+                      "name": "query1",
+                      "indexes": ["*"],
+                      "group_by": [
+                        {
+                          "facet": "@zscaler.tunneltype",
+                          "sort": { "aggregation": "count", "order": "desc" },
+                          "limit": 10
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": { "x": 4, "y": 0, "width": 4, "height": 2 }
+          },
+          {
+            "id": 1331890568880528,
+            "definition": {
+              "type": "note",
+              "content": "Tunnel logs: View data about GRE and IPSec tunnels, such as their health, status, and authentication and encryption algorithms. For more information on the fields available, check out [Zscaler documentation](https://help.zscaler.com/zia/tunnel-insights-logs-columns)\n",
+              "background_color": "purple",
+              "font_size": "16",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": { "x": 8, "y": 0, "width": 4, "height": 2 }
+          },
+          {
+            "id": 7464658587878514,
+            "definition": {
+              "title": "Zscaler Tunnel Logs",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "log_stream",
+              "indexes": [],
+              "query": "source:zscaler @sourcetype:zscalernss-tunnel $ClientIP $DestinationIP $UserID $HTTPHost $HTTPProtocol $HTTPContentType $ZscalerAppClass $Outcome $DNSRequestName",
+              "sort": { "column": "time", "order": "desc" },
+              "columns": [
+                "@usr.id",
+                "@zscaler.Recordtype",
+                "@zscaler.tunneltype",
+                "@network.destination.ip",
+                "@network.client.ip",
+                "@network.client.port",
+                "@zscaler.rxbytes"
+              ],
+              "show_date_column": true,
+              "show_message_column": false,
+              "message_display": "inline"
+            },
+            "layout": { "x": 0, "y": 2, "width": 12, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 21, "width": 12, "height": 6 }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "ClientIP",
+      "default": "*",
+      "prefix": "@network.client.ip",
+      "available_values": []
+    },
+    {
+      "name": "DestinationIP",
+      "default": "*",
+      "prefix": "@network.destination.ip",
+      "available_values": []
+    },
+    {
+      "name": "UserID",
+      "default": "*",
+      "prefix": "@usr.id",
+      "available_values": []
+    },
+    {
+      "name": "HTTPHost",
+      "default": "*",
+      "prefix": "@http.url_details.host",
+      "available_values": []
+    },
+    {
+      "name": "HTTPProtocol",
+      "default": "*",
+      "prefix": "@zscaler.protocol",
+      "available_values": []
+    },
+    {
+      "name": "HTTPContentType",
+      "default": "*",
+      "prefix": "@zscaler.contenttype",
+      "available_values": []
+    },
+    {
+      "name": "ZscalerAppClass",
+      "default": "*",
+      "prefix": "@zscaler.appclass",
+      "available_values": []
+    },
+    {
+      "name": "Outcome",
+      "default": "*",
+      "prefix": "@evt.outcome",
+      "available_values": []
+    },
+    {
+      "name": "DNSRequestName",
+      "default": "*",
+      "prefix": "@zscaler.dns_req",
+      "available_values": []
+    }
+  ],
+  "layout_type": "ordered",
+  "is_read_only": false,
+  "notify_list": [],
+  "reflow_type": "fixed"
+}


### PR DESCRIPTION
### What does this PR do?

This PR removes the `id` field from all our integration dashboards' JSON definitions so that they pass the dashboard validation that we are introducing in the Asset Publishing Workflow (see #apw-dashboard-reporting on Slack)
Note that we only accept string `id`s in our dashboard validators, but integration dashboards ids are integer and they are autogenerated on Postgres).

### Motivation

What inspired you to submit this pull request?
We want to add asset validation for the Asset Publishing Workflow.
### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
