### PR TITLE
Update manifest.json

### DIFF
--- a/fluxcd/manifest.json
+++ b/fluxcd/manifest.json
@@ -1,47 +1,54 @@
 {
-  "manifest_version": "2.0.0",
-  "app_uuid": "11cc5047-83aa-44df-b7ca-9c6e1c32b723",
-  "app_id": "fluxcd",
-  "display_on_public_website": true,
-  "tile": {
-    "overview": "README.md#Overview",
-    "configuration": "README.md#Setup",
-    "support": "README.md#Support",
-    "changelog": "CHANGELOG.md",
-    "description": "Fluxcd integration with openmetric v2",
-    "title": "fluxcd",
-    "media": [],
-    "classifier_tags": [
-      "Category::Kubernetes",
-      "Supported OS::Linux",
-      "Supported OS::Windows",
-      "Supported OS::macOS"
-    ]
-  },
-  "author": {
-    "support_email": "melchior.moulin@blablacar.com",
-    "homepage": "https://github.com/DataDog/integrations-extras",
-    "sales_email": "melchior.moulin@blablacar.com",
-    "name": "Community"
-  },
-  "oauth": {},
-  "assets": {
-    "integration": {
-      "source_type_name": "fluxcd",
-      "configuration": {
-        "spec": "assets/configuration/spec.yaml"
-      },
-      "events": {
-        "creates_events": false
-      },
-      "metrics": {
-        "prefix": "fluxcd.",
-        "check": "fluxcd.gotk.suspend.status",
-        "metadata_path": "metadata.csv"
-      },
-      "service_checks": {
-        "metadata_path": "assets/service_checks.json"
+   "manifest_version":"2.0.0",
+   "app_uuid":"11cc5047-83aa-44df-b7ca-9c6e1c32b723",
+   "app_id":"fluxcd",
+   "display_on_public_website":true,
+   "tile":{
+      "overview":"README.md#Overview",
+      "configuration":"README.md#Setup",
+      "support":"README.md#Support",
+      "changelog":"CHANGELOG.md",
+      "description":"Fluxcd integration with openmetric v2",
+      "title":"fluxcd",
+      "media":[
+         
+      ],
+      "classifier_tags":[
+         "Category::Kubernetes",
+         "Supported OS::Linux",
+         "Supported OS::Windows",
+         "Supported OS::macOS"
+      ]
+   },
+   "author":{
+      "support_email":"melchior.moulin@blablacar.com",
+      "homepage":"https://github.com/DataDog/integrations-extras",
+      "sales_email":"melchior.moulin@blablacar.com",
+      "name":"Community"
+   },
+   "oauth":{
+      
+   },
+   "assets":{
+      "integration":{
+         "source_type_name":"fluxcd",
+         "configuration":{
+            "spec":"assets/configuration/spec.yaml"
+         },
+         "events":{
+            "creates_events":false
+         },
+         "metrics":{
+            "prefix":"fluxcd.",
+            "check":"fluxcd.gotk.suspend.status",
+            "metadata_path":"metadata.csv"
+         },
+         "service_checks":{
+            "metadata_path":"assets/service_checks.json"
+         },
+         "dashboards":{
+            "fluxcd-overview":"assets/dashboards/fluxcd_overview.json"
+         }
       }
-    }
-  }
+   }
 }


### PR DESCRIPTION
Add proposed `fluxcd` dashboard asset to fluxcd manifest.json

### What does this PR do?

Adding of proposed dashboard asset to `fluxcd manifest.json`

### Motivation

https://github.com/DataDog/integrations-extras/pull/2096

### Review checklist

- [ X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ X] Feature or bugfix has tests
- [ X] Git history is clean
- [X ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

In relation to PR. Check failed due to:
- https://github.com/DataDog/integrations-extras/pull/2096 
`assets/dashboards/fluxcd_overview.json not found in manifest.json. Add it to the manifest or remove the file.`
