### PR TITLE
Set the author name to `Community`

### DIFF
--- a/mergify/manifest.json
+++ b/mergify/manifest.json
@@ -41,7 +41,7 @@
   },
   "author": {
     "support_email": "support@mergify.com",
-    "name": "Mergify",
+    "name": "Community",
     "homepage": "https://mergify.com",
     "sales_email": "hello@mergify.com"
   },


### PR DESCRIPTION
### What does this PR do?

Set the author name to `Community` in the `manifest.json` file.

### Motivation

This field is used in our UI to differentiate community integrations and [Technology Partner](https://partners.datadoghq.com/) integrations. Since you're not (yet?) a technology partner, I'm modifying this to `Community`. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
