### PR TITLE
[ecos 1214] remove old unused oauth manifest field

### DIFF
--- a/1e/manifest.json
+++ b/1e/manifest.json
@@ -58,6 +58,5 @@
     "name": "1E",
     "homepage": "https://1E.com",
     "sales_email": "sales@1E.com"
-  },
-  "oauth": {}
+  }
 }

--- a/ably/manifest.json
+++ b/ably/manifest.json
@@ -62,6 +62,5 @@
     "name": "Ably",
     "homepage": "https://ably.com",
     "sales_email": "sales@ably.com"
-  },
-  "oauth": {}
+  }
 }

--- a/agora_analytics/manifest.json
+++ b/agora_analytics/manifest.json
@@ -63,6 +63,5 @@
     "name": "Agora",
     "sales_email": "sales-us@agora.io",
     "support_email": "support@agora.io"
-  },
-  "oauth": {}
+  }
 }

--- a/akamai_datastream_2/manifest.json
+++ b/akamai_datastream_2/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Datadog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Akamai DataStream 2",

--- a/akeyless_gateway/manifest.json
+++ b/akeyless_gateway/manifest.json
@@ -33,7 +33,6 @@
     "sales_email": "sales@akeyless.io",
     "name": "Akeyless Security"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Akeyless Gateway",

--- a/alertnow/manifest.json
+++ b/alertnow/manifest.json
@@ -28,7 +28,6 @@
     "sales_email": "sales@opsnow.com",
     "support_email": "support@opsnow.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "AlertNow",

--- a/algorithmia/manifest.json
+++ b/algorithmia/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "support@algorithmia.io",
     "name": "Algorithmia"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Algorithmia",

--- a/altostra/manifest.json
+++ b/altostra/manifest.json
@@ -27,7 +27,6 @@
     "sales_email": "support@altostra.com",
     "name": "Altostra"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Altostra",

--- a/ambassador/manifest.json
+++ b/ambassador/manifest.json
@@ -27,7 +27,6 @@
     "sales_email": "hello@datawire.io",
     "name": "Ambassador"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Ambassador",

--- a/amixr/manifest.json
+++ b/amixr/manifest.json
@@ -29,7 +29,6 @@
     "sales_email": "ildar@amixr.io",
     "name": "Amixr"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Amixr",

--- a/apache-apisix/manifest.json
+++ b/apache-apisix/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "dev@apisix.apache.org",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "dashboards": {
       "Apache APISIX Dashboard": "assets/dashboards/apache-apisix_overview.json"

--- a/apollo/manifest.json
+++ b/apollo/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "sachin@apollographql.com",
     "name": "Apollo"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Apollo Engine",

--- a/appkeeper/manifest.json
+++ b/appkeeper/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "rd-pd-1@sios.com",
     "name": "SIOS AppKeeper"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "AppKeeper",

--- a/apptrail/manifest.json
+++ b/apptrail/manifest.json
@@ -56,6 +56,5 @@
     "sales_email": "sales@apptrail.com",
     "support_email": "support@apptrail.com"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/aqua/manifest.json
+++ b/aqua/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "oran.moshai@aquasec.com",
     "name": "Aqua"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Aqua",

--- a/auth0/manifest.json
+++ b/auth0/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Auth0"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Auth0",

--- a/aws_pricing/manifest.json
+++ b/aws_pricing/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "tsein@brightcove.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "AWS Pricing",

--- a/backstage/manifest.json
+++ b/backstage/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "oss@roadie.io",
     "name": "Roadie"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "backstage",

--- a/bind9/manifest.json
+++ b/bind9/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "ashuvyas45@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "BIND 9",

--- a/blink/manifest.json
+++ b/blink/manifest.json
@@ -64,6 +64,5 @@
     "name": "Blink",
     "homepage": "https://www.blinkops.com/",
     "sales_email": "support@blinkops.com"
-  },
-  "oauth": {}
+  }
 }

--- a/bluematador/manifest.json
+++ b/bluematador/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "support@bluematador.com",
     "name": "Blue Matador"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Blue Matador",

--- a/bonsai/manifest.json
+++ b/bonsai/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "dev@onemorecloud.com",
     "name": "Bonsai"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Bonsai",

--- a/botprise/manifest.json
+++ b/botprise/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Botprise"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "botprise",

--- a/bottomline_recordandreplay/manifest.json
+++ b/bottomline_recordandreplay/manifest.json
@@ -46,7 +46,6 @@
     "vendor_id": "bottomline",
     "sales_email": "partner.cfrm@bottomline.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Bottomline Mainframe",

--- a/buddy/manifest.json
+++ b/buddy/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "support@buddy.works",
     "name": "Buddy"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Buddy",

--- a/buoyant_cloud/manifest.json
+++ b/buoyant_cloud/manifest.json
@@ -92,6 +92,5 @@
     "name": "Buoyant",
     "homepage": "https://buoyant.io/cloud",
     "sales_email": "cloud@buoyant.io"
