### PR TITLE
Update contributor name to Community

### DIFF
--- a/sonarr/manifest.json
+++ b/sonarr/manifest.json
@@ -39,7 +39,7 @@
   },
   "author": {
     "support_email": "hadrien.patte@datadoghq.com",
-    "name": "Hadrien Patte",
+    "name": "Community",
     "homepage": "https://github.com/DataDog/integrations-extras",
     "sales_email": "hadrien.patte@datadoghq.com"
   },


### PR DESCRIPTION
### What does this PR do?

Community (non technology partner) integrations should have the `author` name as `Community`.

### Motivation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
