### PR TITLE
Sync with logs backend

### DIFF
--- a/akamai_datastream_2/assets/logs/akamai.datastream.yaml
+++ b/akamai_datastream_2/assets/logs/akamai.datastream.yaml
@@ -1,5 +1,6 @@
 id: akamai.datastream
 metric_id: akamai-datastream-2
+backend_only: false
 facets:
   - name: Duration
     source: log
@@ -137,7 +138,7 @@ facets:
     type: integer
     groups:
       - Akamai DataStream 2
-  - name: URL Port # needed because http.url_details.port has an ambiguous type
+  - name: URL Port  # needed because http.url_details.port has an ambiguous type
     source: log
     path: akamai.datastream.reqPort
     type: integer

--- a/aqua/assets/logs/aqua.yaml
+++ b/aqua/assets/logs/aqua.yaml
@@ -1,5 +1,6 @@
 id: aqua
 metric_id: aqua
+backend_only: false
 facets:
   - name: User
     source: log

--- a/auth0/assets/logs/auth0.yaml
+++ b/auth0/assets/logs/auth0.yaml
@@ -1,5 +1,6 @@
 id: auth0
 metric_id: auth0
+backend_only: false
 facets:
   - name: Event Name
     source: log
@@ -106,7 +107,6 @@ facets:
     path: data.hostname
     groups:
       - Auth0
-
 pipeline:
   type: pipeline
   name: Auth0

--- a/bottomline_recordandreplay/assets/logs/bottomline.yaml
+++ b/bottomline_recordandreplay/assets/logs/bottomline.yaml
@@ -1,5 +1,6 @@
 id: bottomline
 metric_id: bottomline-recordandreplay
+backend_only: false
 facets:
   - name: City Name
     source: log

--- a/contrastsecurity/assets/logs/contrastsecurity.yaml
+++ b/contrastsecurity/assets/logs/contrastsecurity.yaml
@@ -1,5 +1,6 @@
 id: contrastsecurity
 metric_id: contrastsecurity
+backend_only: false
 facets:
   - name: Event Outcome
     source: log

--- a/datazoom/assets/logs/datazoom.yaml
+++ b/datazoom/assets/logs/datazoom.yaml
@@ -1,4 +1,5 @@
 id: datazoom
+backend_only: false
 facets:
   - name: Browser
     source: log

--- a/hbase_master/assets/logs/hbase.yaml
+++ b/hbase_master/assets/logs/hbase.yaml
@@ -1,5 +1,6 @@
 id: hbase
 metric_id: hbase-master
+backend_only: false
 facets:
   - name: Logger Name
     source: log

--- a/invary/assets/logs/invary.yaml
+++ b/invary/assets/logs/invary.yaml
@@ -1,4 +1,5 @@
 id: invary
+backend_only: false
 facets:
   - path: distribution.codename
     source: log

--- a/jamf_protect/assets/logs/jamfprotect.yaml
+++ b/jamf_protect/assets/logs/jamfprotect.yaml
@@ -1,5 +1,6 @@
 id: jamfprotect
 metric_id: jamf-protect
+backend_only: false
 facets:
   - name: Event Name
     source: log

--- a/jfrog_platform_cloud/assets/logs/jfrog_artifactory.yaml
+++ b/jfrog_platform_cloud/assets/logs/jfrog_artifactory.yaml
@@ -1,5 +1,6 @@
 id: jfrog_artifactory
 metric_id: jfrog-platform-cloud
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/jfrog_platform_self_hosted/assets/logs/jfrog_platform.yaml
+++ b/jfrog_platform_self_hosted/assets/logs/jfrog_platform.yaml
@@ -1,5 +1,6 @@
 id: jfrog_platform
 metric_id: jfrog-platform
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/lacework/assets/logs/lacework.yaml
+++ b/lacework/assets/logs/lacework.yaml
@@ -1,5 +1,6 @@
 id: lacework
 metric_id: lacework
+backend_only: false
 facets:
   - name: Event Name
     source: log
@@ -11,7 +12,6 @@ facets:
     path: evt.category
     groups:
       - Event
-
 pipeline:
   type: pipeline
   name: Lacework