-  },
-  "oauth": {}
+  }
 }

--- a/census/manifest.json
+++ b/census/manifest.json
@@ -57,6 +57,5 @@
     "name": "Census",
     "homepage": "https://www.getcensus.com/",
     "sales_email": "sales@getcensus.com"
-  },
-  "oauth": {}
+  }
 }

--- a/cfssl/manifest.json
+++ b/cfssl/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "JeanFred1@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "cfssl",

--- a/cloudnatix/manifest.json
+++ b/cloudnatix/manifest.json
@@ -71,6 +71,5 @@
     "homepage": "https://cloudnatix.com/",
     "sales_email": "sales@cloudnatix.com"
   },
-  "oauth": {},
   "pricing": []
 }

--- a/cloudsmith/manifest.json
+++ b/cloudsmith/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "ccarey@cloudsmith.io",
     "name": "Cloudsmith"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Cloudsmith",

--- a/cockroachdb_dedicated/manifest.json
+++ b/cockroachdb_dedicated/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Datadog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "CockroachDB Dedicated",

--- a/concourse_ci/manifest.json
+++ b/concourse_ci/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Concourse CI",

--- a/configcat/manifest.json
+++ b/configcat/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "developer@configcat.com",
     "name": "ConfigCat"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "ConfigCat",

--- a/contrastsecurity/manifest.json
+++ b/contrastsecurity/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "kristiana.mitchell@contrastsecurity.com",
     "name": "Contrast Security"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "contrastsecurity",

--- a/convox/manifest.json
+++ b/convox/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Convox"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Convox",

--- a/cortex/manifest.json
+++ b/cortex/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "support@getcortexapp.com",
     "name": "Cortex"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "cortex",

--- a/cribl_stream/manifest.json
+++ b/cribl_stream/manifest.json
@@ -45,7 +45,6 @@
     "homepage": "https://cribl.io",
     "sales_email": "sales@cribl.io"
   },
-  "oauth": {},
   "assets": {
     "dashboards": {
       "cribl_stream_overview": "assets/dashboards/cribl_stream_overview.json"

--- a/cybersixgill_actionable_alerts/manifest.json
+++ b/cybersixgill_actionable_alerts/manifest.json
@@ -72,6 +72,5 @@
     "name": "Cybersixgill",
     "homepage": "https://www.cybersixgill.com/",
     "sales_email": "info@cybersixgill.com"
-  },
-  "oauth": {}
+  }
 }

--- a/cyral/manifest.json
+++ b/cyral/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "product@cyral.com",
     "name": "Cyral"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Cyral",

--- a/data_runner/manifest.json
+++ b/data_runner/manifest.json
@@ -30,6 +30,5 @@
     "sales_email": "sales@datadog.com",
     "support_email": "help@datadoghq.com"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/datazoom/manifest.json
+++ b/datazoom/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Datadog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Datazoom",

--- a/devcycle/manifest.json
+++ b/devcycle/manifest.json
@@ -26,6 +26,5 @@
         "name": "DevCycle",
         "homepage": "https://devcycle.com",
         "sales_email": "sales@devcycle.com"
-    },
-    "oauth": {}
+    }
 }

--- a/docontrol/manifest.json
+++ b/docontrol/manifest.json
@@ -62,6 +62,5 @@
     "support_email": "support@docontrol.io",
     "sales_email": "sales@docontrol.io"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/doctordroid/manifest.json
+++ b/doctordroid/manifest.json
@@ -54,7 +54,6 @@
     "homepage": "https://www.drdroid.io",
     "name": "Doctor Droid"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "auto_install": true,

--- a/drata/manifest.json
+++ b/drata/manifest.json
@@ -27,7 +27,6 @@
     "support_email": "support@drata.com",
     "sales_email": "sales@drata.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Drata",

--- a/dylibso-webassembly/manifest.json
+++ b/dylibso-webassembly/manifest.json
@@ -33,6 +33,5 @@
     "name": "Dylibso",
     "homepage": "https://dylibso.com",
     "sales_email": "sales@dylibso.com"
-  },
-  "oauth": {}
+  }
 }

--- a/embrace_mobile/manifest.json
+++ b/embrace_mobile/manifest.json
@@ -53,7 +53,6 @@
     "name": "Embrace",
     "support_email": "support@embrace.io"
   },
