### PR TITLE
Fix Instabug blog link

### DIFF
--- a/instabug/README.md
+++ b/instabug/README.md
@@ -33,11 +33,11 @@ Need help? Contact [Instabug Support][3].
 
 Additional helpful documentation, links, and articles:
 
-- [Leverage user context to debug mobile performance issues with the Instabug Datadog Marketplace offering][5]
+- [Leverage user context to debug mobile performance issues with the Instabug Datadog Marketplace offering][6]
 
 [1]: http://instabug.com
 [2]: https://dashboard.instabug.com/signup
 [3]: mailto:support@instabug.com
 [4]: https://app.datadoghq.com/dashboard/lists
 [5]: https://docs.instabug.com/docs/introduction
-[5]: https://www.datadoghq.com/blog/instabug-mobile-usability/
+[6]: https://www.datadoghq.com/blog/instabug-mobile-usability/


### PR DESCRIPTION
### What does this PR do?

Fixes the duplicate destination link in the Instabug integration.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [X] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
