### PR TITLE
Migrate recommended monitor runs to new pipeline

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,6 @@ jobs:
       models: true
       package: true
       readmes: true
-      recommended-monitors: true
       saved-views: true
       service-checks: true
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?

The recommended monitors are now being validated as part of the "validate-asset-monitors" check run, so stop running it through the now defunct `ddev validate recommended-monitors` method (which will be removed in the next version of ddev)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