-  "oauth": {},
   "assets": {
     "dashboards": {
       "Embrace Overview": "assets/dashboards/embrace_mobile_overview.json"

--- a/emnify/manifest.json
+++ b/emnify/manifest.json
@@ -48,7 +48,6 @@
     "sales_email": "sales@emnify.com",
     "name": "EMnify"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "EMnify",

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Eventstore",

--- a/eversql/manifest.json
+++ b/eversql/manifest.json
@@ -47,6 +47,5 @@
     "support_email": "support@eversql.com",
     "sales_email": "sales@eversql.com"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/exim/manifest.json
+++ b/exim/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "JeanFred1@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "exim",

--- a/f5-distributed-cloud/manifest.json
+++ b/f5-distributed-cloud/manifest.json
@@ -38,7 +38,6 @@
     "sales_email": "sales@f5.com",
     "support_email": "g.coward@f5.com"
   },
-  "oauth": {},
   "assets": {
     "dashboards": {
       "f5xc_access": "assets/dashboards/f5xc_access.json"

--- a/fairwinds_insights_ui/manifest.json
+++ b/fairwinds_insights_ui/manifest.json
@@ -31,6 +31,5 @@
     "support_email": "insights@fairwinds.com",
     "sales_email": "datadog-marketplace@fairwinds.com"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/federatorai/manifest.json
+++ b/federatorai/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "support@prophetstor.com",
     "name": "ProphetStor"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Federator.ai",

--- a/fiddler/manifest.json
+++ b/fiddler/manifest.json
@@ -60,7 +60,6 @@
     "support_email": "sales@fiddler.ai",
     "sales_email": "sales@fiddler.ai"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "fiddler",

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "jean@tripping.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Filebeat",

--- a/filemage/manifest.json
+++ b/filemage/manifest.json
@@ -56,6 +56,5 @@
     "name": "Community",
     "homepage": "https://dopensource.com/",
     "sales_email": "info@dopensource.com"
-  },
-  "oauth": {}
+  }
 }

--- a/finout/manifest.json
+++ b/finout/manifest.json
@@ -46,6 +46,5 @@
     "support_email": "support@finout.io",
     "sales_email": "support@finout.io"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/firefly/manifest.json
+++ b/firefly/manifest.json
@@ -50,6 +50,5 @@
     "support_email": "contact@gofirefly.io",
     "sales_email": "contact@gofirefly.io"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/flagsmith-rum/manifest.json
+++ b/flagsmith-rum/manifest.json
@@ -38,6 +38,5 @@
     "sales_email": "support@flagsmith.com",
     "name": "Flagsmith"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/flagsmith/manifest.json
+++ b/flagsmith/manifest.json
@@ -27,7 +27,6 @@
     "sales_email": "support@flagsmith.com",
     "name": "Flagsmith"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Flagsmith",

--- a/fluentbit/manifest.json
+++ b/fluentbit/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "zhenyamzk+GitHub@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Fluent Bit",

--- a/flume/manifest.json
+++ b/flume/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "kealan.maas@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "flume",

--- a/gatekeeper/manifest.json
+++ b/gatekeeper/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "ara.pulido@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Gatekeeper",

--- a/gitea/manifest.json
+++ b/gitea/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "florent.clarret@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Gitea",

--- a/gnatsd/manifest.json
+++ b/gnatsd/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "dev@goldstar.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Gnatsd",

--- a/gnatsd_streaming/manifest.json
+++ b/gnatsd_streaming/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "dev@goldstar.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Gnatsd streaming",

--- a/go_pprof_scraper/manifest.json
+++ b/go_pprof_scraper/manifest.json
@@ -23,7 +23,6 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "go_pprof_scraper",

--- a/gremlin/manifest.json
+++ b/gremlin/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "support@gremlin.com",
     "name": "Gremlin"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Gremlin",

--- a/grpc_check/manifest.json
+++ b/grpc_check/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "help@datadoghq.com",
     "support_email": "keisuke.umegaki.630@gmail.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "gRPC Check",

--- a/harness_cloud_cost_management/manifest.json
+++ b/harness_cloud_cost_management/manifest.json
@@ -42,7 +42,6 @@
     "support_email": "akash.bhardwaj@harness.io",
     "sales_email": "akash.bhardwaj@harness.io"
   },
-  "oauth": {},
   "assets": {
     "dashboards": {
       "harness_cloud_cost_management_overview": "assets/dashboards/harness_cloud_cost_management_overview.json"

--- a/hasura_cloud/manifest.json
+++ b/hasura_cloud/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "support@hasura.io",
     "name": "Hasura"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Hasura Cloud",

--- a/hbase_master/manifest.json
+++ b/hbase_master/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "everpeace@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "HBase master",

--- a/hbase_regionserver/manifest.json
+++ b/hbase_regionserver/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "everpeace@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "HBase regionserver",

--- a/hcp_vault/manifest.json
+++ b/hcp_vault/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Datadog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "HCPVault",

--- a/hikaricp/manifest.json
+++ b/hikaricp/manifest.json
@@ -43,6 +43,5 @@
     "name": "Community",
     "homepage": "https://github.com/DataDog/integrations-extras",
     "sales_email": "damien.bertau@blablacar.com"
-  },
-  "oauth": {}
+  }
 }

--- a/ilert/manifest.json
+++ b/ilert/manifest.json
@@ -34,7 +34,6 @@
     "sales_email": "support@ilert.com",
     "name": "ilert"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "iLert",

