### PR TITLE
NVML: Upgrade grpcio dep to address linux/arm64 build error

### DIFF
--- a/nvml/CHANGELOG.md
+++ b/nvml/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - nvml
 
+## 1.0.8 / 2023-08-14
+
+* Upgrade grpcio dependency to solve some linux/arm64 build errors ([related issue](https://github.com/DataDog/integrations-extras/issues/1752)).
+
 ## 1.0.7 / 2023-06-07
 
 ***Fixed***:

--- a/nvml/datadog_checks/nvml/__about__.py
+++ b/nvml/datadog_checks/nvml/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.7'
+__version__ = '1.0.8'

--- a/nvml/pyproject.toml
+++ b/nvml/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
-    "grpcio==1.27.2",
+    "grpcio==1.57.0",
     "pynvml==8.0.4",
 ]
 

--- a/nvml/pyproject.toml
+++ b/nvml/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = [
 [project.optional-dependencies]
 deps = [
     "grpcio==1.57.0",
-    "pynvml==8.0.4",
+    "pynvml==11.4.1",
 ]
 
 [project.urls]

--- a/nvml/requirements.in
+++ b/nvml/requirements.in
@@ -1,2 +1,2 @@
 pynvml==11.4.1
-grpcio==1.27.2
+grpcio==1.57.0

--- a/nvml/tests/Dockerfile
+++ b/nvml/tests/Dockerfile
@@ -1,13 +1,13 @@
 # As the NVML integration is a community integration, it is not packaged with the Agent image by default. A custom image with the packaged integration should therefore be used in containerized environments.
 # Setup taken from https://docs.datadoghq.com/agent/guide/use-community-integrations/?tab=docker
 
-# Installs the NVML integration version 1.0.6.
+# Installs the NVML integration version 1.0.8.
 # See the changelog for the other versions that are available (https://github.com/DataDog/integrations-extras/blob/master/nvml/CHANGELOG.md)
 FROM gcr.io/datadoghq/agent:latest
-RUN agent integration install -t -r datadog-nvml==1.0.6
+RUN agent integration install -t -r datadog-nvml==1.0.8
 
-# Use the permalink to the requirements to install the PIP libraries used by the check
-RUN curl https://raw.githubusercontent.com/DataDog/integrations-extras/c94cd62f61bcd763ae18a601f0862da308563c03/nvml/requirements.in > requirements.in && /opt/datadog-agent/embedded/bin/pip3 install -r requirements.in
+# Use versioned link to the requirements to install the PIP libraries used by the check
+RUN curl https://raw.githubusercontent.com/DataDog/integrations-extras/nvml-1.0.8/nvml/requirements.in > /tmp/requirements.in && /opt/datadog-agent/embedded/bin/pip3 install -r /tmp/requirements.in
 
 # Why do you need these variables: See https://github.com/NVIDIA/nvidia-docker/wiki/Usage
 ENV NVIDIA_VISIBLE_DEVICES all


### PR DESCRIPTION
### What does this PR do?

Update the grpcio dependency so integration will successfully build on linux/arm64 host. Also perform some small housekeeping changes that were observed.

### Motivation

I needed to make this change to build the integration in my environment and wanted to pass along to fix to the next person who might need it: [Comment describing the problem](https://github.com/DataDog/integrations-extras/issues/1752#issuecomment-1678101960).

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
