### PR TITLE
Updated spacing for changelogs

### DIFF
--- a/ambassador/CHANGELOG.md
+++ b/ambassador/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG - AwesomeApp Integration
 
-## 1.0.0 / Unreleased
+## 1.0.0
+
 ***Added:***
+
 * Initial Ambassador Tile.

--- a/apollo/CHANGELOG.md
+++ b/apollo/CHANGELOG.md
@@ -6,17 +6,14 @@
 
 * Renamed metrics to start with `apollo` instead of `apollo.engine`. Changed `service` tag to `graph`. Existing users can migrate to the new metrics via their integrations page in Apollo Studio.
 
-
 ## 1.1.0
 
 ***Added***: 
 
 * Added variant tagging for Datadog metrics.
 
-
 ## 1.0.0
 
 ***Added***: 
 
 * Initial Apollo Integration Tile.
-

--- a/apptrail/CHANGELOG.md
+++ b/apptrail/CHANGELOG.md
@@ -3,4 +3,5 @@
 ## 1.0.0
 
 ***Added:***
-- Initial release with Apptrail Datadog Logs integration.
+
+* Initial release with Apptrail Datadog Logs integration.

--- a/blink/CHANGELOG.md
+++ b/blink/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.0.0 / 2022-11-20
 
-
 ***Added***: 
 
 * Initial Datadog-Blink Integration Tile.
-

--- a/bonsai/CHANGELOG.md
+++ b/bonsai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Bonsai Integration
 
-## 1.0.0 / Unreleased
+## 1.0.0
 
 ***Added***: 
 

--- a/botprise/CHANGELOG.md
+++ b/botprise/CHANGELOG.md
@@ -5,5 +5,3 @@
 ***Added***: 
 
 * Initial Botprise Integration Tile.
-
-

--- a/buoyant_cloud/CHANGELOG.md
+++ b/buoyant_cloud/CHANGELOG.md
@@ -6,10 +6,8 @@
 
 * Buoyant Cloud metrics sent to Datadog.
 
-
 ## 1.0.0 / 2022-12-20
 
 ***Added***: 
 
 * Buoyant Cloud events sent to Datadog.
-

--- a/devcycle/CHANGELOG.md
+++ b/devcycle/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG - DevCycle
 
 ## 1.0.0 / 2023-05-16
+
 ***Added***: 
 
 * Initial Release
-

--- a/docontrol/CHANGELOG.md
+++ b/docontrol/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 1.0.0
 
-
-## Changes
-
 ***Added***: 
 
 * Initial Datadog-DoControl Integration Tile.
-

--- a/embrace_mobile/CHANGELOG.md
+++ b/embrace_mobile/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 1.0.0
 
-
 ***Added***: 
 
 * adds Embrace Mobile integration.

--- a/eventstore/CHANGELOG.md
+++ b/eventstore/CHANGELOG.md
@@ -10,13 +10,11 @@
 
 * Support EventStoreDB >=v20.6.0
 
-
 ## 1.1.0
 
 ***Added***: 
 
 * Allow passing a custom CA bundle
-
 
 ## 1.0.0
 
@@ -24,10 +22,8 @@
 
 * Add metrics from multiple API endpoints
 
-
 ## 0.1.0
 
 ***Added***: 
 
 * first version
-

--- a/fiddler/CHANGELOG.md
+++ b/fiddler/CHANGELOG.md
@@ -5,5 +5,3 @@
 ***Added***: 
 
 * Fiddler Datadog integration.
-
-

--- a/filebeat/CHANGELOG.md
+++ b/filebeat/CHANGELOG.md
@@ -1,22 +1,22 @@
 # CHANGELOG - Filebeat Integration
 
 ## 1.3.0 
+
 ***Added***: 
 
 * Add support for Filebeat file registry post version 7.x
 
-
 ## 1.2.0 
+
 ***Fixed***: 
 
 * Send config instance tags along with checks
 
-
 ## 1.1.0 
+
 ***Added***: 
 
 * Add option to ignore the registry file check