--- a/insightfinder/manifest.json
+++ b/insightfinder/manifest.json
@@ -28,7 +28,6 @@
     "sales_email": "support@insightfinder.com",
     "name": "InsightFinder"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "InsightFinder",

--- a/instabug/manifest.json
+++ b/instabug/manifest.json
@@ -58,6 +58,5 @@
     "name": "Instabug",
     "homepage": "https://www.instabug.com/",
     "sales_email": "success@instabug.com"
-  },
-  "oauth": {}
+  }
 }

--- a/invary/manifest.json
+++ b/invary/manifest.json
@@ -48,6 +48,5 @@
     "name": "Invary",
     "homepage": "https://www.invary.com",
     "sales_email": "sales@invary.com"
-  },
-  "oauth": {}
+  }
 }

--- a/isdown/manifest.json
+++ b/isdown/manifest.json
@@ -58,6 +58,5 @@
     "name": "IsDown",
     "homepage": "https://isdown.app",
     "sales_email": "sales@isdown.app"
-  },
-  "oauth": {}
+  }
 }

--- a/jamf_protect/manifest.json
+++ b/jamf_protect/manifest.json
@@ -24,7 +24,6 @@
     "homepage": "https://www.jamf.com/products/jamf-protect/",
     "sales_email": "support@jamf.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "jamf_logs",

--- a/jfrog_platform_cloud/manifest.json
+++ b/jfrog_platform_cloud/manifest.json
@@ -61,6 +61,5 @@
     "name": "JFrog",
     "homepage": "https://jfrog.com/",
     "sales_email": "partners@jfrog.com"
-  },
-  "oauth": {}
+  }
 }

--- a/jfrog_platform_self_hosted/manifest.json
+++ b/jfrog_platform_self_hosted/manifest.json
@@ -56,7 +56,6 @@
     "sales_email": "partners@jfrog.com",
     "name": "JFrog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "JFrog Platform",

--- a/k6/manifest.json
+++ b/k6/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "support@k6.io",
     "name": "k6"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "k6",

--- a/keep/manifest.json
+++ b/keep/manifest.json
@@ -54,6 +54,5 @@
     "name": "Keep",
     "homepage": "https://www.keephq.dev",
     "sales_email": "founders@keephq.dev"
-  },
-  "oauth": {}
+  }
 }

--- a/kernelcare/manifest.json
+++ b/kernelcare/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "schvaliuk@cloudlinux.com",
     "name": "CloudLinux"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Kernelcare",

--- a/komodor/manifest.json
+++ b/komodor/manifest.json
@@ -66,6 +66,5 @@
   "legal_terms": {
     "eula": "Komodor Terms of use.pdf"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/lacework/manifest.json
+++ b/lacework/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Datadog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Lacework",

--- a/lambdatest/manifest.json
+++ b/lambdatest/manifest.json
@@ -29,7 +29,6 @@
     "sales_email": "prateeksaini@lambdatest.com",
     "name": "LambdaTest"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "LambdaTest",

--- a/launchdarkly/manifest.json
+++ b/launchdarkly/manifest.json
@@ -44,7 +44,6 @@
     "support_email": "support@launchdarkly.com",
     "sales_email": "sales@launchdarkly.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "LaunchDarkly",

--- a/lighthouse/manifest.json
+++ b/lighthouse/manifest.json
@@ -22,7 +22,6 @@
     "sales_email": "mustin.eric@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Lighthouse",

--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "ervansetiawan@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Logstash",

--- a/logzio/manifest.json
+++ b/logzio/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Logz.io"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Logz.io",

--- a/mendix/manifest.json
+++ b/mendix/manifest.json
@@ -63,6 +63,5 @@
     "name": "Mendix",
     "homepage": "https://mendix.com/",
     "sales_email": "mxsupport@mendix.com"
-  },
-  "oauth": {}
+  }
 }

--- a/mergify/manifest.json
+++ b/mergify/manifest.json
@@ -48,6 +48,5 @@
     "name": "Community",
     "homepage": "https://mergify.com",
     "sales_email": "hello@mergify.com"
-  },
-  "oauth": {}
+  }
 }

--- a/mongodb_atlas/manifest.json
+++ b/mongodb_atlas/manifest.json
@@ -52,6 +52,5 @@
     "name": "Datadog",
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
-  },
-  "oauth": {}
+  }
 }

--- a/n2ws/manifest.json
+++ b/n2ws/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "eliad.eini@n2ws.com",
     "name": "N2WS"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "N2WS Backup & Recovery",

--- a/neo4j/manifest.json
+++ b/neo4j/manifest.json
@@ -35,7 +35,6 @@
     "sales_email": "support@neotechnology.com",
     "name": "Neo4j"
   },
