### PR TITLE
Add a blog link to the Seagence README

### DIFF
--- a/seagence/README.md
+++ b/seagence/README.md
@@ -45,6 +45,12 @@ Seagence posts an event to Datadog upon detecting a defect.
 
 Need help? Contact [Seagence support][4].
 
+## Further Reading
+
+Additional helpful documentation, links, and articles:
+
+- [Detect Java code-level issues with Seagence and Datadog][7]
+
 
 [1]: https://www.seagence.com
 [2]: https://app.seagence.com/SeagenceWeb/
@@ -52,3 +58,4 @@ Need help? Contact [Seagence support][4].
 [4]: mailto:support@seagence.com
 [5]: https://app.datadoghq.com/integrations/seagence
 [6]: https://app.datadoghq.com/organization-settings/api-keys?filter=Seagence
+[7]: https://www.datadoghq.com/blog/seagence-datadog-marketplace/


### PR DESCRIPTION
### What does this PR do?

Adds a Datadog blog link to the Seagence README

### Motivation

Part of the docs team rotational Tuesday task responsibilities. Helps drive traffic to the blog.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
