### PR TITLE
(DOCS-5505) Replace broken developer tool links in READMEs

### DIFF
--- a/fluentbit/README.md
+++ b/fluentbit/README.md
@@ -80,4 +80,4 @@ Need help? Contact [Datadog support][10].
 [9]: https://github.com/DataDog/integrations-extras/blob/master/fluentbit/assets/service_checks.json
 [10]: https://docs.datadoghq.com/help/
 [11]: https://docs.datadoghq.com/integrations/fluentbit/
-[12]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[12]: https://docs.datadoghq.com/developers/integrations/python/

--- a/fluentbit/datadog_checks/fluentbit/config_models/defaults.py
+++ b/fluentbit/datadog_checks/fluentbit/config_models/defaults.py
@@ -114,6 +114,10 @@ def instance_hostname_label(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_ignore_connection_errors(field, value):
+    return False
+
+
 def instance_ignore_tags(field, value):
     return get_default_field_value(field, value)
 

--- a/fluentbit/datadog_checks/fluentbit/config_models/instance.py
+++ b/fluentbit/datadog_checks/fluentbit/config_models/instance.py
@@ -93,6 +93,7 @@ class InstanceConfig(BaseModel):
     histogram_buckets_as_distributions: Optional[bool]
     hostname_format: Optional[str]
     hostname_label: Optional[str]
+    ignore_connection_errors: Optional[bool]
     ignore_tags: Optional[Sequence[str]]
     include_labels: Optional[Sequence[str]]
     kerberos_auth: Optional[str]

--- a/fluentbit/datadog_checks/fluentbit/data/conf.yaml.example
+++ b/fluentbit/datadog_checks/fluentbit/data/conf.yaml.example
@@ -160,6 +160,11 @@ instances:
     #
     # enable_health_service_check: true
 
+    ## @param ignore_connection_errors - boolean - optional - default: false
+    ## Whether or not to ignore connection errors when scraping `openmetrics_endpoint`.
+    #
+    # ignore_connection_errors: false
+
     ## @param hostname_label - string - optional
     ## Override the hostname for every metric submission with the value of one of its labels.
     #

--- a/fluentbit/datadog_checks/fluentbit/data/conf.yaml.example
+++ b/fluentbit/datadog_checks/fluentbit/data/conf.yaml.example
@@ -51,7 +51,7 @@ instances:
   - metrics_endpoint: http://127.0.0.1:2020/api/v1/metrics/prometheus
 
     ## @param raw_metric_prefix - string - optional
-    ## A prefix that will be removed from all exposed metric names, if present.
+    ## A prefix that is removed from all exposed metric names, if present.
     ## All configuration options will use the prefix-less name.
     #
     # raw_metric_prefix: <PREFIX>_
@@ -114,7 +114,7 @@ instances:
     # exclude_metrics: []
 
     ## @param exclude_metrics_by_labels - mapping - optional
-    ## A mapping of labels where metrics with matching label name and values are ignored. To match
+    ## A mapping of labels to exclude metrics with matching label name and their corresponding metric values. To match
     ## all values of a label, set it to `true`.
     ##
     ## Note: Label filtering happens before `rename_labels`.
@@ -148,7 +148,7 @@ instances:
     # include_labels: []
 
     ## @param rename_labels - mapping - optional
-    ## A mapping of label names to how they should be renamed.
+    ## A mapping of label names to their new names.
     #
     # rename_labels:
     #   <LABEL_NAME_1>: <NEW_LABEL_NAME_1>
@@ -167,7 +167,7 @@ instances:
 
     ## @param hostname_format - string - optional
     ## When `hostname_label` is set, this instructs the check how to format the values. The string
-    ## `<HOSTNAME>` will be replaced by the value of the label defined by `hostname_label`.
+    ## `<HOSTNAME>` is replaced by the value of the label defined by `hostname_label`.
     #
     # hostname_format: <HOSTNAME>
 
@@ -177,7 +177,7 @@ instances:
     # collect_histogram_buckets: true
 
     ## @param non_cumulative_histogram_buckets - boolean - optional - default: false
-    ## Whether or not histogram buckets should be non-cumulative and to come with a `lower_bound` tag.
+    ## Whether or not histogram buckets are non-cumulative and to come with a `lower_bound` tag.
     #
     # non_cumulative_histogram_buckets: false
 
@@ -219,7 +219,7 @@ instances:
     ## For example, the following configuration instructs the check to apply all labels from `metric_a`
     ## to all other metrics, the `node` label from `metric_b` to only those metrics that have a `pod`
     ## label value that matches the `pod` label value of `metric_b`, and all labels from `metric_c`
-    ## to all other metrics if its value is equal to `23` or `42`.
+    ## to all other metrics if their value is equal to `23` or `42`.
     ##
     ##   share_labels:
     ##     metric_a: true
@@ -255,18 +255,13 @@ instances:
     #
     # cache_metric_wildcards: true
 
-    ## @param use_latest_spec - boolean - optional - default: false
-    ## Whether or not the parser will strictly adhere to the latest version of the OpenMetrics specification.
-    #
-    # use_latest_spec: false
-
     ## @param telemetry - boolean - optional - default: false
     ## Whether or not to submit metrics prefixed by `<NAMESPACE>.telemetry.` for debugging purposes.
     #
     # telemetry: false
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of regular expressions used to ignore tags added by autodiscovery and entries in the `tags` option.
+    ## A list of regular expressions used to ignore tags added by Autodiscovery and entries in the `tags` option.
     #
     # ignore_tags:
     #   - <FULL:TAG>

--- a/fluentbit/datadog_checks/fluentbit/data/conf.yaml.example
+++ b/fluentbit/datadog_checks/fluentbit/data/conf.yaml.example
@@ -51,7 +51,7 @@ instances:
   - metrics_endpoint: http://127.0.0.1:2020/api/v1/metrics/prometheus
 
     ## @param raw_metric_prefix - string - optional
-    ## A prefix that is removed from all exposed metric names, if present.
+    ## A prefix that will be removed from all exposed metric names, if present.
     ## All configuration options will use the prefix-less name.
     #
     # raw_metric_prefix: <PREFIX>_
@@ -114,7 +114,7 @@ instances:
     # exclude_metrics: []
 
     ## @param exclude_metrics_by_labels - mapping - optional
-    ## A mapping of labels to exclude metrics with matching label name and their corresponding metric values. To match
+    ## A mapping of labels where metrics with matching label name and values are ignored. To match
     ## all values of a label, set it to `true`.
     ##
     ## Note: Label filtering happens before `rename_labels`.
@@ -148,7 +148,7 @@ instances:
     # include_labels: []
 
     ## @param rename_labels - mapping - optional
-    ## A mapping of label names to their new names.
+    ## A mapping of label names to how they should be renamed.
     #
     # rename_labels:
     #   <LABEL_NAME_1>: <NEW_LABEL_NAME_1>
@@ -167,7 +167,7 @@ instances:
 
     ## @param hostname_format - string - optional
     ## When `hostname_label` is set, this instructs the check how to format the values. The string
-    ## `<HOSTNAME>` is replaced by the value of the label defined by `hostname_label`.
+    ## `<HOSTNAME>` will be replaced by the value of the label defined by `hostname_label`.
     #
     # hostname_format: <HOSTNAME>
 
@@ -177,7 +177,7 @@ instances:
     # collect_histogram_buckets: true
 
     ## @param non_cumulative_histogram_buckets - boolean - optional - default: false
-    ## Whether or not histogram buckets are non-cumulative and to come with a `lower_bound` tag.
+    ## Whether or not histogram buckets should be non-cumulative and to come with a `lower_bound` tag.
     #
     # non_cumulative_histogram_buckets: false
 
@@ -219,7 +219,7 @@ instances:
     ## For example, the following configuration instructs the check to apply all labels from `metric_a`
     ## to all other metrics, the `node` label from `metric_b` to only those metrics that have a `pod`
     ## label value that matches the `pod` label value of `metric_b`, and all labels from `metric_c`
-    ## to all other metrics if their value is equal to `23` or `42`.
+    ## to all other metrics if its value is equal to `23` or `42`.
     ##
     ##   share_labels:
     ##     metric_a: true
@@ -255,13 +255,18 @@ instances:
     #
     # cache_metric_wildcards: true
 
+    ## @param use_latest_spec - boolean - optional - default: false
+    ## Whether or not the parser will strictly adhere to the latest version of the OpenMetrics specification.
+    #
+    # use_latest_spec: false
+
     ## @param telemetry - boolean - optional - default: false
     ## Whether or not to submit metrics prefixed by `<NAMESPACE>.telemetry.` for debugging purposes.
     #
     # telemetry: false
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of regular expressions used to ignore tags added by Autodiscovery and entries in the `tags` option.
+    ## A list of regular expressions used to ignore tags added by autodiscovery and entries in the `tags` option.
     #
     # ignore_tags:
     #   - <FULL:TAG>

--- a/fluxcd/README.md
+++ b/fluxcd/README.md
@@ -63,4 +63,4 @@ Need help? Contact [Datadog support][9].
 [7]: https://github.com/DataDog/integrations-extras/blob/master/fluxcd/metadata.csv
 [8]: https://github.com/DataDog/integrations-extras/blob/master/fluxcd/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
-[10]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[10]: https://docs.datadoghq.com/developers/integrations/python/

--- a/gatekeeper/README.md
+++ b/gatekeeper/README.md
@@ -126,7 +126,7 @@ Need help? Contact [Datadog support][10].
 [1]: https://github.com/open-policy-agent/gatekeeper
 [2]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/gatekeeper/images/gatekeeper_dashboard.png
 [3]: https://docs.datadoghq.com/agent/kubernetes/integrations/
-[4]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[4]: https://docs.datadoghq.com/developers/integrations/python/
 [5]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile
 [6]: https://github.com/DataDog/integrations-extras/blob/master/gatekeeper/datadog_checks/gatekeeper/data/conf.yaml.example
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/grpc_check/README.md
+++ b/grpc_check/README.md
@@ -67,4 +67,4 @@ Need help? Contact [Datadog support][9].
 [7]: https://github.com/DataDog/integrations-extras/blob/master/grpc_check/metadata.csv
 [8]: https://github.com/DataDog/integrations-extras/blob/master/grpc_check/assets/service_checks.json
 [9]: help@datadoghq.com
-[10]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[10]: https://docs.datadoghq.com/developers/integrations/python/

--- a/hikaricp/README.md
+++ b/hikaricp/README.md
@@ -59,6 +59,6 @@ Need help? Contact [Datadog support][9].
 [7]: https://github.com/DataDog/integrations-extras/blob/master/hikaricp/metadata.csv
 [8]: https://github.com/DataDog/integrations-extras/blob/master/hikaricp/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
-[10]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[10]: https://docs.datadoghq.com/developers/integrations/python/
 [11]: https://github.com/DataDog/integrations-extras/blob/master/hikaricp/assets/service_checks.json
 

--- a/hikaricp/datadog_checks/hikaricp/config_models/defaults.py
+++ b/hikaricp/datadog_checks/hikaricp/config_models/defaults.py
@@ -114,6 +114,10 @@ def instance_hostname_label(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_ignore_connection_errors(field, value):
+    return False
+
+
 def instance_ignore_tags(field, value):
     return get_default_field_value(field, value)
 

--- a/hikaricp/datadog_checks/hikaricp/config_models/instance.py
+++ b/hikaricp/datadog_checks/hikaricp/config_models/instance.py
@@ -93,6 +93,7 @@ class InstanceConfig(BaseModel):
     histogram_buckets_as_distributions: Optional[bool]
     hostname_format: Optional[str]
     hostname_label: Optional[str]
+    ignore_connection_errors: Optional[bool]
     ignore_tags: Optional[Sequence[str]]
     include_labels: Optional[Sequence[str]]
     kerberos_auth: Optional[str]

--- a/hikaricp/datadog_checks/hikaricp/data/conf.yaml.example
+++ b/hikaricp/datadog_checks/hikaricp/data/conf.yaml.example
@@ -160,6 +160,11 @@ instances:
     #
     # enable_health_service_check: true
 
+    ## @param ignore_connection_errors - boolean - optional - default: false
+    ## Whether or not to ignore connection errors when scraping `openmetrics_endpoint`.
+    #
+    # ignore_connection_errors: false
+
     ## @param hostname_label - string - optional
     ## Override the hostname for every metric submission with the value of one of its labels.
     #

--- a/hikaricp/datadog_checks/hikaricp/data/conf.yaml.example
+++ b/hikaricp/datadog_checks/hikaricp/data/conf.yaml.example
@@ -51,7 +51,7 @@ instances:
   - openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
 
     ## @param raw_metric_prefix - string - optional
-    ## A prefix that will be removed from all exposed metric names, if present.
+    ## A prefix that is removed from all exposed metric names, if present.
     ## All configuration options will use the prefix-less name.
     #
     # raw_metric_prefix: <PREFIX>_
@@ -114,7 +114,7 @@ instances:
     # exclude_metrics: []
 
     ## @param exclude_metrics_by_labels - mapping - optional
-    ## A mapping of labels where metrics with matching label name and values are ignored. To match
+    ## A mapping of labels to exclude metrics with matching label name and their corresponding metric values. To match
     ## all values of a label, set it to `true`.
     ##
     ## Note: Label filtering happens before `rename_labels`.
@@ -148,7 +148,7 @@ instances:
     # include_labels: []
 
     ## @param rename_labels - mapping - optional
-    ## A mapping of label names to how they should be renamed.
+    ## A mapping of label names to their new names.
     #
     # rename_labels:
     #   <LABEL_NAME_1>: <NEW_LABEL_NAME_1>
@@ -167,7 +167,7 @@ instances:
 
     ## @param hostname_format - string - optional
     ## When `hostname_label` is set, this instructs the check how to format the values. The string
-    ## `<HOSTNAME>` will be replaced by the value of the label defined by `hostname_label`.
+    ## `<HOSTNAME>` is replaced by the value of the label defined by `hostname_label`.
     #
     # hostname_format: <HOSTNAME>
 
@@ -177,7 +177,7 @@ instances:
     # collect_histogram_buckets: true
 
     ## @param non_cumulative_histogram_buckets - boolean - optional - default: false
-    ## Whether or not histogram buckets should be non-cumulative and to come with a `lower_bound` tag.
+    ## Whether or not histogram buckets are non-cumulative and to come with a `lower_bound` tag.
     #
     # non_cumulative_histogram_buckets: false
 
@@ -219,7 +219,7 @@ instances:
     ## For example, the following configuration instructs the check to apply all labels from `metric_a`
     ## to all other metrics, the `node` label from `metric_b` to only those metrics that have a `pod`
     ## label value that matches the `pod` label value of `metric_b`, and all labels from `metric_c`
-    ## to all other metrics if its value is equal to `23` or `42`.
+    ## to all other metrics if their value is equal to `23` or `42`.
     ##
     ##   share_labels:
     ##     metric_a: true
@@ -255,18 +255,13 @@ instances:
     #
     # cache_metric_wildcards: true
 
-    ## @param use_latest_spec - boolean - optional - default: false
-    ## Whether or not the parser will strictly adhere to the latest version of the OpenMetrics specification.
-    #
-    # use_latest_spec: false
-
     ## @param telemetry - boolean - optional - default: false
     ## Whether or not to submit metrics prefixed by `<NAMESPACE>.telemetry.` for debugging purposes.
     #
     # telemetry: false
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of regular expressions used to ignore tags added by autodiscovery and entries in the `tags` option.
+    ## A list of regular expressions used to ignore tags added by Autodiscovery and entries in the `tags` option.
     #
     # ignore_tags:
     #   - <FULL:TAG>

--- a/hikaricp/datadog_checks/hikaricp/data/conf.yaml.example
+++ b/hikaricp/datadog_checks/hikaricp/data/conf.yaml.example
@@ -51,7 +51,7 @@ instances:
   - openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
 
     ## @param raw_metric_prefix - string - optional
-    ## A prefix that is removed from all exposed metric names, if present.
+    ## A prefix that will be removed from all exposed metric names, if present.
     ## All configuration options will use the prefix-less name.
     #
     # raw_metric_prefix: <PREFIX>_
@@ -114,7 +114,7 @@ instances:
     # exclude_metrics: []
 
     ## @param exclude_metrics_by_labels - mapping - optional
-    ## A mapping of labels to exclude metrics with matching label name and their corresponding metric values. To match
+    ## A mapping of labels where metrics with matching label name and values are ignored. To match
     ## all values of a label, set it to `true`.
     ##
     ## Note: Label filtering happens before `rename_labels`.
@@ -148,7 +148,7 @@ instances:
     # include_labels: []
 
     ## @param rename_labels - mapping - optional
-    ## A mapping of label names to their new names.
+    ## A mapping of label names to how they should be renamed.
     #
     # rename_labels:
     #   <LABEL_NAME_1>: <NEW_LABEL_NAME_1>
@@ -167,7 +167,7 @@ instances:
 
     ## @param hostname_format - string - optional
     ## When `hostname_label` is set, this instructs the check how to format the values. The string
-    ## `<HOSTNAME>` is replaced by the value of the label defined by `hostname_label`.
+    ## `<HOSTNAME>` will be replaced by the value of the label defined by `hostname_label`.
     #
     # hostname_format: <HOSTNAME>
 
@@ -177,7 +177,7 @@ instances:
     # collect_histogram_buckets: true
 
     ## @param non_cumulative_histogram_buckets - boolean - optional - default: false
-    ## Whether or not histogram buckets are non-cumulative and to come with a `lower_bound` tag.
+    ## Whether or not histogram buckets should be non-cumulative and to come with a `lower_bound` tag.
     #
     # non_cumulative_histogram_buckets: false
 
@@ -219,7 +219,7 @@ instances:
     ## For example, the following configuration instructs the check to apply all labels from `metric_a`
     ## to all other metrics, the `node` label from `metric_b` to only those metrics that have a `pod`
     ## label value that matches the `pod` label value of `metric_b`, and all labels from `metric_c`
-    ## to all other metrics if their value is equal to `23` or `42`.
+    ## to all other metrics if its value is equal to `23` or `42`.
     ##
     ##   share_labels:
     ##     metric_a: true
@@ -255,13 +255,18 @@ instances:
     #
     # cache_metric_wildcards: true
 
+    ## @param use_latest_spec - boolean - optional - default: false
+    ## Whether or not the parser will strictly adhere to the latest version of the OpenMetrics specification.
+    #
+    # use_latest_spec: false
+
     ## @param telemetry - boolean - optional - default: false
     ## Whether or not to submit metrics prefixed by `<NAMESPACE>.telemetry.` for debugging purposes.
     #
     # telemetry: false
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of regular expressions used to ignore tags added by Autodiscovery and entries in the `tags` option.
+    ## A list of regular expressions used to ignore tags added by autodiscovery and entries in the `tags` option.
     #
     # ignore_tags:
     #   - <FULL:TAG>

--- a/octoprint/README.md
+++ b/octoprint/README.md
@@ -89,7 +89,7 @@ Need help? Contact [Datadog support][9].
 
 [1]: https://octoprint.org/
 [2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
-[3]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[3]: https://docs.datadoghq.com/developers/integrations/python/
 [4]: https://app.datadoghq.com/account/settings#agent
 [5]: https://github.com/DataDog/integrations-extras/blob/master/octoprint/datadog_checks/octoprint/data/conf.yaml.example
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/open_policy_agent/README.md
+++ b/open_policy_agent/README.md
@@ -129,7 +129,7 @@ Need help? Contact [Datadog support][13].
 
 [1]: https://www.openpolicyagent.org/
 [2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
-[3]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[3]: https://docs.datadoghq.com/developers/integrations/python/
 [4]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile
 [5]: https://github.com/DataDog/integrations-extras/blob/master/open_policy_agent/datadog_checks/open_policy_agent/data/conf.yaml.example
 [6]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/open_policy_agent/images/msg_facet.png

--- a/php_opcache/README.md
+++ b/php_opcache/README.md
@@ -77,7 +77,7 @@ Need help? Contact [Datadog support][10].
 
 [1]: https://www.php.net/manual/en/book.opcache.php
 [2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
-[3]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[3]: https://docs.datadoghq.com/developers/integrations/python/
 [4]: https://app.datadoghq.com/account/settings#agent
 [5]: https://github.com/DataDog/integrations-extras/blob/master/php_opcache/datadog_checks/php_opcache/assets/exporter/opcache-dd-handler.php
 [6]: https://github.com/DataDog/integrations-extras/blob/master/php_opcache/datadog_checks/php_opcache/data/conf.yaml.example

--- a/unifi_console/README.md
+++ b/unifi_console/README.md
@@ -59,5 +59,5 @@ Need help? Contact [Datadog support][9].
 [7]: https://github.com/DataDog/integrations-extras/blob/master/unifi_console/metadata.csv
 [8]: https://github.com/DataDog/integrations-extras/blob/master/unifi_console/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
-[10]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[10]: https://docs.datadoghq.com/developers/integrations/python/
 [11]: https://github.com/DataDog/integrations-extras/blob/master/unifi_console/datadog_checks/unifi_console/data/conf.yaml.example


### PR DESCRIPTION
### What does this PR do?

Fixes some links to the developer tools documentation, which is now on a different page.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