-  "oauth": {},
   "assets": {
     "dashboards": {
       "Neo4j V4 Dashboard": "assets/dashboards/Neo4j4.xDefaultDashboard.json",

--- a/neoload/manifest.json
+++ b/neoload/manifest.json
@@ -54,6 +54,5 @@
     "homepage": "https://www.tricentis.com/products/performance-testing-neoload",
     "sales_email": "sales@tricentis.com",
     "support_email": "support@tricentis.com"
-  },
-  "oauth": {}
+  }
 }

--- a/neutrona/manifest.json
+++ b/neutrona/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "david@neutrona.com",
     "name": "Neutrona"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Neutrona",

--- a/nextcloud/manifest.json
+++ b/nextcloud/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "emeric.planet@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Nextcloud",

--- a/ngrok/manifest.json
+++ b/ngrok/manifest.json
@@ -59,6 +59,5 @@
     "name": "ngrok",
     "homepage": "https://ngrok.com",
     "sales_email": "sales@ngrok.com"
-  },
-  "oauth": {}
+  }
 }

--- a/nn_sdwan/manifest.json
+++ b/nn_sdwan/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "info@netnology.io",
     "name": "Netnology"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Netnology SD-WAN",

--- a/nobl9/manifest.json
+++ b/nobl9/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "support@nobl9.com",
     "name": "Nobl9"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Nobl9",

--- a/nomad/manifest.json
+++ b/nomad/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Nomad"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Nomad",

--- a/notion/manifest.json
+++ b/notion/manifest.json
@@ -57,6 +57,5 @@
     "name": "Notion Labs, Inc.",
     "homepage": "https://www.notion.so/",
     "sales_email": "integrations@makenotion.com"
-  },
-  "oauth": {}
+  }
 }

--- a/ns1/manifest.json
+++ b/ns1/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "zjohnson@ns1.com",
     "name": "NS1"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "NS1",

--- a/nvml/manifest.json
+++ b/nvml/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "nvml",

--- a/octoprint/manifest.json
+++ b/octoprint/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "gwaldo@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "OctoPrint",

--- a/open_policy_agent/manifest.json
+++ b/open_policy_agent/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "ara.pulido@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "open_policy_agent",

--- a/pagerduty/manifest.json
+++ b/pagerduty/manifest.json
@@ -50,7 +50,6 @@
     "sales_email": "sales@pagerduty.com",
     "support_email": "support@pagerduty.com"
   },
-  "oauth": {},
   "assets": {
     "dashboards": {
       "PagerDuty for Datadog": "assets/dashboards/pagerduty_overview.json"

--- a/perimeterx/manifest.json
+++ b/perimeterx/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "support@perimeterx.com",
     "name": "PerimeterX"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "PerimeterX",

--- a/php_apcu/manifest.json
+++ b/php_apcu/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "noname@withgod.jp",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "PHP APCu",

--- a/php_opcache/manifest.json
+++ b/php_opcache/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "noname@withgod.jp",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "PHP OPcache",

--- a/pihole/manifest.json
+++ b/pihole/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "monganai@tcd.ie",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "pihole",

--- a/ping/manifest.json
+++ b/ping/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "jim.stanton@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Ping",

--- a/planetscale/manifest.json
+++ b/planetscale/manifest.json
@@ -21,7 +21,6 @@
     "name": "PlanetScale",
     "sales_email": "sales@planetscale.com"
   },
-  "oauth": {},
   "assets": {
     "dashboards": {
       "planetscale_overview": "assets/dashboards/planetscale_overview.json"

--- a/pliant/manifest.json
+++ b/pliant/manifest.json
@@ -28,7 +28,6 @@
     "sales_email": "hello@pliant.io",
     "name": "Pliant"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Pliant",

--- a/portworx/manifest.json
+++ b/portworx/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "paul@portworx.com",
     "name": "Portworx"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Portworx",

--- a/postman/manifest.json
+++ b/postman/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "integrations-partnerships@postman.com",
     "name": "Postman"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Postman",

--- a/pulumi/manifest.json
+++ b/pulumi/manifest.json
@@ -30,7 +30,6 @@
     "sales_email": "team@pulumi.com",
     "name": "Pulumi"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Pulumi",

--- a/puma/manifest.json
+++ b/puma/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "justin.morris@ferocia.com.au",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Puma",

--- a/purefa/manifest.json
+++ b/purefa/manifest.json
@@ -42,7 +42,6 @@
     "support_email": "pure-observability@purestorage.com",
     "sales_email": "sales@purestorage.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "PureFA",

--- a/purefb/manifest.json
+++ b/purefb/manifest.json
@@ -42,7 +42,6 @@
     "sales_email": "sales@purestorage.com",
     "support_email": "pure-observability@purestorage.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "PureFB",

--- a/radarr/manifest.json
+++ b/radarr/manifest.json
@@ -44,6 +44,5 @@
     "name": "Community",
     "homepage": "https://github.com/DataDog/integrations-extras",
     "sales_email": "hadrien.patte@datadoghq.com"
-  },
-  "oauth": {}
+  }
 }

