### PR TITLE
[DOCS-6293] clarifying which events get published from Signal Science

### DIFF
--- a/sigsci/README.md
+++ b/sigsci/README.md
@@ -89,7 +89,7 @@ See [metadata.csv][13] for a list of metrics provided by this integration.
 
 ### Events
 
-All Signal Sciences events are sent to your [Datadog Event Stream][9]
+Events are created and sent to your [Datadog Event Stream][9] when an IP address is flagged on Signal Sciences.
 
 ### Service Checks
 


### PR DESCRIPTION
### What does this PR do?

Clarifying in the docs that the Signal Sciences event integration only creates an event when IP addresses are flagged on Signal Sciences.

### Motivation

[DOCS-6293](https://datadoghq.atlassian.net/browse/DOCS-6293)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
