### PR TITLE
Add DEFAULT_METRIC_LIMIT = 0 for OpenMetrics-based integrations

### DIFF
--- a/cyral/datadog_checks/cyral/cyral.py
+++ b/cyral/datadog_checks/cyral/cyral.py
@@ -8,6 +8,8 @@ class CyralCheck(OpenMetricsBaseCheck):
     Collect metrics from Cyral
     """
 
+    DEFAULT_METRIC_LIMIT = 0
+
     def __init__(self, name, init_config, instances=None):
         instance = instances[0]
         endpoint = instance.get('prometheus_url')

--- a/fluentbit/datadog_checks/fluentbit/check.py
+++ b/fluentbit/datadog_checks/fluentbit/check.py
@@ -4,6 +4,8 @@ from datadog_checks.base import OpenMetricsBaseCheckV2
 class FluentBitCheck(OpenMetricsBaseCheckV2):
     __NAMESPACE__ = 'fluentbit'
 
+    DEFAULT_METRIC_LIMIT = 0
+
     def __init__(self, name, init_config, instances):
         super(FluentBitCheck, self).__init__(name, init_config, instances)
         self.check_initializations.appendleft(self._parse_config)

--- a/fluxcd/datadog_checks/fluxcd/check.py
+++ b/fluxcd/datadog_checks/fluxcd/check.py
@@ -5,6 +5,7 @@ from datadog_checks.fluxcd.metrics import METRIC_MAP
 
 class FluxcdCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = "fluxcd"
+    DEFAULT_METRIC_LIMIT = 0
 
     def get_default_config(self):
         return {"metrics": [METRIC_MAP]}

--- a/gitea/datadog_checks/gitea/gitea.py
+++ b/gitea/datadog_checks/gitea/gitea.py
@@ -6,6 +6,8 @@ from datadog_checks.gitea.metrics import METRIC_MAP
 class GiteaCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = "gitea"
 
+    DEFAULT_METRIC_LIMIT = 0
+
     def get_default_config(self):
         return {
             "metrics": [METRIC_MAP],

--- a/hikaricp/datadog_checks/hikaricp/check.py
+++ b/hikaricp/datadog_checks/hikaricp/check.py
@@ -6,5 +6,7 @@ from datadog_checks.hikaricp.metrics import METRIC_MAP
 class HikaricpCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = "hikaricp"
 
+    DEFAULT_METRIC_LIMIT = 0
+
     def get_default_config(self):
         return {"metrics": [METRIC_MAP]}

--- a/jfrog_platform/datadog_checks/jfrog_platform/check.py
+++ b/jfrog_platform/datadog_checks/jfrog_platform/check.py
@@ -6,6 +6,8 @@ class JfrogPlatformCheck(OpenMetricsBaseCheck):
     Collect metrics from JFrog
     """
 
+    DEFAULT_METRIC_LIMIT = 0
+
     def __init__(self, name, init_config, instances=None):
 
         instance = instances[0]

--- a/neo4j/datadog_checks/neo4j/neo4j.py
+++ b/neo4j/datadog_checks/neo4j/neo4j.py
@@ -10,6 +10,8 @@ GLOBAL_DB_NAME = 'global'
 class Neo4jCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = 'neo4j'
 
+    DEFAULT_METRIC_LIMIT = 0
+
     def __init__(self, name, init_config, instances):
         super().__init__(name, init_config, instances)
 

--- a/purefa/datadog_checks/purefa/purefa.py
+++ b/purefa/datadog_checks/purefa/purefa.py
@@ -7,7 +7,7 @@ from .metrics import METRIC_MAP
 class PureFACheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = "purefa"
 
-    DEFAULT_METRIC_LIMIT = 100000
+    DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, instances):
 

--- a/purefb/datadog_checks/purefb/purefb.py
+++ b/purefb/datadog_checks/purefb/purefb.py
@@ -7,7 +7,7 @@ from .metrics import METRIC_MAP
 class PureFBCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = "purefb"
 
-    DEFAULT_METRIC_LIMIT = 100000
+    DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, instances):
 

--- a/tidb/datadog_checks/tidb/check.py
+++ b/tidb/datadog_checks/tidb/check.py
@@ -8,6 +8,8 @@ from .utils import build_check
 
 # A check object is mapped to a single instance in integration config.
 class TiDBCheck(OpenMetricsBaseCheck):
+    DEFAULT_METRIC_LIMIT = 0
+
     def __init__(self, name, init_config, instances=None):
 
         # Expand tidb check instance to openmetrics check instance


### PR DESCRIPTION
### What does this PR do?

This PR adds `DEFAULT_METRIC_LIMIT = 0` for all OpenMetrics-based integrations, since by policy there should be no metric limit for non-custom OpenMetrics integrations.

### Motivation
Adding Validation to check this in https://github.com/DataDog/integrations-core/pull/14528

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