--- a/rbltracker/manifest.json
+++ b/rbltracker/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "RBL Tracker"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "RBLTracker",

--- a/reboot_required/manifest.json
+++ b/reboot_required/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "support@krugerheavyindustries.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Reboot required",

--- a/redis_sentinel/manifest.json
+++ b/redis_sentinel/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Redis Sentinel",

--- a/redisenterprise/manifest.json
+++ b/redisenterprise/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "github@mague.com",
     "name": "Redis"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Redis Enterprise",

--- a/redpanda/manifest.json
+++ b/redpanda/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "support@redpanda.com",
     "name": "Redpanda"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Redpanda",

--- a/resin/manifest.json
+++ b/resin/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "brent@bmontague.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Resin",

--- a/retool/manifest.json
+++ b/retool/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "support@retool.com",
     "name": "Retool"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Retool",

--- a/riak_repl/manifest.json
+++ b/riak_repl/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "britt.treece@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Riak MDC Replication",

--- a/rigor/manifest.json
+++ b/rigor/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "support@rigor.com",
     "name": "Rigor"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Rigor",

--- a/robust_intelligence_ai_firewall/manifest.json
+++ b/robust_intelligence_ai_firewall/manifest.json
@@ -60,6 +60,5 @@
     "name": "Robust Intelligence",
     "homepage": "https://www.robustintelligence.com/",
     "sales_email": "contact@robustintelligence.com"
-  },
-  "oauth": {}
+  }
 }

--- a/rookout/manifest.json
+++ b/rookout/manifest.json
@@ -41,7 +41,6 @@
     "support_email": "support@rookout.com",
     "sales_email": "support@rookout.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Rookout for Datadog",

--- a/rum_android/manifest.json
+++ b/rum_android/manifest.json
@@ -26,6 +26,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rum_angular/manifest.json
+++ b/rum_angular/manifest.json
@@ -23,6 +23,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rum_cypress/manifest.json
+++ b/rum_cypress/manifest.json
@@ -26,6 +26,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rum_expo/manifest.json
+++ b/rum_expo/manifest.json
@@ -27,6 +27,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rum_flutter/manifest.json
+++ b/rum_flutter/manifest.json
@@ -27,6 +27,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rum_ios/manifest.json
+++ b/rum_ios/manifest.json
@@ -24,6 +24,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rum_javascript/manifest.json
+++ b/rum_javascript/manifest.json
@@ -24,6 +24,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rum_react/manifest.json
+++ b/rum_react/manifest.json
@@ -28,6 +28,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rum_react_native/manifest.json
+++ b/rum_react_native/manifest.json
@@ -27,6 +27,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rum_roku/manifest.json
+++ b/rum_roku/manifest.json
@@ -24,6 +24,5 @@
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
   },
-  "assets": {},
-  "oauth": {}
+  "assets": {}
 }

--- a/rundeck/manifest.json
+++ b/rundeck/manifest.json
@@ -27,7 +27,6 @@
     "sales_email": "forrest@rundeck.com",
     "name": "Rundeck"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Rundeck",

--- a/scalr/manifest.json
+++ b/scalr/manifest.json
@@ -56,6 +56,5 @@
     "name": "Scalr",
     "homepage": "https://scalr.com",
     "sales_email": "sales@scalr.com"
-  },
-  "oauth": {}
+  }
 }

--- a/seagence/manifest.json
+++ b/seagence/manifest.json
@@ -69,6 +69,5 @@
     "name": "Seagence Technologies",
     "homepage": "https://www.seagence.com/",
     "sales_email": "sales@seagence.com"
-  },
-  "oauth": {}
+  }
 }

--- a/sedai/manifest.json
+++ b/sedai/manifest.json
@@ -29,7 +29,6 @@
     "sales_email": "praveen.prakash@sedai.io",
     "name": "Sedai"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Sedai",

--- a/sendmail/manifest.json
+++ b/sendmail/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "david.bouchare@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Sendmail",

--- a/shoreline/manifest.json
+++ b/shoreline/manifest.json
@@ -45,6 +45,5 @@
     "sales_email": "sales@shoreline.io",
     "support_email": "support@shoreline.io"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/signl4/manifest.json
+++ b/signl4/manifest.json
@@ -28,7 +28,6 @@
     "sales_email": "success@signl4.com",
     "name": "SIGNL4"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "SIGNL4",

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "info@signalsciences.com",
     "name": "Signal Sciences"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Signal Sciences",

--- a/singlestoredb_cloud/manifest.json
+++ b/singlestoredb_cloud/manifest.json
@@ -53,6 +53,5 @@
     "name": "Singlestore",
     "homepage": "https://www.singlestore.com",
     "sales_email": "info@singlestore.com"
-  },
-  "oauth": {}
+  }
 }

