### PR TITLE
Remove StormForge from docs page

### DIFF
--- a/stormforge/manifest.json
+++ b/stormforge/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6f1ddcc9-e704-4f94-941b-8a914fcd89a0",
   "app_id": "stormforge",
-  "display_on_public_website": true,
+  "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?

Looking to remove this integration from the public docs page

### Motivation



### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

