### PR TITLE
[docs] Include required `dd-agent user flag `

### DIFF
--- a/ping/README.md
+++ b/ping/README.md
@@ -23,7 +23,7 @@ For Agent v7.21+ / v6.21+, follow the instructions below to install the ping che
 
    ```shell
    # Linux
-   datadog-agent integration install -t datadog-ping==<INTEGRATION_VERSION>
+   sudo -u dd-agent -- datadog-agent integration install -t datadog-ping==<INTEGRATION_VERSION>
    
    # Windows
    agent.exe integration install -t datadog-ping==<INTEGRATION_VERSION>


### PR DESCRIPTION
Ticket in Reference:

<link>https://datadog.zendesk.com/agent/tickets/1509271</link>

Ping Installation steps do not reference this running command with:

`sudo -u dd-agent --`

Which caused issue with customer upgrading Agent and re-installing Ping Integration. Discovered that documents command was the issue as it caused a permissions issue with the Agent.

Integration Management Documents refer to running with dd-agent user

<link>https://docs.datadoghq.com/agent/guide/integration-management/?tab=linux</link>

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [X ] Feature or bugfix has tests
- [ X] Git history is clean
- [ X] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
