### PR TITLE
quick typo corrections to devcycle integration tile

### DIFF
--- a/devcycle/README.md
+++ b/devcycle/README.md
@@ -28,7 +28,7 @@ const dvcClient = initialize("<DVC_CLIENT_SDK_KEY>", user, dvcOptions);
 // for all variable evaluations
 
 dvcClient.subscribe(
-    "variableEvaluted:*",
+    "variableEvaluated:*",
     (key, variable) => {
         datadogRum.addFeatureFlagEvaluation(key, variable.value);
     }
@@ -37,7 +37,7 @@ dvcClient.subscribe(
 // for a particular variable's evaluations
 
 dvcClient.subscribe(
-    "variableEvaluted:my-variable-key",
+    "variableEvaluated:my-variable-key",
     (key, variable) => {
         datadogRum.addFeatureFlagEvaluation(key, variable.value);
     }


### PR DESCRIPTION
### What does this PR do?

Fixes two typos in the devcycle integration docs

### Motivation

Our integration docs went live and someone noticed the typos.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
