### PR TITLE
Vercel | Fix integration URL

### DIFF
--- a/vercel/README.md
+++ b/vercel/README.md
@@ -46,5 +46,5 @@ Need help? Contact [Datadog support][8].
 [5]: /logs/
 [6]: /synthetics/
 [7]: https://app.datadoghq.com/organization-settings/api-keys
-[8]: https://vercel.com/integrations/datadog-logs
+[8]: https://vercel.com/integrations/datadog
 [9]: /help/


### PR DESCRIPTION
### What does this PR do?

Updates the Datadog integration marketplace URL to the correct one 

### Motivation

The current URL leads to a 404

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
