### PR TITLE
Update HCP_Vault integration to add `project_id` variable in the associated dashboard

### DIFF
--- a/hcp_vault/README.md
+++ b/hcp_vault/README.md
@@ -38,7 +38,8 @@ To enable metrics streaming:
 5. Click Save. 
 **Note**: HCP Vault supports metrics streaming to only one metrics endpoint at a time.
 
-6. Navigate to Datadog, and enable the integration by clicking Install on the integration tile. This installs a HCP Vault dashboard with widgets that make the most of your HCP Vault telemetry. You can find the dashboard by searching for "HCP Vault Overview" in the dashboard list. 
+6. Navigate to Datadog, and enable the integration by clicking Install on the integration tile. This installs a HCP Vault dashboard with widgets that make the most of your HCP Vault telemetry. You can find the dashboard by searching for "HCP Vault Overview" in the dashboard list.
+   **Note**: On the dashboard, give the values of `cluster` & `project_id` to select the metrics for the right cluster. The `cluster` is the name of the cluster that you have set on cluster creation. The `project_id` is the present in the URL on HCP portal `https://portal.cloud.hashicorp.com/orgs/xxxx/projects/xxxx`
 
 ## Data Collected
 

--- a/hcp_vault/assets/dashboards/hcp_vault_overview.json
+++ b/hcp_vault/assets/dashboards/hcp_vault_overview.json
@@ -16,8 +16,7 @@
                         "id": 5633470244696532,
                         "definition": {
                             "type": "note",
-                            "content": "[HCP Vault Cluster Link](https://portal.cloud.hashicorp.com/services/vault/$cluster.value?project_id=$project.value)\n\nWith HCP Vault, you can leverage a SaaS service with secret management and encryption capabilities. This dashboard provides a high-level overview of your Vault clusters so you can monitor performance and cluster health.",
-                            "background_color": "purple",
+                            "content": "[HCP Vault Cluster Link](https://portal.cloud.hashicorp.com/services/vault/$cluster.value?project_id=$project_id.value)\n\nWith HCP Vault, you can leverage a SaaS service with secret management and encryption capabilities. This dashboard provides a high-level overview of your Vault clusters so you can monitor performance and cluster health.",                            "background_color": "purple",
                             "font_size": "14",
                             "text_align": "left",
                             "vertical_align": "top",
@@ -75,8 +74,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:hcp.vault_core_unsealed{$cluster}",
-                                            "data_source": "metrics",
+                                            "query": "sum:hcp.vault_core_unsealed{$cluster,$project_id}",                                            "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"
                                         }
@@ -107,7 +105,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "max:hcp.vault_secret_kv_count{$cluster} by {mount_point}",
+                                            "query": "max:hcp.vault_secret_kv_count{$cluster,$project_id} by {mount_point}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "avg"
@@ -138,7 +136,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:hcp.vault_identity_entity_count{$cluster} by {namespace}",
+                                            "query": "avg:hcp.vault_identity_entity_count{$cluster,$project_id} by {namespace}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "avg"
@@ -163,7 +161,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:hcp.vault_expire_num_leases{$cluster}",
+                                            "query": "avg:hcp.vault_expire_num_leases{$cluster,$project_id}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"
@@ -219,7 +217,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:hcp.vault_token_count{$cluster}",
+                                            "query": "avg:hcp.vault_token_count{$cluster,$project_id}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"
@@ -261,7 +259,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:hcp.vault_token_count_by_policy{$cluster} by {policy}",
+                                            "query": "avg:hcp.vault_token_count_by_policy{$cluster,$project_id} by {policy}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "avg"
@@ -301,7 +299,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:hcp.vault_token_count_by_ttl{$cluster} by {creation_ttl}",
+                                            "query": "avg:hcp.vault_token_count_by_ttl{$cluster,$project_id} by {creation_ttl}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "avg"
@@ -325,7 +323,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:hcp.vault_token_count_by_auth{$cluster} by {auth_method}",
+                                            "query": "avg:hcp.vault_token_count_by_auth{$cluster,$project_id} by {auth_method}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "avg"
@@ -369,7 +367,7 @@
                                     "on_right_yaxis": false,
                                     "queries": [
                                         {
-                                            "query": "avg:hcp.vault_token_creation{$cluster} by {auth_method,creation_ttl}.as_count()",
+                                            "query": "avg:hcp.vault_token_creation{$cluster,$project_id} by {auth_method,creation_ttl}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }
@@ -418,12 +416,12 @@
                                     "response_format": "timeseries",
                                     "queries": [
                                         {
-                                            "query": "sum:host.cpu_seconds_total{$cluster} by {cluster_id}.as_rate()",
+                                            "query": "sum:host.cpu_seconds_total{$cluster,$project_id} by {cluster_id}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         },
                                         {
-                                            "query": "sum:host.cpu_seconds_total{$cluster,mode:idle} by {cluster_id}.as_rate()",
+                                            "query": "sum:host.cpu_seconds_total{$cluster,mode:idle,$project_id} by {cluster_id}.as_rate()",
                                             "data_source": "metrics",
                                             "name": "query2"
                                         }
@@ -459,12 +457,12 @@
                                     "response_format": "timeseries",
                                     "queries": [
                                         {
-                                            "query": "avg:host.filesystem_total_bytes{$cluster} by {cluster_id}",
+                                            "query": "avg:host.filesystem_total_bytes{$cluster,$project_id} by {cluster_id}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         },
                                         {
-                                            "query": "avg:host.filesystem_free_bytes{$cluster} by {cluster_id}",
+                                            "query": "avg:host.filesystem_free_bytes{$cluster,$project_id} by {cluster_id}",
                                             "data_source": "metrics",
                                             "name": "query2"
                                         }
@@ -500,12 +498,12 @@
                                     "response_format": "timeseries",
                                     "queries": [
                                         {
-                                            "query": "sum:host.memory_total_bytes{$cluster} by {cluster_id}",
+                                            "query": "sum:host.memory_total_bytes{$cluster,$project_id} by {cluster_id}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         },
                                         {
-                                            "query": "sum:host.memory_available_bytes{$cluster} by {cluster_id}",
+                                            "query": "sum:host.memory_available_bytes{$cluster,$project_id} by {cluster_id}",
                                             "data_source": "metrics",
                                             "name": "query2"
                                         }
@@ -530,7 +528,7 @@
             "layout": {"x": 8, "y": 11, "width": 4, "height": 7}
         }
     ],
-    "template_variables": [{"name": "cluster", "default": "*", "prefix": "cluster_id", "available_values": []}],
+    "template_variables": [{"name": "cluster", "default": "*", "prefix": "cluster_id", "available_values": []},{"name": "project_id", "default": "*", "prefix": "project_id", "available_values": []}],
     "layout_type": "ordered",
     "is_read_only": false,
     "notify_list": [],


### PR DESCRIPTION
### What does this PR do?

I am part of HCP Vault team in hashicorp. We want to add a `project_id` variable when filtering for the cluster resource in the associated dashboard. 

### Motivation

This is in light of a new feature released by us which allows multiple projects. Thus clusters with same name can exist in multiple projects and thus an extra filtering layer of project_id is needed to get to right cluster resource. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
