### PR TITLE
Add Page Alias

### DIFF
--- a/jfrog_platform_self_hosted/manifest.json
+++ b/jfrog_platform_self_hosted/manifest.json
@@ -10,6 +10,7 @@
     "changelog": "CHANGELOG.md",
     "description": "View and analyze JFrog Artifactory and Xray Logs, Violations and Metrics",
     "title": "JFrog Platform (Self-hosted)",
+    "aliases": ["/integrations/jfrog_platform"],
     "media": [
       {
         "media_type": "image",

--- a/jfrog_platform_self_hosted/manifest.json
+++ b/jfrog_platform_self_hosted/manifest.json
@@ -3,6 +3,7 @@
   "app_uuid": "b2748652-b976-461c-91dd-5abd4467f361",
   "app_id": "jfrog-platform",
   "display_on_public_website": true,
+  "aliases": ["/integrations/jfrog_platform"],
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
@@ -10,7 +11,6 @@
     "changelog": "CHANGELOG.md",
     "description": "View and analyze JFrog Artifactory and Xray Logs, Violations and Metrics",
     "title": "JFrog Platform (Self-hosted)",
-    "aliases": ["/integrations/jfrog_platform"],
     "media": [
       {
         "media_type": "image",


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

Adds a page alias flagged by the Documentation 404 URL Dashboard.

### Motivation

Ready to merge.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
