### PR TITLE
fix(mergify): raise timeout error rather than returning None

### DIFF
--- a/mergify/datadog_checks/mergify/check.py
+++ b/mergify/datadog_checks/mergify/check.py
@@ -43,7 +43,7 @@ class MergifyCheck(AgentCheck):
                 AgentCheck.CRITICAL,
                 message="Request timeout: {}, {}".format(url, e),
             )
-            return
+            raise
 
         except (HTTPError, InvalidURL, ConnectionError) as e:
             if (


### PR DESCRIPTION
The current behaviour is to return None which triggers an error later in the
code:

[{"message": "'NoneType' object is not subscriptable", "traceback": "Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 1142, in run
    self.check(instance)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mergify/check.py", line 29, in check
    self.send_queues_metrics()
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mergify/check.py", line 86, in send_queues_metrics
    for queue in response_json["queues"]:
TypeError: 'NoneType' object is not subscriptable
"}]

This implements the same behaviour than the other errors, being raising back
the error to the caller.

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [X] Git history is clean
- [X] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes