### PR TITLE
Adding 2 recommended monitors

### DIFF
--- a/fluxcd/assets/recommended_monitors/active_workers.json
+++ b/fluxcd/assets/recommended_monitors/active_workers.json
@@ -1,0 +1,25 @@
+{
+    "id": 11520271,
+    "name": "[Fluxcd] Active Workers Count",
+    "type": "query alert",
+    "query": "sum(last_5m):max:fluxcd.controller.runtime.active.workers{*} by {kube_namespace,controller} >= 2",
+    "message": "{{#is_warning}}\nController {{controller.name}} has {{value}} active workers in namespace:{{kube_namespace.name}} for the last 5 minutes.\n{{/is_warning}} \n{{#is_alert}}\nController {{controller.name}} has {{value}} active workers in namespace:{{kube_namespace.name}} for the last 5 minutes.\n{{/is_alert}}",
+    "tags": ["integration:fluxcd"],
+    "options": {
+      "thresholds": {
+        "critical": 2,
+        "warning": 1
+      },
+      "notify_audit": false,
+      "on_missing_data": "default",
+      "include_tags": true,
+      "new_group_delay": 60,
+      "avalanche_window": 10,
+      "silenced": {}
+    },
+    "recommended_monitor_metadata": {
+      "description": "Notify your team when your active worker count has reached system resource capacity."
+    },
+    "priority": null,
+    "restricted_roles": null
+  }

--- a/fluxcd/assets/recommended_monitors/error_count.json
+++ b/fluxcd/assets/recommended_monitors/error_count.json
@@ -17,7 +17,7 @@
       "silenced": {}
     },
     "recommended_monitor_metadata": {
-      "description": "Notify your team when your active worker count has reached system resource capacity."
+      "description": "Notify your team when an reconciliation error occurs for your develoment state controller."
     },
     "priority": null,
     "restricted_roles": null

--- a/fluxcd/assets/recommended_monitors/error_count.json
+++ b/fluxcd/assets/recommended_monitors/error_count.json
@@ -1,0 +1,24 @@
+{
+    "id": 11520177,
+    "name": "[Fluxcd] Error Count",
+    "type": "query alert",
+    "query": "sum(last_5m):sum:fluxcd.controller.runtime.reconcile.errors.count{*} by {kube_namespace,controller}.as_count() >= 1",
+    "message": "{{#is_alert}}\nController {{controller.name}} has encountered {{value}} state reconcile errors namespace:{{kube_namespace.name}} for the last 5 minutes.\n{{/is_alert}}",
+    "tags": ["integration:fluxcd"],
+    "options": {
+      "thresholds": {
+        "critical": 1
+      },
+      "notify_audit": false,
+      "on_missing_data": "default",
+      "include_tags": true,
+      "new_group_delay": 60,
+      "avalanche_window": 10,
+      "silenced": {}
+    },
+    "recommended_monitor_metadata": {
+      "description": "Notify your team when your active worker count has reached system resource capacity."
+    },
+    "priority": null,
+    "restricted_roles": null
+  }

--- a/fluxcd/manifest.json
+++ b/fluxcd/manifest.json
@@ -45,6 +45,10 @@
     },
     "dashboards": {
       "Fluxcd": "assets/dashboards/fluxcd.json"
+    },
+    "monitors": {
+      "Active Workers": "assets/recommended_monitors/active_workers.json",
+      "Error Count": "assets/recommended_monitors/error_count.json"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Proposed addition of 2 recommended monitors for Fluxcd Integration.

### Motivation

https://datadoghq.atlassian.net/browse/AI-3001

### Review checklist

- [ X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ X] Feature or bugfix has tests
- [ X] Git history is clean
- [X ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Fluxcd sandbox running to simulate monitor behaviors.

Active Worker Count Monitor
https://dd.datad0g.com/monitors/11520271

![image](https://github.com/DataDog/integrations-extras/assets/107069502/42011d6c-0148-4cef-a152-75443a20a850)

Error Count Monitor
https://dd.datad0g.com/monitors/11520177

![image](https://github.com/DataDog/integrations-extras/assets/107069502/4e0bd536-c664-44b1-8b68-a6a70cba58f3)

Inclusion of `integration:fluxcd` tag links to OOTB dashboard.
