### PR TITLE
Change query for top 10 zones usage to match top 10 records

### DIFF
--- a/ns1/assets/dashboards/overview.json
+++ b/ns1/assets/dashboards/overview.json
@@ -1225,10 +1225,10 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:ns1.usage.zone{*} by {zone}",
+                                            "query": "sum:ns1.usage.zone{*} by {zone}.as_count()",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "aggregator": "avg"
+                                            "aggregator": "sum"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
### What does this PR do?

This PR updates the query in the top 10 zone usage dashboard to match the one for top 10 records, to rule out any issue with the query itself.

### Motivation

Users reported the top 10 zone usage chart was blank, however the top 10 record usage chart is working.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