-
 
 ## 1.0.0 
 
@@ -28,20 +28,17 @@
 
 * Remove the first slash from the path to the service_checks.json file in each integration's manifest.json file
 
-## 0.3.0 / Unreleased
-
-### Add service check
+## 0.3.0
 
 ***Added***: 
 
 * Add [Service check](https://docs.datadoghq.com/developers/service_checks/agent_service_checks_submission/)
 
-
 ## 0.2.0 / Unreleased
 
-### Making the filebeat check compatible with versions > 5.x, and making it able to use the HTTP profiler
-
 ***Added***: 
+
+* Making the filebeat check compatible with versions > 5.x, and making it able to use the HTTP profiler
 
 * Makes it possible to push to Datadog the metrics Filebeat exposes via its HTTP profiler, when started with the `--httpprof [HOST]:PORT` option (see https://www.elastic.co/guide/en/beats/filebeat/current/command-line-options.html)
 
@@ -49,11 +46,8 @@
 
 * This patch makes the filebeat check compatible with the new syntax Filebeat started using in versions 5.x and later for its registry file. It still maintains backward compatibility with the syntax from previous versions.
 
-
-## 0.1.0 / Unreleased
-### Initial version
+## 0.1.0 
 
 ***Added***: 
 
 * Initial Filebeat integration, using Filebeat's registry files.
-

--- a/filemage/CHANGELOG.md
+++ b/filemage/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG - filemage
 
 ## 1.0.0
+
 ***Added***: 
 
 * Initial version of Filemage integration.
-

--- a/finout/CHANGELOG.md
+++ b/finout/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.0.0
 
-
 ***Added***: 
 
 * Initial release - Finout Datadog Application
-

--- a/firefly/CHANGELOG.md
+++ b/firefly/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.0.0 / 2022-07-15
 
-
 ***Added***: 
 
 * Initial release - Firefly Datadog Integration
-

--- a/flagsmith-rum/CHANGELOG.md
+++ b/flagsmith-rum/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 1.0.0 / 2023-06-01
 
-
 ***Added***: 
 
 * Initial release - Flagsmith/Datadog RUM Integration
-

--- a/fluentbit/CHANGELOG.md
+++ b/fluentbit/CHANGELOG.md
@@ -1,15 +1,15 @@
 # CHANGELOG - Fluent Bit
 
 ## 1.0.2 / 2023-04-28
+
 ***Fixed***: 
 
 * Remove the use_latest_spec option from the config file. See [#1835](https://github.com/DataDog/integrations-extras/pull/1835).
 
-
 ## 1.0.1 / 2023-01-25
+
 ***Added***: 
 
 * Add Fluent Bit `build_info` metric. See [#1740](https://github.com/DataDog/integrations-extras/pull/1740).
-
 
 ## 1.0.0 / 2022-04-29

--- a/gitea/CHANGELOG.md
+++ b/gitea/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - Gitea
 
 ## 1.0.1 / 2023-04-28
+
 ***Fixed***: 
 
 * Remove the use_latest_spec option from the config file. See [#1835](https://github.com/DataDog/integrations-extras/pull/1835).
-
 
 ## 1.0.0
 

--- a/gnatsd/CHANGELOG.md
+++ b/gnatsd/CHANGELOG.md
@@ -12,10 +12,8 @@
 * Update example config. See [#1143](https://github.com/DataDog/integrations-extras/pull/1143).
 * Add `allow_redirects` to config files. See [#1001](https://github.com/DataDog/integrations-extras/pull/1001).
 
-
 ## 1.0.0 / 2018-06-01
 
 ***Added***: 
 
 * Add gnatsd integration. See [#116](https://github.com/DataDog/integrations-extras/pull/116).
-

--- a/go_pprof_scraper/CHANGELOG.md
+++ b/go_pprof_scraper/CHANGELOG.md
@@ -6,13 +6,11 @@
 
 * Add documentation on configuring TLS for profile collection.
 
-
 ## 1.0.3 / 2023-01-17
 
 ***Fixed***: 
 
 * The `pprof_url` parameter no longer requires a trailing "/" to work properly.
-
 
 ## 1.0.2 / 2022-12-27
 
@@ -21,10 +19,8 @@
 * Decrease `min_collection_interval` value to prevent long pause between collecting profiles.
 * Properly encode the socket path in the trace agent's profiling endpoint URL when sending profiles over UDS.
 
-
 ## 1.0.1 / 2022-11-10
 
 ***Added***: 
 
 * Add Go pprof scraper integration. See [#1541](https://github.com/DataDog/integrations-extras/pull/1541).
-

--- a/grpc_check/CHANGELOG.md
+++ b/grpc_check/CHANGELOG.md
@@ -1,9 +1,9 @@
 # CHANGELOG - gRPC Check
 
 ## 1.0.2 / 2022-11-09
+
 ***Fixed***: 
 
 * Fix timeout default value. See [#1601](https://github.com/DataDog/integrations-extras/pull/1601).
-
 
 ## 1.0.1 / 2022-08-02

--- a/hasura_cloud/CHANGELOG.md
+++ b/hasura_cloud/CHANGELOG.md
@@ -1,18 +1,19 @@
 # CHANGELOG - Hasura Cloud
 
 ## 1.1.1 / 2022-10-17
+
 ***Fixed***: 
 
 * Support Datadog `env` tag in traces from Hasura Cloud
 
-
 ## 1.1.0 / 2022-06-02
+
 ***Added***: 
 
 * Add support for sending Hasura Cloud traces to Datadog
 
-
 ## 1.0.0 / 2021-05-12
+
 ***Added***: 
 
 * Initial Hasura Cloud integration

--- a/hbase_master/CHANGELOG.md
+++ b/hbase_master/CHANGELOG.md
@@ -6,13 +6,11 @@
 
 * Adds HBase Master Integration. See [#59][1]
 
-
 ## 1.1.0 / 2020-08-21
 
 ***Fixed***: 
 
 * Update configuration to use `metrics.yaml` for JMX. See [#697][2]
-
 
 <!---  --->
 [1]: https://github.com/DataDog/integrations-core/pull/59

--- a/hbase_regionserver/CHANGELOG.md
+++ b/hbase_regionserver/CHANGELOG.md
@@ -6,13 +6,11 @@
 
 * Adds HBase Region Server Integration. See [#59][1]
 
-
 ## 1.1.0 / 2020-08-21
 
 ***Added***: 
 
 * Added `metrics.yaml` for JMX checks. See [#697][2]
-
 
 <!---  --->
 [1]: https://github.com/DataDog/integrations-core/pull/59

--- a/hikaricp/CHANGELOG.md
+++ b/hikaricp/CHANGELOG.md
@@ -1,14 +1,13 @@
 # CHANGELOG - hikaricp
 
 ## 1.0.1 / 2023-04-28
+
 ***Fixed***: 
 
 * Remove the use_latest_spec option from the config file. See [#1835](https://github.com/DataDog/integrations-extras/pull/1835).
-
 
 ## 1.0.0
 
 ***Added***: 
 
 * Initial Hikaricp Integration.
-

--- a/komodor/CHANGELOG.md
+++ b/komodor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Komodor
+
 ## 1.0.0 
-### Initial version
 
 ***Added***: 
 

--- a/lighthouse/CHANGELOG.md
+++ b/lighthouse/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 * Add desktop emulation argument. See [#1729](https://github.com/DataDog/integrations-extras/pull/1729). Thanks [HoriaA](https://github.com/HoriaA).
 
-
 ## 2.1.0 / 2022-05-09
 
 ***Added***: 
@@ -14,7 +13,6 @@
 * Enhance Lighthouse Integration - Multiple URLs, Form Factor Configuration, and New Metrics. See [#1123](https://github.com/DataDog/integrations-extras/pull/1123). Thanks [baerbradford](https://github.com/baerbradford).
 * Add `pyproject.toml` file. See [#1166](https://github.com/DataDog/integrations-extras/pull/1166).
 * Add curated_metric column to metadata.csv files. See [#1209](https://github.com/DataDog/integrations-extras/pull/1209).
-
 
 ## 2.0.0 / 2020-05-05
 
@@ -27,11 +25,8 @@
 
 * Fixes fixes possible TypeError if `score` exists with a `null` value. See [#590](https://github.com/DataDog/integrations-extras/pull/590)
 
-
-
 ## 1.0.0 / 2019-06-19
 
 ***Added***:
 
 * Lighthouse initial release. See [#409](https://github.com/DataDog/integrations-extras/pull/409)
-

--- a/logstash/CHANGELOG.md
+++ b/logstash/CHANGELOG.md
@@ -1,19 +1,13 @@
 # CHANGELOG - Logstash
 
-Logstash Datadog Agent integration changes.
-
 ## 1.1.0
-
 
 ***Added***: 
 
 * expanded queue statistics.
 
-
 ## 1.0.0/ Unreleased
-
 
 ***Added***: 
 
 * adds logstash integration.
-

--- a/mendix/CHANGELOG.md
+++ b/mendix/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG - Mendix
 
 ## 1.0.0 / 2023-04-06
+
 ***Added***: 
 
 * Initial Release

--- a/mergify/CHANGELOG.md
+++ b/mergify/CHANGELOG.md
@@ -1,20 +1,27 @@
 # CHANGELOG - Mergify
 
 ## 1.0.1
+
 ***Added:***
+
 * Updated the default dashboard with the metrics, added and modified, in 0.1.0 and 1.0.0
 * Added a WARNING service check that will be triggered when the user or organization, that the tokens belongs to, is rate limited on GitHub
 
 ## 1.0.0
+
 ***Changed:***
+
 * Changed default value of `min_collection_interval` to 120
 
 ***Added:***
+
 * Refactored the `queue_checks_outcome` metric to have each outcome as a tag, instead of a metric per outcome.
 * `mergify_api_url` is now an optional attribute in the config
 * Added missing metrics in manifest.json
 
 ## 0.1.0
+
 ***Added:***
+
 * Added `time_to_merge` metrics
 * Added `queue_checks_outcome` metrics

--- a/mongodb_atlas/CHANGELOG.md
+++ b/mongodb_atlas/CHANGELOG.md
@@ -5,5 +5,3 @@
 ***Added***: 
 
 * Initial release
-
-

--- a/neo4j/CHANGELOG.md
+++ b/neo4j/CHANGELOG.md
@@ -1,29 +1,29 @@
 # CHANGELOG - neo4j
 
 ## 3.0.1 / 2023-07-05
+
 ***Added***:
 
 * Added server routing metrics which were introduced in Neo4j 5.10
 
 ## 3.0.0 / 2023-06-02
+
 ***Added***: 
 
 * Update Neo4j Integration to support Neo4j 5. 
 * Added addtional [metrics](https://neo4j.com/docs/operations-manual/5/monitoring/metrics/reference/) to support Neo4j 5.
 
-
 ## 2.0.2 / 2023-04-28
+
 ***Changed***: 
 
 * Remove the use_latest_spec option from the config file.
-
 
 ## 2.0.1 / 2022-08-22
 
 ***Added***: 
 
 * Added causal_cluster read replica metrics. See [#1509](https://github.com/DataDog/integrations-extras/pull/1509).
-
 
 ## 2.0.0 / 2022-02-24
 
@@ -36,10 +36,8 @@
 * Add curated_metric column to metadata.csv files. See [#1209](https://github.com/DataDog/integrations-extras/pull/1209).
 * Validate config files. See [#1001](https://github.com/DataDog/integrations-extras/pull/1001).
 
-
 ## 1.0.1 / 2021-07-28
 
 ***Added***: 
 
 * Update neo4j check to use requests wrapper. See [#894](https://github.com/DataDog/integrations-extras/pull/894).
-

--- a/ngrok/CHANGELOG.md
+++ b/ngrok/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG - ngrok
 
 ## 1.0.0 / 2023-06-20
+
 ***Added***: 
 
 * Initial Release

--- a/nn_sdwan/CHANGELOG.md
+++ b/nn_sdwan/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG - nn-sdwan
 
 ## 1.0.1 / 2023-04-11
+
 ***Added***: 
 
 * Integration will try fetching all metrics, even if some result in failure.
@@ -9,8 +10,8 @@
 
 * Correct parsing scheme for the `connection_summary` metrics.
 
-
 ## 1.0.0 / 2022-06-03
+
 ***Added***: 
 
 * Initial nn-sdwan Integration Tile with support for Cisco SD-WAN vManage controllers.

--- a/nomad/CHANGELOG.md
+++ b/nomad/CHANGELOG.md
@@ -1,6 +1,5 @@
 # CHANGELOG - Nomad
 
-
 ## 1.0.0 / Unreleased
 
 ***Added***: 

--- a/notion/CHANGELOG.md
+++ b/notion/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG - Notion
 
 ## 1.0.0 / 2023-05-31
+
 ***Added***: 
 
 * Initial Release

--- a/ns1/CHANGELOG.md
+++ b/ns1/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 * Add API rate limit handler
 
-
 ## 0.0.5
 
 ***Added***: 
@@ -19,7 +18,6 @@
 
 * Fixed some typos
 
-
 ## 0.0.4
 
 ***Added***: 
@@ -28,10 +26,8 @@
 * Changes to allow reporting of more than one network usage statistic
 * Improved test coverage
 
-
 ## 0.0.1
 
 ***Added***: 
 
 * First version
-

--- a/nvml/CHANGELOG.md
+++ b/nvml/CHANGELOG.md
@@ -6,24 +6,33 @@
 
 * fix(nvml): decode no longer needed. See [#1774](https://github.com/DataDog/integrations-extras/pull/1774). Thanks [cep21](https://github.com/cep21).
 
-
 ## 1.0.6
+
+***Added***:
 
 * Add compute_running_process metrics.
 
 ## 1.0.5
 
+***Added***:
+
 * Add fan speed to monitored metrics.
 
 ## 1.0.4
+
+***Changed***:
 
 * Change monotonic_count to gauge for temperature. 
 
 ## 1.0.3
 
+***Fixed***:
+
 * Fix version.
 
 ## 1.0.2
+
+***Added***:
 
 * Add GPU temperature metric. 
 
@@ -32,4 +41,3 @@
 ***Fixed***: 
 
 * Make nvml check quieter on non-GPU hosts (https://github.com/DataDog/integrations-extras/pull/817)
-

--- a/pagerduty/CHANGELOG.md
+++ b/pagerduty/CHANGELOG.md
@@ -1,11 +1,11 @@
 # CHANGELOG - PagerDuty
 
 ## 1.0.0 / 2021-10-20
+
 ## 1.1.0 / 2022-02-03
+
 ***Added***: 
 
 * Status Dashboard by PagerDuty widget
 * Incidents by PagerDuty widget
 * Updated UI for the Incidents by PagerDuty widget. Widget now also displays Escalation Policies.
-
-

--- a/ping/CHANGELOG.md
+++ b/ping/CHANGELOG.md
@@ -6,11 +6,8 @@
 
 * Fix compatibility with non-US Windows. See [#992](https://github.com/DataDog/integrations-extras/pull/992).
 
-
 ## 1.0.1 / 2021-03-04
 
 ***Fixed***: 
 
 * Fix ping check with bad float conversion. See [#818](https://github.com/DataDog/integrations-extras/pull/818).
-
-

--- a/pliant/CHANGELOG.md
+++ b/pliant/CHANGELOG.md
@@ -5,5 +5,3 @@
 ***Added***: 
 
 * Initial Pliant Integration Tile.
-
-

--- a/puma/CHANGELOG.md
+++ b/puma/CHANGELOG.md
@@ -11,13 +11,11 @@
 
 * Update conf.yaml.example files. See [#1147](https://github.com/DataDog/integrations-extras/pull/1147).
 
-
 ## 1.1.0 / 2021-05-17
 
 ***Added***: 
 
 * Sync conf.yaml.example. See [#737](https://github.com/DataDog/integrations-extras/pull/737).
-
 
 ## 1.0.0 / 2021-10-13
 

--- a/purefa/CHANGELOG.md
+++ b/purefa/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - PureFA
 
 ## 1.1.1 / 2023-04-28
+
 ***Fixed***: 
 
 * Remove the use_latest_spec option from the config file. See [#1835](https://github.com/DataDog/integrations-extras/pull/1835).
-
 
 ## 1.1.0
 
@@ -16,17 +16,14 @@
 
 * Support for [Pure FlashArray OpenMetrics Exporter](https://github.com/PureStorage-OpenConnect/pure-fa-openmetrics-exporter)
 
-
 ## 1.0.1
 
 ***Fixed***: 
 
 * Updated purefa.py to include a default `openmetrics_endpoint` from `spec.yaml`
 
-
 ## 1.0.0
 
 ***Added***: 
 
 * Initial Pure Storage FlashArray integration.
-

--- a/purefb/CHANGELOG.md
+++ b/purefb/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - PureFB
 
 ## 1.0.3 / 2023-04-28
+
 ***Fixed***: 
 
 * Remove the use_latest_spec option from the config file. See [#1835](https://github.com/DataDog/integrations-extras/pull/1835).
-
 
 ## 1.0.2 / 2022-12-14
 
@@ -12,17 +12,14 @@
 
 * Added support for the `purefb.array.space_utilization` metric introduced in `pure-fb-openmetrics-exporter v1.0.1`.
 
-
 ## 1.0.1 / 2022-10-04
 
 ***Fixed***: 
 
 * Fixed the link for Pure Storage Logo on the `Pure FlashBlade - Overview` dashboard.
 
-
 ## 1.0.0 / 2022-05-04
 
 ***Added***: 
 
 * Initial Pure Storage FlashBlade integration.
-

--- a/redisenterprise/CHANGELOG.md
+++ b/redisenterprise/CHANGELOG.md
@@ -15,19 +15,13 @@
 * Sync config. See [#1689](https://github.com/DataDog/integrations-extras/pull/1689).
 * Update conf.yaml.example files. See [#1147](https://github.com/DataDog/integrations-extras/pull/1147).
 
-
 ## 1.1.1
-
-### Bug fix for monitors
 
 ***Fixed***: 
 
 * Unable to get monitor results without a hostname set - fixed
 
-
 ## 1.1.0
-
-### Add in new Active Active metrics
 
 ***Added***: 
 
@@ -37,23 +31,14 @@
 
 * the http wrapper now allows get params, so revert usage of python requests
 
-
-
 ## 1.0.0
-
-### Fix redirect error on cluster follower
 
 ***Fixed***: 
 
 * The http wrapper did not honor settings to not follow redirects - confirmed with Datadog team
 
-
-
 ## 0.3.1
-
-### Fix for cluster with no databases created
 
 ***Fixed***: 
 
 * This stops the integration from throwing an error when there are no databases create on the cluster
-

--- a/redpanda/CHANGELOG.md
+++ b/redpanda/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - redpanda
 
 ## 1.1.1 / 2023-04-28
+
 ***Fixed***: 
 
 * Remove the use_latest_spec option from the config file. See [#1835](https://github.com/DataDog/integrations-extras/pull/1835).
-
 
 ## 1.1.0 / 2022-03-24
 
@@ -17,7 +17,6 @@
 ***Fixed***: 
 
 * Update conf.yaml.example files. See [#1147](https://github.com/DataDog/integrations-extras/pull/1147).
-
 
 ## 1.0.0 / 2021-11-10
 

--- a/retool/CHANGELOG.md
+++ b/retool/CHANGELOG.md
@@ -1,3 +1,3 @@
 # CHANGELOG - retool_retool
-## Latest
+
 * https://updates.retool.com/en

--- a/riak_repl/CHANGELOG.md
+++ b/riak_repl/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 * Add a condition to check that `rt_sink_connected_to` is a dict before collecting `sink_stats`
 
-
 ## 1.0.0
 
 ***Added***: 
@@ -19,17 +18,14 @@
 
 * Implement tests to ensure replication is enabled before expecting stats
 
-
 ## 0.0.2
 
 ***Added***: 
 
 * Adds basic fullsync_coordinator metrics
 
-
 ## 0.0.1
 
 ***Added***: 
 
 * Adds riak-repl integration
-

--- a/rum_roku/CHANGELOG.md
+++ b/rum_roku/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG - Roku
 
 ## 1.0.0 / 2023-05-02
+
 ***Added***: 
 
 * Initial Roku RUM Integration tile

--- a/speedtest/CHANGELOG.md
+++ b/speedtest/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 1.0.0/ Released
 
-
 ***Added***: 
 
 * adds speedtest integration.

--- a/split/CHANGELOG.md
+++ b/split/CHANGELOG.md
@@ -1,7 +1,6 @@
 # CHANGELOG - Split.io
 
-
-## 1.0.0 / Unreleased
+## 1.0.0
 
 ***Added***: 
 

--- a/stackpulse/CHANGELOG.md
+++ b/stackpulse/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 1.0.0
 
-
-## Changes
-
 ***Added***: 
 
 * Initial Datadog-StackPulse Integration Tile.
-

--- a/stardog/CHANGELOG.md
+++ b/stardog/CHANGELOG.md
@@ -6,18 +6,14 @@
 
 * Upgrades Stardog integration for overhauled Stardog metrics behavior
 
-
 ## 1.0.1
 
 ***Fixed***: 
 
 * formatting issue with auth header in python 3
 
-
 ## 1.0.0
-
 
 ***Added***: 
 
 * adds Stardog integration.
-

--- a/steadybit/CHANGELOG.md
+++ b/steadybit/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG - Steadybit
 
 ## 1.0.0 / 2023-01-18
+
 ***Added***: 
 
 * Initial Steadybit Integration

--- a/storm/CHANGELOG.md
+++ b/storm/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 * Fix response parsing. See [#724](https://github.com/DataDog/integrations-extras/pull/724).
 
-
-
 ## 1.0.0 / 2020-07-27
 
 ***Added***: 
@@ -22,4 +20,3 @@
 * Make this more robust to api errors.
 * Cluster metrics sent with 0 values if unable to connect to Storm UI. Now bails on ConnectionErrors.
 * If on Agent6 - TypeError: gauge() got an unexpected keyword argument 'metric'
-

--- a/stormforge/CHANGELOG.md
+++ b/stormforge/CHANGELOG.md
@@ -6,13 +6,11 @@
 
 * Initial StormForge Integration
 
-
 ## 1.0.1
 
 ***Fixed***: 
 
 * Update support for Optimize Live 0.3.0 with additional risk tolerances in dashboard
-
 
 ## 1.0.3
 
@@ -20,10 +18,8 @@
 
 * HPA support: Adding new metric stormforge.recommendation_target and two widgets for HPA ("CPU HPA Target" and "CPU Scale Point Recommended" )
 
-
 ## 1.1.0 / 2022-12-13
 
 ***Added***: 
 
 * Rewrite the StormForge Optimize Live dashboard to focus on clearly communicating the impact of Optimize Live recommendations for a selected workload
-

--- a/superwise/CHANGELOG.md
+++ b/superwise/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG - Superwise
 
 ## 1.0.0 / 2021-12-29
+
 ***Added***: 
 
-* - Add Superwise integration.
+* Add Superwise integration.
 

--- a/torq/CHANGELOG.md
+++ b/torq/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## 1.0.0
 
-
-## Changes
-
 ***Added***: 
 
 * Initial Datadog-Torq Integration Tile.

--- a/traefik/CHANGELOG.md
+++ b/traefik/CHANGELOG.md
@@ -12,13 +12,11 @@
 
 * Do not use requests directly. See [#1090](https://github.com/DataDog/integrations-extras/pull/1090).
 
-
 ## 0.2.0
 
 ***Added***: 
 
 * configuration now allows scheme parameter
-
 
 ## 0.1.0
 

--- a/twingate/CHANGELOG.md
+++ b/twingate/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG - Twingate
 
 ## 1.0.0 / 2022-10-20
+
 ***Added***: 
 
 * Initial Twingate Integration Tile.

--- a/unbound/CHANGELOG.md
+++ b/unbound/CHANGELOG.md
@@ -5,5 +5,3 @@
 ***Added***: 
 
 * Allow the use of hostname for server address. See [#937](https://github.com/DataDog/integrations-extras/pull/937).
-
-

--- a/unifi_console/CHANGELOG.md
+++ b/unifi_console/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG - Unifi Console
 
-
 ## 1.2.0
+
 ***Added***: 
 
 * Add support for device specific metrics (UAP, UDM, USG, USW, USX). See [#1715](https://github.com/DataDog/integrations-extras/pull/1715)
@@ -10,20 +10,20 @@
 
 * Fixed checks pilling up
 
-
 ## 1.1.1
+
 ***Fixed***: 
 
 * Fixed url issue for non UMP setup. See [#1596](https://github.com/DataDog/integrations-extras/pull/1596)
 
-
 ## 1.1.0
+
 ***Added***: 
 
 * Add support for UMP and update dashboard. See [#1562](https://github.com/DataDog/integrations-extras/pull/1562)
 
-
 ## 1.0.0
+
 ***Added***:
 
 * Unifi initial realease. See [#1351](https://github.com/DataDog/integrations-extras/pull/1351)

--- a/upsc/CHANGELOG.md
+++ b/upsc/CHANGELOG.md
@@ -6,11 +6,8 @@
 
 * Fix encoding errors when capturing output and improve device handling. See [#1354](https://github.com/DataDog/integrations-extras/pull/1354).
 
-
 ## 0.1.0/ Unreleased
-
 
 ***Added***: 
 
 * adds upsc stats collector integration.
-

--- a/uptime/CHANGELOG.md
+++ b/uptime/CHANGELOG.md
@@ -1,9 +1,7 @@
 # CHANGELOG - Uptime.com
 
-
 ## 1.0.0 / Unreleased
 
 ***Added***: 
 
 * Initial Uptime.com tile.
-

--- a/vespa/CHANGELOG.md
+++ b/vespa/CHANGELOG.md
@@ -10,5 +10,3 @@
 
 * Normalize vespa service check names. See [#1035](https://github.com/DataDog/integrations-extras/pull/1035).
 * DOCS-1135 Update integration install instructions (part 8). See [#993](https://github.com/DataDog/integrations-extras/pull/993).
-
-

--- a/vns3/CHANGELOG.md
+++ b/vns3/CHANGELOG.md
@@ -6,11 +6,8 @@
 
 * fix the metadata.csv file to match supported `metric_type` names.
 
-
-
 ## 1.0.0
 
 ***Added***: 
 
 * Initial VNS3 tile.
-

--- a/zabbix/CHANGELOG.md
+++ b/zabbix/CHANGELOG.md
@@ -6,12 +6,9 @@
 
 * Avoid sending non-numeric values as gauge. See [#1519](https://github.com/DataDog/integrations-extras/pull/1519).
 
-
 ## 1.1.0 / 2021-11-18
 
 ***Added***: 
 
 * validate config files. See [#1001](https://github.com/DataDog/integrations-extras/pull/1001).
 * Normalize zabbix metric names. See [#741](https://github.com/DataDog/integrations-extras/pull/741).
-
-


### PR DESCRIPTION
Update changelog formatting so it standardized across all integration changelogs.

I am working on a validation script that checks for correct headers, spacing, syntax, etc. and these fixes standardize the integrations and allow them to pass.