### PR TITLE
[ECOS-928] Add empty assets field

### DIFF
--- a/rum_android/manifest.json
+++ b/rum_android/manifest.json
@@ -24,5 +24,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }

--- a/rum_angular/manifest.json
+++ b/rum_angular/manifest.json
@@ -23,5 +23,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }

--- a/rum_cypress/manifest.json
+++ b/rum_cypress/manifest.json
@@ -26,5 +26,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }

--- a/rum_expo/manifest.json
+++ b/rum_expo/manifest.json
@@ -29,5 +29,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }

--- a/rum_flutter/manifest.json
+++ b/rum_flutter/manifest.json
@@ -28,5 +28,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }

--- a/rum_ios/manifest.json
+++ b/rum_ios/manifest.json
@@ -24,5 +24,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }

--- a/rum_javascript/manifest.json
+++ b/rum_javascript/manifest.json
@@ -24,5 +24,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }

--- a/rum_react/manifest.json
+++ b/rum_react/manifest.json
@@ -28,5 +28,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }

--- a/rum_react_native/manifest.json
+++ b/rum_react_native/manifest.json
@@ -29,5 +29,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }

--- a/rum_roku/manifest.json
+++ b/rum_roku/manifest.json
@@ -22,5 +22,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
+  "assets": {},
   "oauth": {}
 }


### PR DESCRIPTION
### What does this PR do?

A new validation is being added that will require an `assets` field, even if empty, as part of the `manifest.json` file.  Updating files to adhere to the new format.

See validation update here: https://github.com/DataDog/dd-source/pull/54872
