### PR TITLE
Sync logs integrations from logs-backend

### DIFF
--- a/vercel/assets/logs/vercel.yaml
+++ b/vercel/assets/logs/vercel.yaml
@@ -106,3 +106,55 @@ pipeline:
       enabled: true
       sources:
         - proxy.timestamp
+metrics:
+  - name: vercel.functions.invocations
+    query: source:vercel @source:lambda REPORT
+    groupBys:
+      - path: '@projectName'
+        tagName: projectName
+      - path: '@deploymentName'
+        tagName: deploymentName
+      - path: '@functionName'
+        tagName: functionName
+  - name: vercel.functions.errors
+    query: source:vercel @source:lambda status:error
+    groupBys:
+      - path: '@projectName'
+        tagName: projectName
+      - path: '@deploymentName'
+        tagName: deploymentName
+      - path: '@functionName'
+        tagName: functionName
+  - name: vercel.functions.duration
+    query: source:vercel @source:lambda
+    groupBys:
+      - path: '@projectName'
+        tagName: projectName
+      - path: '@deploymentName'
+        tagName: deploymentName
+      - path: '@functionName'
+        tagName: functionName
+    aggregation:
+      path: '@lambda.duration'
+      includePercentiles: true
+  - name: vercel.functions.execution
+    query: source:vercel @source:lambda
+    groupBys:
+      - path: '@projectName'
+        tagName: projectName
+      - path: '@deploymentName'
+        tagName: deploymentName
+      - path: '@functionName'
+        tagName: functionName
+    aggregation:
+      path: '@lambda.execution'
+      includePercentiles: false
+  - name: vercel.builds.number_of_builds
+    query: source:vercel "Build completed in"
+    groupBys:
+      - path: '@projectName'
+        tagName: projectName
+      - path: '@deploymentName'
+        tagName: deploymentName
+      - path: '@functionName'
+        tagName: functionName


### PR DESCRIPTION
### What does this PR do?

Syncing logs integrations from `logs-backend` into `integrations-extras`. This is a no-op change since we're not yet reading integrations from APW. 

These vercel changes are part of adding OOTB metrics for the integration. PRs for reference: 
- [Create metric for vercel integration](https://github.com/DataDog/logs-backend/pull/58881)
- [Add metrics for Vercel integration](https://github.com/DataDog/logs-backend/pull/58939)

### Motivation

Integrations in this repository are out of sync from logs-backend. Syncing them to make sure they're up to date.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
