### PR TITLE
(maint) Fix docs as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 .github/CODEOWNERS*                                        @DataDog/agent-integrations
 
 # Documentation
-/*/README.md                             @DataDog/documentation @DataDog/agent-integrations
-/*/*metadata.csv                         @DataDog/documentation @DataDog/agent-integrations
-/*/manifest.json                         @DataDog/documentation @DataDog/agent-integrations
+**/README.md                             @DataDog/documentation @DataDog/agent-integrations
+**/*metadata.csv                         @DataDog/documentation @DataDog/agent-integrations
+**/manifest.json                         @DataDog/documentation @DataDog/agent-integrations
 
 # Community partners
 /1e/                                     support@1e.com @DataDog/ecosystems-review


### PR DESCRIPTION
### What does this PR do?

The docs team isn't being added to some PRs ([example](https://github.com/DataDog/integrations-extras/pull/2147)). This should fix it.


### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
