### PR TITLE
Fixed strings in NS1 integration to allow wildcard records

### DIFF
--- a/ns1/datadog_checks/ns1/ns1_api_url.py
+++ b/ns1/datadog_checks/ns1/ns1_api_url.py
@@ -3,9 +3,9 @@ NS1_ENDPOINTS = {
     # qps and usage stats account wide
     "qps.usage": "{apiendpoint}/v1/stats/{key}{query}",
     # qps and usage stats per zone
-    "qps.usage.zone": "{apiendpoint}/v1/stats/{key}/{domain}{query}",
+    "qps.usage.zone": r"{apiendpoint}/v1/stats/{key}/{domain}{query}",
     # qps and usage stats per dns record
-    "qps.usage.record": "{apiendpoint}/v1/stats/{key}/{domain}/{record}/{rectype}{query}",
+    "qps.usage.record": r"{apiendpoint}/v1/stats/{key}/{domain}/{record}/{rectype}{query}",
     # lease stats account wide
     "ddi.leases": "{apiendpoint}/v1/stats/leases?period=24h",
     # lps account wide
@@ -15,7 +15,7 @@ NS1_ENDPOINTS = {
     # lps for scope
     "ddi.lps.scope": "{apiendpoint}/v1/stats/lps/{scope_group_id}?period=24h",
     # ttl for zone
-    "ttl": "{apiendpoint}/v1/zones/{domain}",
+    "ttl": r"{apiendpoint}/v1/zones/{domain}",
     # account plan limits
     "billing": "{apiendpoint}/v1/account/billataglance",
     # pulsar decisions account wide

--- a/ns1/datadog_checks/ns1/ns1_url_utils.py
+++ b/ns1/datadog_checks/ns1/ns1_url_utils.py
@@ -45,16 +45,16 @@ class Ns1Url:
                             apiendpoint=self.api_endpoint, key=key, domain=domain, query=query_string
                         )
                         tags = ["network:{network}".format(network=v), "zone:{zone}".format(zone=domain)]
-                        urlkey = "{key}.{domain}.{netid}".format(key=key, domain=domain, netid=k)
+                        urlkey = r"{key}.{domain}.{netid}".format(key=key, domain=domain, netid=k)
                         urlList[urlkey] = [url, metric_name, tags, metric_type]
                 else:
                     query_string = "?period=1h&expand=false"
                     url = NS1_ENDPOINTS["qps.usage.zone"].format(
                         apiendpoint=self.api_endpoint, key=key, domain=domain, query=query_string
                     )
-                    tags = ["zone:{zone}".format(zone=domain)]
+                    tags = [r"zone:{zone}".format(zone=domain)]
 
-                    urlList["{key}.{domain}".format(key=key, domain=domain)] = [url, metric_zone, tags, metric_type]
+                    urlList[r"{key}.{domain}".format(key=key, domain=domain)] = [url, metric_zone, tags, metric_type]
 
                 if not records:
                     # if records are not specified, get all records for the zone, then build url for each record
@@ -77,7 +77,7 @@ class Ns1Url:
                                     )
                                     tags = [
                                         "network:{network}".format(network=v),
-                                        "zone:{zone}".format(zone=domain),
+                                        r"zone:{zone}".format(zone=domain),
                                         "record:{record}".format(record=rname),
                                         "type:{rectype}".format(rectype=rtype),
                                     ]
@@ -96,7 +96,7 @@ class Ns1Url:
                                     query=query_string,
                                 )
                                 tags = [
-                                    "zone:{zone}".format(zone=domain),
+                                    r"zone:{zone}".format(zone=domain),
                                     "record:{record}".format(record=rname),
                                     "type:{rectype}".format(rectype=rtype),
                                 ]
@@ -150,7 +150,7 @@ class Ns1Url:
                                 query=query_string,
                             )
                             tags = [
-                                "zone:{zone}".format(zone=domain),
+                                r"zone:{zone}".format(zone=domain),
                                 "record:{record}".format(record=rname),
                                 "type:{rectype}".format(rectype=rtype),
                             ]
@@ -212,9 +212,9 @@ class Ns1Url:
                 metric_type = "gauge"
                 if domainList:
                     for domain in domainList:
-                        tags = ["record:{zone}".format(zone=domain)]
+                        tags = [r"record:{zone}".format(zone=domain)]
                         url = NS1_ENDPOINTS["ttl"].format(apiendpoint=self.api_endpoint, domain=domain)
-                        urlList["{key}.ttl.{domain}".format(key=key, domain=domain)] = [
+                        urlList[r"{key}.ttl.{domain}".format(key=key, domain=domain)] = [
                             url,
                             metric_record,
                             tags,
@@ -246,14 +246,14 @@ class Ns1Url:
 
         for record in val:
             for domain, rectype in record.items():
-                tags = ["record:{record}".format(record=domain)]
+                tags = [r"record:{record}".format(record=domain)]
                 metric_type = "count"
                 metric_record = "pulsar.decisions.record"
                 # pulsar decisions for record
                 url = NS1_ENDPOINTS["pulsar.decisions.record"].format(
                     apiendpoint=self.api_endpoint, query=query_string + "&agg=jobid&record=" + domain + "_" + rectype
                 )
-                k = "pulsar.decisions.{rec_name}.{rec_type}".format(rec_name=domain, rec_type=rectype)
+                k = r"pulsar.decisions.{rec_name}.{rec_type}".format(rec_name=domain, rec_type=rectype)
                 urlList[k] = [url, metric_record, tags, metric_type]
 
                 metric_record = "pulsar.routemap.hit.record"
@@ -261,14 +261,14 @@ class Ns1Url:
                 url = NS1_ENDPOINTS["pulsar.routemap.hit.record"].format(
                     apiendpoint=self.api_endpoint, rec_name=domain, rec_type=rectype, query=query_string
                 )
-                k = "pulsar.routemap.hit.{rec_name}.{rec_type}".format(rec_name=domain, rec_type=rectype)
+                k = r"pulsar.routemap.hit.{rec_name}.{rec_type}".format(rec_name=domain, rec_type=rectype)
                 urlList[k] = [url, metric_record, tags, metric_type]
                 metric_record = "pulsar.routemap.miss.record"
                 # route map misses by record
                 url = NS1_ENDPOINTS["pulsar.routemap.miss.record"].format(
                     apiendpoint=self.api_endpoint, rec_name=domain, rec_type=rectype, query=query_string
                 )
-                k = "pulsar.routemap.miss.{rec_name}.{rec_type}".format(rec_name=domain, rec_type=rectype)
+                k = r"pulsar.routemap.miss.{rec_name}.{rec_type}".format(rec_name=domain, rec_type=rectype)
                 urlList[k] = [url, metric_record, tags, metric_type]
         return urlList
 


### PR DESCRIPTION
### What does this PR do?

Strings in NS1 integration that use domains are now being parsed as raw strings to allow wildcard records

### Motivation

When parsing wildcard records that were in this format: "\*.test.com" the output, and consequentially used for the NS1 api call, would be "%5C*.test.com" thus failing. This change prevents escape characters and uses the raw string from the config file

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

