### PR TITLE
Blink Datadog docs links update

### DIFF
--- a/blink/README.md
+++ b/blink/README.md
@@ -45,7 +45,7 @@ Need help? Contact [Blink support][6].
 
 [1]: https://www.blinkops.com/
 [2]: https://library.blinkops.com/automations?vendors=Datadog
-[3]: https://www.docs.blinkops.com/docs/Integrations/datadog/actions/
-[4]: https://www.docs.blinkops.com/docs/Integrations/datadog/
+[3]: https://www.docs.blinkops.com/docs/integrations/datadog/actions
+[4]: https://www.docs.blinkops.com/docs/integrations/datadog
 [5]: https://app.datadoghq.com/organization-settings/api-keys
 [6]: mailto:support@blinkops.com


### PR DESCRIPTION
### What does this PR do?

Fixed broken links to Blink Datadog actions documentation - the current ones are 404 pages.

### Motivation

Changes in Blink documentation routes.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

