### PR TITLE
Fix broken link

### DIFF
--- a/vercel/README.md
+++ b/vercel/README.md
@@ -44,5 +44,5 @@ Need help? Contact [Datadog support][8].
 [4]: https://vercel.com/docs/serverless-functions/introduction
 [5]: /logs/
 [6]: /synthetics/
-[7]: /setup/vercel
+[7]: https://app.datadoghq.com/setup/vercel
 [8]: /help/


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/integrations-extras/pull/2226 - This PR uses a relative link to the vercel setup page, which should instead be a link to the app. This is currently breaking the docs build.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
