### PR TITLE
Added hikaricp.connections.max (pool max size)

### DIFF
--- a/hikaricp/datadog_checks/hikaricp/metrics.py
+++ b/hikaricp/datadog_checks/hikaricp/metrics.py
@@ -2,6 +2,7 @@ METRIC_MAP = {
     "hikaricp_connections": "connections",
     "hikaricp_connections_active": "connections.active",
     "hikaricp_connections_idle": "connections.idle",
+    "hikaricp_connections_max": "connections.max",
     "hikaricp_connections_pending": "connections.pending",
     "hikaricp_connections_timeout": "connections.timeout",
     "hikaricp_connections_acquire_seconds": "connections.acquire.seconds",

--- a/hikaricp/metadata.csv
+++ b/hikaricp/metadata.csv
@@ -3,7 +3,7 @@ hikaricp.connections,gauge,,,,Number of connections,0,hikaricp,connection number
 hikaricp.connections.timeout.count,count,,,,Total number of timeout connections,0,hikaricp,connection timeout total,
 hikaricp.connections.active,gauge,,,,Number of active connections,0,hikaricp,active connection number,
 hikaricp.connections.idle,gauge,,,,Number of idle connections,0,hikaricp,idle connection number,
-hikaricp.connections.max,gauge,,,,Max Number of connections,0,hikaricp,max connection number,
+hikaricp.connections.max,gauge,,,,Max number of connections,0,hikaricp,max connection number,
 hikaricp.connections.pending,gauge,,,,Number of pending connections,0,hikaricp,pending connection number,
 hikaricp.connections.acquire.seconds.count,count,,second,,Count of acquire connection time,0,hikaricp,acquire connections time seconds,
 hikaricp.connections.acquire.seconds.max,gauge,,second,, Max of acquire connection time,0,hikaricp,acquire connections time seconds,

--- a/hikaricp/metadata.csv
+++ b/hikaricp/metadata.csv
@@ -3,7 +3,7 @@ hikaricp.connections,gauge,,,,Number of connections,0,hikaricp,connection number
 hikaricp.connections.timeout.count,count,,,,Total number of timeout connections,0,hikaricp,connection timeout total,
 hikaricp.connections.active,gauge,,,,Number of active connections,0,hikaricp,active connection number,
 hikaricp.connections.idle,gauge,,,,Number of idle connections,0,hikaricp,idle connection number,
-hikaricp.connections.max,gauge,,,,Number of max connections,0,hikaricp,max connection number,
+hikaricp.connections.max,gauge,,,,Max Number of connections,0,hikaricp,max connection number,
 hikaricp.connections.pending,gauge,,,,Number of pending connections,0,hikaricp,pending connection number,
 hikaricp.connections.acquire.seconds.count,count,,second,,Count of acquire connection time,0,hikaricp,acquire connections time seconds,
 hikaricp.connections.acquire.seconds.max,gauge,,second,, Max of acquire connection time,0,hikaricp,acquire connections time seconds,

--- a/hikaricp/metadata.csv
+++ b/hikaricp/metadata.csv
@@ -3,7 +3,7 @@ hikaricp.connections,gauge,,,,Number of connections,0,hikaricp,connection number
 hikaricp.connections.timeout.count,count,,,,Total number of timeout connections,0,hikaricp,connection timeout total,
 hikaricp.connections.active,gauge,,,,Number of active connections,0,hikaricp,active connection number,
 hikaricp.connections.idle,gauge,,,,Number of idle connections,0,hikaricp,idle connection number,
-hikaricp.connections.max,gauge,,,,Max number of connections,0,hikaricp,max connection number,
+hikaricp.connections.max,gauge,,connection,,Max number of connections,0,hikaricp,max connection number,
 hikaricp.connections.pending,gauge,,,,Number of pending connections,0,hikaricp,pending connection number,
 hikaricp.connections.acquire.seconds.count,count,,second,,Count of acquire connection time,0,hikaricp,acquire connections time seconds,
 hikaricp.connections.acquire.seconds.max,gauge,,second,, Max of acquire connection time,0,hikaricp,acquire connections time seconds,

--- a/hikaricp/metadata.csv
+++ b/hikaricp/metadata.csv
@@ -3,6 +3,7 @@ hikaricp.connections,gauge,,,,Number of connections,0,hikaricp,connection number
 hikaricp.connections.timeout.count,count,,,,Total number of timeout connections,0,hikaricp,connection timeout total,
 hikaricp.connections.active,gauge,,,,Number of active connections,0,hikaricp,active connection number,
 hikaricp.connections.idle,gauge,,,,Number of idle connections,0,hikaricp,idle connection number,
+hikaricp.connections.max,gauge,,,,Number of max connections,0,hikaricp,max connection number,
 hikaricp.connections.pending,gauge,,,,Number of pending connections,0,hikaricp,pending connection number,
 hikaricp.connections.acquire.seconds.count,count,,second,,Count of acquire connection time,0,hikaricp,acquire connections time seconds,
 hikaricp.connections.acquire.seconds.max,gauge,,second,, Max of acquire connection time,0,hikaricp,acquire connections time seconds,

--- a/hikaricp/tests/test_hikaricp.py
+++ b/hikaricp/tests/test_hikaricp.py
@@ -7,6 +7,7 @@ EXPECTED_METRICS = {
     "hikaricp.connections",
     "hikaricp.connections.active",
     "hikaricp.connections.idle",
+    "hikaricp.connections.max",
     "hikaricp.connections.pending",
     "hikaricp.connections.timeout.count",
     "hikaricp.connections.acquire.seconds.count",


### PR DESCRIPTION
### What does this PR do?
Add `hikaricp.connections.max` for HikariCP max connection pool size.

### Motivation
I wnat to calculate a pool utilization. To do so, I need to know the maximum size and the number of idle/busy connections.
But, max size is not provided.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes
N/A
