### PR TITLE
 Renaming integration category: messaging -> message queues

### DIFF
--- a/gnatsd/manifest.json
+++ b/gnatsd/manifest.json
@@ -15,7 +15,7 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Messaging",
+      "Category::Message Queues",
       "Category::Notifications"
     ]
   },

--- a/redpanda/manifest.json
+++ b/redpanda/manifest.json
@@ -13,7 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Category::Log Collection",
-      "Category::Messaging",
+      "Category::Message Queues",
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"


### PR DESCRIPTION
### What does this PR do?

Renames the messaging category to message queues based on feedback

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
