### PR TITLE
added timeout parameter, added ability to tag instances, fixed double-posting o…

### DIFF
--- a/bind9/CHANGELOG.md
+++ b/bind9/CHANGELOG.md
@@ -6,3 +6,19 @@
 
 * first version
 
+## 1.0.1
+
+***Added***
+
+* Ability to define custom tags at the instance level
+* Ability to define a timeout for the DNS stats endpoint in `init_config`
+
+***Fixed***
+
+* Logical error where service check was "OK" even if it can't connect, causing two service checks to be posted
+* Any unreachable DNS stats endpoint caused the agent to hang indefinitely waiting for the request to finish
+
+***Changed***
+
+* Minor changes to the format of the example config file
+* Instance parameter "url" and its value will always be added as a tag for each instance

--- a/bind9/datadog_checks/bind9/__about__.py
+++ b/bind9/datadog_checks/bind9/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/bind9/datadog_checks/bind9/bind9.py
+++ b/bind9/datadog_checks/bind9/bind9.py
@@ -36,7 +36,7 @@ class Bind9Check(AgentCheck):
 
     def getStatsFromUrl(self, dns_url):
         # Try to get timeout from init_config, otherwise default to 5 seconds
-        timeout = self.init_config.get('timeout', 5)
+        timeout = self.init_config.get('timeout', str(5))
 
         try:
             response = requests.get(dns_url, timeout=timeout)

--- a/bind9/datadog_checks/bind9/data/conf.yaml.example
+++ b/bind9/datadog_checks/bind9/data/conf.yaml.example
@@ -1,8 +1,21 @@
 init_config:
+    ## @param timeout - int - optional - default: 5
+    ## How long to wait for a response from the DNS server stats endpoint
+    #
+    # timeout: 5
 
 instances:
 
-      ## @param url - string - required
-      ## Base statistic URL of your bind9 instance.
-      #
-    - url : http://10.10.1.101:8080
+    ## @param url - string - required
+    ## Base statistic URL of your bind9 instance.
+    #
+  - url: http://10.10.1.101:8080
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>

--- a/bind9/datadog_checks/bind9/data/conf.yaml.example
+++ b/bind9/datadog_checks/bind9/data/conf.yaml.example
@@ -1,5 +1,5 @@
 init_config:
-    ## @param timeout - int - optional - default: 5
+    ## @param timeout - string - optional - default: 5
     ## How long to wait for a response from the DNS server stats endpoint
     #
     # timeout: 5


### PR DESCRIPTION
### What does this PR do?
This PR 
* Fixes a logical error where the service check would post an AgentCheck.OK as well as an AgentCheck.CRITICAL if the DNS endpoint wasn't reachable for any reason (the only validation before was whether dns_url was set, not that it was actually reachable)
* Adds the ability to define tags on an instance level
* Adds the value of the url instance parameter by default
* Adds the ability to set a timeout (how long to wait for stats from the DNS endpoint, right now it will hang indefinitely on an unreachable DNS server)

### Motivation

Trying to use this integration was working well but only for the "happy path", we ran into several errors when DNS servers were unreachable. It was also difficult to build a dashboard when you have multiple DNS servers due to the missing ability to add tags.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
