### PR TITLE
Fix an inappropriate test expression to remove a logical short circuit

### DIFF
--- a/storm/datadog_checks/storm/storm.py
+++ b/storm/datadog_checks/storm/storm.py
@@ -352,7 +352,7 @@ class StormCheck(AgentCheck):
         :return: Version info
         :rtype: StormCheck.StormVersion
         """
-        if len(cluster_stats) >= 0:
+        if len(cluster_stats) > 0:
             version = (
                 _get_string(cluster_stats, _get_string(cluster_stats, 'unknown', 'stormVersion'), 'version')
                 .replace(' ', '_')


### PR DESCRIPTION
In file: storm.py, the comparison of Collection length creates a logical short circuit; the previous case will always evaluate to true. I suggested that the Collection length comparison should be done without creating a logical short circuit. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.