### PR TITLE
Pin the Python version for PRs

### DIFF
--- a/gitea/datadog_checks/gitea/gitea.py
+++ b/gitea/datadog_checks/gitea/gitea.py
@@ -5,7 +5,6 @@ from datadog_checks.gitea.metrics import METRIC_MAP
 
 class GiteaCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = "gitea"
-
     DEFAULT_METRIC_LIMIT = 0
 
     def get_default_config(self):


### PR DESCRIPTION
### What does this PR do?

[Pin the Python version for PRs](https://github.com/DataDog/integrations-extras/pull/2205/commits/4d6cb8fae0688f84c21d15e5bb071bba98f2aa93)

### Motivation

Right now we use the default version that is on the master branch of integrations. When we bump this version in -core, it will also affect this repo, which might not be ready yet and it would break the CI for PRs. 

Note that we already pinned the version for the CI that is running on master, it seems we missed to pin it here too.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
