### PR TITLE
Update CloudZero manifest to be public

### DIFF
--- a/cloudzero/manifest.json
+++ b/cloudzero/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6f1a61c2-e875-42f7-b8ba-94b191786846",
   "app_id": "cloudzero",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?

Update the CloudZero manifest file to display the docs on the public website.

### Motivation

Noticed that the integration was merged, but the docs are not visible on the public website ([#2047](https://github.com/DataDog/integrations-extras/pull/2047)). Not sure if this is intentional, or just a missed detail.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
