### PR TITLE
Remove Linux from SupportedOS Classifier tags

### DIFF
--- a/jamf_protect/manifest.json
+++ b/jamf_protect/manifest.json
@@ -11,7 +11,6 @@
     "description": "Endpoint security and mobile threat defense (MTD) for Mac and mobile devices.",
     "title": "Jamf Protect",
     "classifier_tags": [
-      "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS",
       "Category::Security"


### PR DESCRIPTION
### What does this PR do?

This PR removes Linux as a Supported OS for Jamf Protect

### Motivation

Our partners at Jamf requested for this tag to be remove as they don't support Linux. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
