### PR TITLE
[ECOS] Remove deprecated category from Nvidia NVML integration

### DIFF
--- a/nvml/manifest.json
+++ b/nvml/manifest.json
@@ -15,7 +15,6 @@
       "Category::AI/ML",
       "Category::Kubernetes",
       "Category::OS & System",
-      "Category::Machine Learning & LLM",
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"


### PR DESCRIPTION
### What does this PR do?

Removes deprecated category from appearing in-app.

### Motivation



### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