--- a/sleuth/manifest.json
+++ b/sleuth/manifest.json
@@ -27,7 +27,6 @@
     "sales_email": "support@sleuth.io",
     "name": "Sleuth"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Sleuth",

--- a/snmpwalk/manifest.json
+++ b/snmpwalk/manifest.json
@@ -26,6 +26,5 @@
     "sales_email": "help@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/sofy_sofy/manifest.json
+++ b/sofy_sofy/manifest.json
@@ -67,6 +67,5 @@
     "vendor_id": "sofy",
     "sales_email": "devops@sofy.ai",
     "support_email": "devops@sofy.ai"
-  },
-  "oauth": {}
+  }
 }

--- a/sonarr/manifest.json
+++ b/sonarr/manifest.json
@@ -44,6 +44,5 @@
     "name": "Community",
     "homepage": "https://github.com/DataDog/integrations-extras",
     "sales_email": "hadrien.patte@datadoghq.com"
-  },
-  "oauth": {}
+  }
 }

--- a/sortdb/manifest.json
+++ b/sortdb/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "namrata.deshpande4@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Sortdb",

--- a/sosivio/manifest.json
+++ b/sosivio/manifest.json
@@ -33,7 +33,6 @@
     "name": "Sosivio",
     "sales_email": "sales@sosiv.io"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Sosivio",

--- a/speedscale/manifest.json
+++ b/speedscale/manifest.json
@@ -27,7 +27,6 @@
     "sales_email": "support@speedscale.com",
     "name": "Speedscale"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Speedscale",

--- a/speedtest/manifest.json
+++ b/speedtest/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "cody.lee@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "speedtest",

--- a/split-rum/manifest.json
+++ b/split-rum/manifest.json
@@ -38,6 +38,5 @@
     "sales_email": "partners@split.io",
     "name": "Split"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/split/manifest.json
+++ b/split/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Split"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Split",

--- a/sqreen/manifest.json
+++ b/sqreen/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "support@sqreen.com",
     "name": "Datadog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Sqreen",

--- a/squadcast/manifest.json
+++ b/squadcast/manifest.json
@@ -28,7 +28,6 @@
     "sales_email": "it@squadcast.com",
     "name": "Squadcast"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Squadcast",

--- a/stackpulse/manifest.json
+++ b/stackpulse/manifest.json
@@ -28,7 +28,6 @@
     "sales_email": "support@stackpulse.io",
     "name": "Torq"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "StackPulse",

--- a/stardog/manifest.json
+++ b/stardog/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "support@stardog.com",
     "name": "Stardog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Stardog",

--- a/statsig/manifest.json
+++ b/statsig/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "support@statsig.com",
     "name": "Statsig"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Statsig",

--- a/statsig_rum/manifest.json
+++ b/statsig_rum/manifest.json
@@ -40,6 +40,5 @@
     "name": "Statsig",
     "homepage": "https://statsig.com",
     "sales_email": "support@statsig.com"
-  },
-  "oauth": {}
+  }
 }

--- a/steadybit/manifest.json
+++ b/steadybit/manifest.json
@@ -69,6 +69,5 @@
     "name": "Steadybit",
     "homepage": "https://steadybit.com/",
     "sales_email": "sales@steadybit.com"
-  },
-  "oauth": {}
+  }
 }

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "storm",

--- a/stormforge/manifest.json
+++ b/stormforge/manifest.json
@@ -40,7 +40,6 @@
     "homepage": "https://stormforge.io",
     "sales_email": "sales@stormforge.io"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "StormForge",

--- a/superwise/manifest.json
+++ b/superwise/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "support@superwise.ai",
     "name": "Superwise"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Superwise",

--- a/syncthing/manifest.json
+++ b/syncthing/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "Alexander@Bushnev.pro",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Syncthing",

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -46,6 +46,5 @@
     "name": "Datadog",
     "homepage": "https://www.datadoghq.com",
     "sales_email": "info@datadoghq.com"
-  },
-  "oauth": {}
+  }
 }

--- a/taskcall/manifest.json
+++ b/taskcall/manifest.json
@@ -52,6 +52,5 @@
     "name": "TaskCall",
     "homepage": "https://taskcallapp.com",
     "sales_email": "support@taskcallapp.com"
-  },
-  "oauth": {}
+  }
 }

--- a/tidb/manifest.json
+++ b/tidb/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "xuyifan02@pingcap.com",
     "name": "PingCAP"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "TiDB",

--- a/tidb_cloud/manifest.json
+++ b/tidb_cloud/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "xuyifan02@pingcap.com",
     "name": "PingCAP"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "TiDB Cloud",

--- a/torq/manifest.json
+++ b/torq/manifest.json
@@ -27,7 +27,6 @@
     "sales_email": "support@torq.io",
     "name": "Torq"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Torq",

--- a/traefik/manifest.json
+++ b/traefik/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Traefik",

--- a/trino/manifest.json
+++ b/trino/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Trino",

