### PR TITLE
Remove broken image link

### DIFF
--- a/mongodb_atlas/manifest.json
+++ b/mongodb_atlas/manifest.json
@@ -10,13 +10,7 @@
     "changelog": "CHANGELOG.md",
     "description": "MongoDB Atlas",
     "title": "MongoDB Atlas",
-    "media": [
-      {
-        "media_type": "image",
-        "caption": "The MongoDB Atlas default dashboard shows throughput and resource utilization metrics",
-        "image_url": "images/mongodb_atlas_dashboard.png"
-      }
-    ],
+    "media": [],
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::Windows",


### PR DESCRIPTION
### What does this PR do?

Removes a broken image in the MongoDB Atlas integration docs.

### Motivation

Need to remove the broken link while I figure out how to resolve this.

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [X] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
