### PR TITLE
Add link to new Vercel onboarding UI from integration tile

### DIFF
--- a/vercel/README.md
+++ b/vercel/README.md
@@ -14,8 +14,7 @@ Integrate Vercel with Datadog to:
 
 ## Setup
 
-- Generate a [Datadog API key][7]
-- Configure the logs integration through the [Vercel Marketplace][8]
+- [Configure the Vercel integration][7]
 
 ## Data Collected
 
@@ -45,6 +44,5 @@ Need help? Contact [Datadog support][8].
 [4]: https://vercel.com/docs/serverless-functions/introduction
 [5]: /logs/
 [6]: /synthetics/
-[7]: https://app.datadoghq.com/organization-settings/api-keys
-[8]: https://vercel.com/integrations/datadog
-[9]: /help/
+[7]: /setup/vercel
+[8]: /help/


### PR DESCRIPTION
### What does this PR do?

Links to the new Vercel onboarding page https://app.datadoghq.com/setup/vercel from the Vercel tile

### Motivation

Helping customers find the Vercel onboarding UI from the tile

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
