### PR TITLE
DOCS-7156 LaunchDarkly Integration Edit

### DIFF
--- a/launchdarkly/README.md
+++ b/launchdarkly/README.md
@@ -2,6 +2,12 @@
 
 ## Overview
 
+<!-- partial
+{{% site-region region="gov" %}}
+**The LaunchDarkly integration is not supported for the Datadog {{< region-param key="dd_site_name" >}} site**.
+{{% /site-region %}}
+partial -->
+
 LaunchDarkly provides the following integrations with Datadog:
 
 ### Events integration


### PR DESCRIPTION
### What does this PR do?

Adds a site region partial that informs users that the LaunchDarkly integration is not supported for Gov. 

Verified with Erica on Slack.

### Motivation

DOCS-7156 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
