### PR TITLE
Re-ordering Neo4j integration doc sections

### DIFF
--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -8,25 +8,6 @@ Neo4j metrics enable database administrators to monitor their Neo4j deployments.
 
 With this integration, visualize important Neo4j metrics in our out-of-the-box dashboards and enable your DBAs to troubleshoot and monitor the health of your Neo4j databases.
 
-### Metrics
-
-**Neo4j Version 4**
-Neo4j 4 metrics are collected as documented [here][11]. The most commonly monitored metrics are provided in the out-of-the-box dashboards. 
-
-**Neo4j Version 5**
-Neo4j 5 metrics are collected as documented [here][10]. The most commonly monitored metrics are provided in the out-of-the-box dashboards. 
-
-Please note each version collects a different set of metrics. The versions are listed in the description of the metric.
-
-See [metadata.csv][6] for the full list of metrics provided by this check.
-
-### Service Checks
-
-Service check `neo4j.prometheus.health` is submitted in the base check
-
-### Events
-
-Neo4j does not include any events.
 
 ## Setup
 
@@ -57,6 +38,18 @@ To install the neo4j check on your host:
 
 ## Data Collected
 
+### Metrics
+
+**Neo4j Version 4**
+Neo4j 4 metrics are collected as documented [here][11]. The most commonly monitored metrics are provided in the out-of-the-box dashboards. 
+
+**Neo4j Version 5**
+Neo4j 5 metrics are collected as documented [here][10]. The most commonly monitored metrics are provided in the out-of-the-box dashboards. 
+
+Please note each version collects a different set of metrics. The versions are listed in the description of the metric.
+
+See [metadata.csv][6] for the full list of metrics provided by this check.
+
 ### Service Checks
 
 Service check `neo4j.prometheus.health` is submitted in the base check
@@ -64,6 +57,7 @@ Service check `neo4j.prometheus.health` is submitted in the base check
 ### Events
 
 Neo4j does not include any events.
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
This PR would move "Metrics" to the "Data Collected" section where it belongs.

It is ridiculous to have to scroll past all the metrics listed out before getting to the installation/configuration/setup instructions for this integration.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
