### PR TITLE
Fix the ecosystems team name in the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -569,7 +569,7 @@
 /emnify/*metadata.csv                  @DataDog/documentation @EMnify/development @EMnify/rademade
 /emnify/manifest.json                  @DataDog/documentation @EMnify/development @EMnify/rademade
 /emnify/README.md                      @DataDog/documentation @EMnify/development @EMnify/rademade
-/adaptive_shield/*metadata.csv         @adaptiveshield @DataDog/documentation @DataDog/ecosystems-reviewq
+/adaptive_shield/*metadata.csv         @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
 /adaptive_shield/manifest.json         @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
 /adaptive_shield/README.md             @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
 /typingdna_activelock/manifest.json    @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/documentation @DataDog/ecosystems-review


### PR DESCRIPTION
### What does this PR do?

Fix the ecosystems team name in the CODEOWNERS file

### Motivation

Noticed reviewing https://github.com/DataDog/integrations-extras/pull/1860

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