--- a/lambdatest/assets/logs/lambdatest.yaml
+++ b/lambdatest/assets/logs/lambdatest.yaml
@@ -1,4 +1,5 @@
 id: lambdatest
+backend_only: false
 facets:
   - name: URL Path
     source: log
@@ -40,7 +41,6 @@ facets:
     path: test_env_browser
     groups:
       - LAMBDATEST
-
 pipeline:
   type: pipeline
   name: LAMBDATEST (Partner Integration)

--- a/logstash/assets/logs/logstash.yaml
+++ b/logstash/assets/logs/logstash.yaml
@@ -1,5 +1,6 @@
 id: logstash
 metric_id: logstash
+backend_only: false
 facets:
   - name: Method
     source: log

--- a/ngrok/assets/logs/ngrok.yaml
+++ b/ngrok/assets/logs/ngrok.yaml
@@ -1,4 +1,5 @@
 id: ngrok
+backend_only: false
 facets:
   - name: Event Name
     source: log

--- a/perimeterx/assets/logs/perimeterx.yaml
+++ b/perimeterx/assets/logs/perimeterx.yaml
@@ -1,5 +1,6 @@
 id: perimeterx
 metric_id: perimeterx
+backend_only: false
 facets:
   - name: Event Name
     source: log
@@ -91,7 +92,6 @@ facets:
     path: px_app_id
     groups:
       - PerimeterX
-
 pipeline:
   type: pipeline
   name: PerimeterX

--- a/sqreen/assets/logs/sqreen.yaml
+++ b/sqreen/assets/logs/sqreen.yaml
@@ -1,5 +1,6 @@
 id: sqreen
 metric_id: sqreen
+backend_only: false
 facets:
   - name: Event Name
     source: log
@@ -136,19 +137,16 @@ facets:
     path: sqreen.event_name
     groups:
       - Sqreen
-
   - name: Sqreen Event Version (Semver)
     source: log
     path: sqreen.event_version
     groups:
       - Sqreen
-
   - name: Sqreen New Incident
     source: log
     path: sqreen.payload.event_type
     groups:
       - Sqreen
-
 pipeline:
   type: pipeline
   name: Sqreen

--- a/sym/assets/logs/sym.yaml
+++ b/sym/assets/logs/sym.yaml
@@ -1,4 +1,5 @@
 id: sym
+backend_only: false
 facets:
   - name: User Email
     source: log

--- a/tailscale/assets/logs/tailscale.yaml
+++ b/tailscale/assets/logs/tailscale.yaml
@@ -1,5 +1,6 @@
 id: tailscale
 metric_id: tailscale
+backend_only: false
 facets:
   - name: Event Name
     source: log

--- a/traefik/assets/logs/traefik.yaml
+++ b/traefik/assets/logs/traefik.yaml
@@ -1,5 +1,6 @@
 id: traefik
 metric_id: traefik
+backend_only: false
 facets:
   - name: Duration
     source: log

--- a/twingate/assets/logs/twingate.yaml
+++ b/twingate/assets/logs/twingate.yaml
@@ -1,4 +1,5 @@
 id: twingate
+backend_only: false
 facets:
   - name: Event Name
     source: log

--- a/typingdna_activelock/assets/logs/typingdna.yaml
+++ b/typingdna_activelock/assets/logs/typingdna.yaml
@@ -1,5 +1,6 @@
 id: typingdna
 metric_id: typingdna-activelock
+backend_only: false
 facets:
   - name: typingdna.result
     source: log

--- a/vercel/assets/logs/vercel.yaml
+++ b/vercel/assets/logs/vercel.yaml
@@ -1,4 +1,5 @@
 id: vercel
+backend_only: false
 facets:
   - name: City Name
     source: log

--- a/zscaler/assets/logs/zscaler.yaml
+++ b/zscaler/assets/logs/zscaler.yaml
@@ -1,5 +1,6 @@
 id: zscaler
 metric_id: z-scaler
+backend_only: false
 facets:
   - name: Event Outcome
     source: log


### PR DESCRIPTION
### What does this PR do?
This adds the backend_only field, which will be mandatory going forward, to yaml files in integrations-extras

### Motivation
The changes to logs core have already been made, now syncing
https://datadoghq.atlassian.net/browse/LOGSC-749

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