--- a/twenty_forty_eight/manifest.json
+++ b/twenty_forty_eight/manifest.json
@@ -30,6 +30,5 @@
     "sales_email": "sales@datadog.com",
     "support_email": "help@datadoghq.com"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/twingate/manifest.json
+++ b/twingate/manifest.json
@@ -37,7 +37,6 @@
     "sales_email": "sales@twingate.com",
     "name": "Twingate"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Twingate",

--- a/tyk/manifest.json
+++ b/tyk/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "yaara@tyk.io",
     "name": "Tyk"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Tyk",

--- a/typingdna_activelock/manifest.json
+++ b/typingdna_activelock/manifest.json
@@ -47,6 +47,5 @@
     "name": "TypingDNA",
     "homepage": "https://www.typingdna.com/contact",
     "sales_email": "datadog.support@typingdna.com"
-  },
-  "oauth": {}
+  }
 }

--- a/unbound/manifest.json
+++ b/unbound/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "david.byron@avast.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Unbound",

--- a/unifi_console/manifest.json
+++ b/unifi_console/manifest.json
@@ -23,7 +23,6 @@
     "sales_email": "antonin.bruneau@gmail.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Unifi Console",

--- a/unitq/manifest.json
+++ b/unitq/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "hello@unitq.com",
     "support_email": "hello@unitq.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "unitQ",

--- a/upbound_uxp/manifest.json
+++ b/upbound_uxp/manifest.json
@@ -69,6 +69,5 @@
     "name": "Upbound",
     "homepage": "https://www.upbound.io/",
     "sales_email": "sales@upbound.io"
-  },
-  "oauth": {}
+  }
 }

--- a/upsc/manifest.json
+++ b/upsc/manifest.json
@@ -22,7 +22,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "UPSC",

--- a/upstash/manifest.json
+++ b/upstash/manifest.json
@@ -56,6 +56,5 @@
     "name": "Upstash",
     "homepage": "https://upstash.com",
     "sales_email": "sales@upstash.com"
-  },
-  "oauth": {}
+  }
 }

--- a/uptime/manifest.json
+++ b/uptime/manifest.json
@@ -25,7 +25,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Uptime"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Uptime",

--- a/uptycs/manifest.json
+++ b/uptycs/manifest.json
@@ -64,6 +64,5 @@
     "name": "Uptycs",
     "homepage": "https://www.uptycs.com",
     "sales_email": "sales@uptycs.com"
-  },
-  "oauth": {}
+  }
 }

--- a/vantage/manifest.json
+++ b/vantage/manifest.json
@@ -47,6 +47,5 @@
   "legal_terms": {
     "eula": "assets/terms-of-service.pdf"
   },
-  "oauth": {},
   "assets": {}
 }

--- a/vercel/manifest.json
+++ b/vercel/manifest.json
@@ -27,7 +27,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Datadog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Vercel",

--- a/vespa/manifest.json
+++ b/vespa/manifest.json
@@ -22,7 +22,6 @@
     "sales_email": "dd@vespa.ai",
     "name": "Vespa"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Vespa",

--- a/vns3/manifest.json
+++ b/vns3/manifest.json
@@ -26,7 +26,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Cohesive Networks"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "VNS3",

--- a/wayfinder/manifest.json
+++ b/wayfinder/manifest.json
@@ -64,6 +64,5 @@
     "name": "Appvia",
     "homepage": "https://www.appvia.io/product/",
     "sales_email": "info@appvia.io"
-  },
-  "oauth": {}
+  }
 }

--- a/yugabytedb_managed/manifest.json
+++ b/yugabytedb_managed/manifest.json
@@ -80,6 +80,5 @@
     "name": "YugabyteDB",
     "homepage": "https://yugabyte.com/",
     "sales_email": "sales@yugabyte.com"
-  },
-  "oauth": {}
+  }
 }

--- a/zabbix/manifest.json
+++ b/zabbix/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "KosukeKamiya@users.noreply.github.com",
     "name": "Community"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Zabbix (Community Version)",

--- a/zebrium/manifest.json
+++ b/zebrium/manifest.json
@@ -44,7 +44,6 @@
     "support_email": "support@zebrium.com",
     "sales_email": "hello@zebrium.com"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "zebrium",

--- a/zenduty/manifest.json
+++ b/zenduty/manifest.json
@@ -55,7 +55,6 @@
     "sales_email": "vishwa@zenduty.com",
     "name": "Zenduty"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Zenduty",

--- a/zscaler/manifest.json
+++ b/zscaler/manifest.json
@@ -24,7 +24,6 @@
     "sales_email": "help@datadoghq.com",
     "name": "Datadog"
   },
-  "oauth": {},
   "assets": {
     "integration": {
       "source_type_name": "Zscaler (Community Version)",


### PR DESCRIPTION
### What does this PR do?
remove old unused oauth manifest field in favor of assets.oauth

### Motivation

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
