### PR TITLE
NS1 Integration: TTL dashboard fix

### DIFF
--- a/ns1/assets/dashboards/overview.json
+++ b/ns1/assets/dashboards/overview.json
@@ -1132,10 +1132,22 @@
                             "type": "change",
                             "requests": [
                                 {
+                                    "formulas": [
+                                        {
+                                            "formula": "top(query1, 10, \"mean\", \"desc\")",
+                                            "alias": "TTL"
+                                        }
+                                    ],
                                     "order_by": "change",
                                     "order_dir": "desc",
                                     "compare_to": "hour_before",
-                                    "q": "top(max:ns1.ttl{*} by {record}, 10, 'mean', 'desc')",
+                                    "queries": [
+                                        {
+                                            "query": "max:ns1.ttl{*} by {record}",
+                                            "data_source": "metrics",
+                                            "name": "query1"
+                                        }
+                                    ],
                                     "show_present": true,
                                     "increase_good": true,
                                     "change_type": "absolute"


### PR DESCRIPTION
### What does this PR do?

Fixes the TTL dashboard on the NS1 integration

### Motivation

Currently the dashboard is displaying the following error: "Query Error: Functions are not supported in metrics data source field. Use the formulas field."

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

