### PR TITLE
[ECOS-1235] Update CODEOWNERS to have each integration own their dashboards/logs/monitors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -230,7 +230,7 @@
 /1e/README.md                            support@1e.com @DataDog/documentation @DataDog/ecosystems-review
 /1e/assets/dashboards                    support@1e.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /1e/assets/monitors                      support@1e.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/1e/assets/logs/                         support@1e.com @DataDog/agent-integrations @DataDog/logs-backend
+/1e/assets/logs                         support@1e.com @DataDog/agent-integrations @DataDog/logs-backend
 
 /ably/*metadata.csv                      @ably support@ably.com @DataDog/documentation @DataDog/ecosystems-review
 /ably/manifest.json                      @ably support@ably.com @DataDog/documentation @DataDog/ecosystems-review
@@ -342,14 +342,14 @@
 /bluematador/README.md                   support@bluematador.com @DataDog/documentation
 /bluematador/assets/dashboards                    support@bluematador.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /bluematador/assets/monitors                      support@bluematador.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/bluematador/assets/logs/                         support@bluematador.com @DataDog/agent-integrations @DataDog/logs-backend
+/bluematador/assets/logs                         support@bluematador.com @DataDog/agent-integrations @DataDog/logs-backend
 
 /bonsai/*metadata.csv                    dev@onemorecloud.com @DataDog/documentation
 /bonsai/manifest.json                    dev@onemorecloud.com @DataDog/documentation
 /bonsai/README.md                        dev@onemorecloud.com @DataDog/documentation
 /bonsai/assets/dashboards                    dev@onemorecloud.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /bonsai/assets/monitors                      dev@onemorecloud.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/bonsai/assets/logs/                         dev@onemorecloud.com @DataDog/agent-integrations @DataDog/logs-backend
+/bonsai/assets/logs                         dev@onemorecloud.com @DataDog/agent-integrations @DataDog/logs-backend
 
 /botprise/*metadata.csv                  @codechefnisha-bp nisha.kumari@botprise.com @DataDog/documentation
 /botprise/manifest.json                  @codechefnisha-bp nisha.kumari@botprise.com @DataDog/documentation
@@ -363,7 +363,7 @@
 /buddy/README.md                         support@buddy.works @DataDog/documentation
 /buddy/assets/dashboards                    support@buddy.works @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /buddy/assets/monitors                      support@buddy.works @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/buddy/assets/logs/                         support@buddy.works @DataDog/agent-integrations @DataDog/logs-backend
+/buddy/assets/logs                         support@buddy.works @DataDog/agent-integrations @DataDog/logs-backend
 
 /census/*metadata.csv                    @sankalp04 support@getcensus.com @DataDog/documentation
 /census/manifest.json                    @sankalp04 support@getcensus.com @DataDog/documentation
@@ -531,7 +531,7 @@
 /gremlin/README.md                       support@gremlin.com @DataDog/documentation
 /gremlin/assets/dashboards                    support@gremlin.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /gremlin/assets/monitors                      support@gremlin.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/gremlin/assets/logs/                         support@gremlin.com @DataDog/agent-integrations @DataDog/logs-backend
+/gremlin/assets/logs                         support@gremlin.com @DataDog/agent-integrations @DataDog/logs-backend
 
 /grpc_check/*metadata.csv                @keisku @DataDog/documentation
 /grpc_check/manifest.json                @keisku @DataDog/documentation
@@ -643,7 +643,7 @@
 /launchdarkly/README.md                  support@launchdarkly.com @DataDog/documentation @DataDog/ecosystems-review
 /launchdarkly/assets/dashboards                    support@launchdarkly.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /launchdarkly/assets/monitors                      support@launchdarkly.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/launchdarkly/assets/logs/                         support@launchdarkly.com @DataDog/agent-integrations @DataDog/logs-backend
+/launchdarkly/assets/logs                         support@launchdarkly.com @DataDog/agent-integrations @DataDog/logs-backend
 
 /lighthouse/*metadata.csv                @DataDog/agent-integrations @DataDog/documentation
 /lighthouse/manifest.json                @DataDog/agent-integrations @DataDog/documentation
@@ -769,7 +769,7 @@
 /perimeterx/README.md                    support@perimeterx.com @DataDog/documentation
 /perimeterx/assets/dashboards                    support@perimeterx.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /perimeterx/assets/monitors                      support@perimeterx.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/perimeterx/assets/logs/                         support@perimeterx.com @DataDog/agent-integrations @DataDog/logs-backend
+/perimeterx/assets/logs                         support@perimeterx.com @DataDog/agent-integrations @DataDog/logs-backend
 
 /php_apcu/*metadata.csv                  @withgod noname@withgod.jp @DataDog/documentation
 /php_apcu/manifest.json                  @withgod noname@withgod.jp @DataDog/documentation
@@ -901,7 +901,7 @@
 /rigor/README.md                         support@rigor.com @DataDog/documentation
 /rigor/assets/dashboards                    support@rigor.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /rigor/assets/monitors                      support@rigor.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/rigor/assets/logs/                         support@rigor.com @DataDog/agent-integrations @DataDog/logs-backend
+/rigor/assets/logs                         support@rigor.com @DataDog/agent-integrations @DataDog/logs-backend
 
 /rookout/*metadata.csv                   support@rookout.com @DataDog/documentation @DataDog/ecosystems-review
 /rookout/manifest.json                   support@rookout.com @DataDog/documentation @DataDog/ecosystems-review
@@ -915,7 +915,7 @@
 /rundeck/README.md                       forrest@rundeck.com @DataDog/documentation
 /rundeck/assets/dashboards                    forrest@rundeck.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /rundeck/assets/monitors                      forrest@rundeck.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/rundeck/assets/logs/                         forrest@rundeck.com @DataDog/agent-integrations @DataDog/logs-backend
+/rundeck/assets/logs                         forrest@rundeck.com @DataDog/agent-integrations @DataDog/logs-backend
 
 /scalr/*metadata.csv                     @soltysss @DataDog/documentation @DataDog/ecosystems-review
 /scalr/manifest.json                     @soltysss @DataDog/documentation @DataDog/ecosystems-review
@@ -1013,7 +1013,7 @@
 /squadcast/README.md                     it@squadcast.com @DataDog/documentation
 /squadcast/assets/dashboards                    it@squadcast.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 /squadcast/assets/monitors                      it@squadcast.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/squadcast/assets/logs/                         it@squadcast.com @DataDog/agent-integrations @DataDog/logs-backend
+/squadcast/assets/logs                         it@squadcast.com @DataDog/agent-integrations @DataDog/logs-backend
 
 /stackpulse/*metadata.csv                @stackpulse/rnd support@stackpulse.io @DataDog/documentation
 /stackpulse/manifest.json                @stackpulse/rnd support@stackpulse.io @DataDog/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,14 +224,6 @@
 /singlestoredb_cloud/                    @tdasarathan @DataDog/ecosystems-review
 /emqx/                                   @zhongwencool @zmstone @DataDog/ecosystems-review
 
-# buffer
-/assets/dashboards                    @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
-/assets/monitors                      @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/assets/logs/                         @DataDog/agent-integrations @DataDog/logs-backend
-# macro
-}"aPkvt/yjPj0Pj0Pkkkf wvnhyj0f wPj0f wPj0f wPj
-# end test
-
 # Community Partners + Documentation
 /1e/*metadata.csv                        support@1e.com @DataDog/documentation @DataDog/ecosystems-review
 /1e/manifest.json                        support@1e.com @DataDog/documentation @DataDog/ecosystems-review
@@ -310,21 +302,19 @@
 /appkeeper/assets/monitors                      @numno1 @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
 /appkeeper/assets/logs/                         @numno1 @DataDog/agent-integrations @DataDog/logs-backend
 
-XXXXX
 /aqua/*metadata.csv                      @DataDog/container-integrations @DataDog/documentation
 /aqua/manifest.json                      @DataDog/container-integrations @DataDog/documentation
 /aqua/README.md                          @DataDog/container-integrations @DataDog/documentation
-/aqua/assets/dashboards                    @DataDog/container-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
-/aqua/assets/monitors                      @DataDog/container-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/aqua/assets/logs/                         @DataDog/container-integrations @DataDog/agent-integrations @DataDog/logs-backend
+/aqua/assets/dashboards                  @DataDog/container-integrations @DataDog/documentation @DataDog/dashboards-backend 
+/aqua/assets/monitors                    @DataDog/container-integrations @DataDog/documentation @DataDog/monitor-app
+/aqua/assets/logs/                       @DataDog/container-integrations @DataDog/logs-backend
 
-XXXX
 /auth0/*metadata.csv                     @DataDog/agent-integrations @DataDog/documentation
 /auth0/manifest.json                     @DataDog/agent-integrations @DataDog/documentation
 /auth0/README.md                         @DataDog/agent-integrations @DataDog/documentation
-/auth0/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
-/auth0/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/auth0/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+/auth0/assets/dashboards                 @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend
+/auth0/assets/monitors                   @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app
+/auth0/assets/logs/                      @DataDog/agent-integrations @DataDog/logs-backend
 
 /aws_pricing/*metadata.csv               @tsein-bc tsein@brightcove.com @DataDog/documentation
 /aws_pricing/manifest.json               @tsein-bc tsein@brightcove.com @DataDog/documentation
@@ -389,13 +379,12 @@ XXXX
 /cloudsmith/assets/monitors                      @cloudsmith ccarey@cloudsmith.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
 /cloudsmith/assets/logs/                         @cloudsmith ccarey@cloudsmith.io @DataDog/agent-integrations @DataDog/logs-backend
 
-XXXXXX
 /concourse_ci/*metadata.csv              @DataDog/agent-integrations @DataDog/documentation
 /concourse_ci/manifest.json              @DataDog/agent-integrations @DataDog/documentation
 /concourse_ci/README.md                  @DataDog/agent-integrations @DataDog/documentation
-/concourse_ci/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
-/concourse_ci/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/concourse_ci/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+/concourse_ci/assets/dashboards          @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend
+/concourse_ci/assets/monitors            @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app
+/concourse_ci/assets/logs/               @DataDog/agent-integrations @DataDog/logs-backend
 
 /configcat/*metadata.csv                 @configcat @DataDog/documentation
 /configcat/manifest.json                 @configcat @DataDog/documentation
@@ -411,13 +400,12 @@ XXXXXX
 /contrastsecurity/assets/monitors                      @kristianamitchellcontrastsecurity kristiana.mitchell@contrastsecurity.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
 /contrastsecurity/assets/logs/                         @kristianamitchellcontrastsecurity kristiana.mitchell@contrastsecurity.com @DataDog/agent-integrations @DataDog/logs-backend
 
-XXXX
 /convox/*metadata.csv                    @DataDog/agent-integrations @DataDog/documentation
 /convox/manifest.json                    @DataDog/agent-integrations @DataDog/documentation
 /convox/README.md                        @DataDog/agent-integrations @DataDog/documentation
-/convox/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
-/convox/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
-/convox/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+/convox/assets/dashboards                @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend
+/convox/assets/monitors                  @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app
+/convox/assets/logs/                     @DataDog/agent-integrations @DataDog/logs-backend
 
 /cortex/*metadata.csv                    @cortexapps/engineering support@getcortexapp.com @DataDog/documentation
 /cortex/manifest.json                    @cortexapps/engineering support@getcortexapp.com @DataDog/documentation
@@ -1097,9 +1085,14 @@ XXXX
 /traefik/assets/monitors                      @renaudhager @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
 /traefik/assets/logs/                         @renaudhager @DataDog/agent-integrations @DataDog/logs-backend
 
-XXXX
-/twingate/manifest.json                  @emrul partnerships@twingate.com @DataDog/documentation @DataDog/ecosystems-review
-/twingate/README.md                      @emrul partnerships@twingate.com @DataDog/documentation @DataDog/ecosystems-review
+
+/twingate/*metadata.csv                  @emrul partnerships@twingate.com @DataDog/documentation @DataDog/ecosystems-review
+/twingate/manifest.json                      @emrul partnerships@twingate.com @DataDog/documentation @DataDog/ecosystems-review
+/twingate/README.md                  @emrul partnerships@twingate.com @DataDog/documentation @DataDog/ecosystems-review
+/twingate/assets/dashboards                     @emrul partnerships@twingate.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/twingate/assets/monitors                       @emrul partnerships@twingate.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/twingate/assets/logs/                          @emrul partnerships@twingate.com @DataDog/agent-integrations @DataDog/logs-backend
+
 
 /tyk/*metadata.csv                       @letzya @DataDog/documentation
 /tyk/manifest.json                       @letzya @DataDog/documentation
@@ -1189,10 +1182,12 @@ XXXX
 /sosivio/assets/monitors                      @danarlowski @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
 /sosivio/assets/logs/                         @danarlowski @DataDog/agent-integrations @DataDog/logs-backend
 
-XXXX
-/emnify/*metadata.csv                  @DataDog/documentation @EMnify/development @EMnify/rademade
-/emnify/manifest.json                  @DataDog/documentation @EMnify/development @EMnify/rademade
-/emnify/README.md                      @DataDog/documentation @EMnify/development @EMnify/rademade
+/emnify/*metadata.csv                 @EMnify/development @EMnify/rademade @DataDog/documentation 
+/emnify/manifest.json                 @EMnify/development @EMnify/rademade @DataDog/documentation 
+/emnify/README.md                     @EMnify/development @EMnify/rademade @DataDog/documentation
+/emnify/assets/dashboards             @EMnify/development @EMnify/rademade @DataDog/documentation @DataDog/dashboards-backend
+/emnify/assets/monitors               @EMnify/development @EMnify/rademade @DataDog/documentation @DataDog/monitor-app
+/emnify/assets/logs/                  @EMnify/development @EMnify/rademade @DataDog/logs-backend
 
 /adaptive_shield/*metadata.csv         @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
 /adaptive_shield/manifest.json         @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 **/manifest.json                         @DataDog/documentation @DataDog/agent-integrations
 **/assets/dashboards                     @Datadog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
 **/assets/monitors                       @Datadog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+**/assets/logs/                          @DataDog/agent-integrations @DataDog/logs-backend
 
 # Community partners
 /1e/                                     support@1e.com @DataDog/ecosystems-review
@@ -54,6 +55,7 @@
 /drata/                                  @jason-drata support@drata.com @DataDog/ecosystems-review
 /docontrol/                              @lielran @DataDog/ecosystems-review
 /doctordroid/                            @dimittal @DataDog/ecosystems-review
+/dylibso-webassembly/                  @nilslice @bhelx @DataDog/ecosystems-review
 /embrace_mobile/                         @jpmunz @joage @DataDog/ecosystems-review
 /eventstore/                             @Xorima
 /eversql/                                @tomershay team@eversql.com @DataDog/ecosystems-review
@@ -86,7 +88,7 @@
 /jfrog_platform_cloud/                   @jfrog/partner-engineering @DataDog/ecosystems-review
 /jfrog_platform_self_hosted/             @jfrog/partner-engineering @DataDog/ecosystems-review
 /instabug/                               @AbdallahHemdan ahemdan@instabug.com @DataDog/ecosystems-review
-/invary/               @tim-invary @DataDog/ecosystems-review
+/invary/                                 @tim-invary @DataDog/ecosystems-review
 /ilert/                                  @yacut support@ilert.com @DataDog/ecosystems-review
 /insightfinder/                          @dearmore @erinlmcmahon support@insightfinder.com @DataDog/ecosystems-review
 /isdown/                                 @ntomas support@isdown.app @DataDog/ecosystems-review
@@ -177,6 +179,7 @@
 /stackpulse/                             @torqio/rnd support@torq.io @DataDog/ecosystems-review
 /stardog/                                @snowell support@stardog.com
 /statsig/                                @marcos-statsig support@statsig.com @DataDog/ecosystems-review
+/statsig_rum/                            @crstatsig support@statig.com
 /steadybit/                              @bripkens support@steadybit.com @DataDog/ecosystems-review
 /storm/                                  @platinummonkey
 /stormforge/                             @bradbeam @tperol support@stormforge.io @DataDog/ecosystems-review
@@ -212,6 +215,7 @@
 /zenoh_router/                           @sashacmc
 /zscaler/                                @BoyangHuang @DataDog/saas-integrations
 /sosivio/                                @danarlowski info@sosiv.io @DataDog/ecosystems-review
+/sym/                                  @symopsio/eng
 /emnify/                                 @EMnify/development @EMnify/rademade
 /adaptive_shield/                        @adaptiveshield @DataDog/ecosystems-review
 /typingdna_activelock/                   @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/ecosystems-review
@@ -409,8 +413,9 @@
 /logzio/*metadata.csv                    @DataDog/agent-integrations @DataDog/documentation
 /logzio/manifest.json                    @DataDog/agent-integrations @DataDog/documentation
 /logzio/README.md                        @DataDog/agent-integrations @DataDog/documentation
-/mendix/README.md                        @mendix/cloud @DataDog/agent-integrations @DataDog/documentation
+/mendix/*metadata.csv                    @mendix/cloud @DataDog/agent-integrations @DataDog/documentation
 /mendix/manifest.json                    @mendix/cloud @DataDog/agent-integrations @DataDog/documentation
+/mendix/README.md                        @mendix/cloud @DataDog/agent-integrations @DataDog/documentation
 /mergify/*metadata.csv                   @Mergifyio/oss-integrations @DataDog/documentation
 /mergify/manifest.json                   @Mergifyio/oss-integrations @DataDog/documentation
 /mergify/README.md                       @Mergifyio/oss-integrations @DataDog/documentation
@@ -530,8 +535,9 @@
 /sigsci/*metadata.csv                    @signalsciences info@signalsciences.com @DataDog/documentation
 /sigsci/manifest.json                    @signalsciences info@signalsciences.com @DataDog/documentation
 /sigsci/README.md                        @signalsciences info@signalsciences.com @DataDog/documentation
-/shoreline/README.md                     @ytnytn1 support@shoreline.io @DataDog/documentation @DataDog/ecosystems-review
+/shoreline/*metadata.csv                 @ytnytn1 support@shoreline.io @DataDog/documentation @DataDog/ecosystems-review
 /shoreline/manifest.json                 @ytnytn1 support@shoreline.io @DataDog/documentation @DataDog/ecosystems-review
+/shoreline/README.md                     @ytnytn1 support@shoreline.io @DataDog/documentation @DataDog/ecosystems-review
 /sleuth/*metadata.csv                    @mtbnut pleal@sleuth.io @DataDog/documentation
 /sleuth/manifest.json                    @mtbnut pleal@sleuth.io @DataDog/documentation
 /sleuth/README.md                        @mtbnut pleal@sleuth.io @DataDog/documentation
@@ -565,7 +571,6 @@
 /statsig/*metadata.csv                   @marcos-statsig support@statsig.com @DataDog/documentation
 /statsig/manifest.json                   @marcos-statsig support@statsig.com @DataDog/documentation
 /statsig/README.md                       @marcos-statsig support@statsig.com @DataDog/documentation
-/statsig_rum/                            @crstatsig support@statig.com
 /steadybit/*metadata.csv                 @bripkens support@steadybit.com @DataDog/documentation @DataDog/ecosystems-review
 /steadybit/manifest.json                 @bripkens support@steadybit.com @DataDog/documentation @DataDog/ecosystems-review
 /steadybit/README.md                     @bripkens support@steadybit.com @DataDog/documentation @DataDog/ecosystems-review
@@ -634,16 +639,15 @@
 /adaptive_shield/*metadata.csv         @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
 /adaptive_shield/manifest.json         @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
 /adaptive_shield/README.md             @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
+/typingdna_activelock/*metadata.csv    @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/documentation @DataDog/ecosystems-review
 /typingdna_activelock/manifest.json    @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/documentation @DataDog/ecosystems-review
 /typingdna_activelock/README.md        @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/documentation @DataDog/ecosystems-review
 /sofy_sofy/*metadata.csv               @Sofy @DataDog/documentation @DataDog/ecosystems-review
 /sofy_sofy/manifest.json               @Sofy @DataDog/documentation @DataDog/ecosystems-review
 /sofy_sofy/README.md                   @Sofy @DataDog/documentation @DataDog/ecosystems-review
-/sym/                                  @symopsio/eng
 /singlestoredb_cloud/*metadata.csv     @tdasarathan @DataDog/ecosystems-review
 /singlestoredb_cloud/manifest.json     @tdasarathan @DataDog/ecosystems-review
 /singlestoredb_cloud/README.md         @tdasarathan @DataDog/ecosystems-review
-/dylibso-webassembly/                  @nilslice @bhelx @DataDog/ecosystems-review
 /emqx/*metadata.csv                    @zhongwencool @zmstone @DataDog/documentation @DataDog/ecosystems-review
 /emqx/manifest.json                    @zhongwencool @zmstone @DataDog/documentation @DataDog/ecosystems-review
 /emqx/README.md                        @zhongwencool @zmstone @DataDog/documentation @DataDog/ecosystems-review

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 **/README.md                             @DataDog/documentation @DataDog/agent-integrations
 **/*metadata.csv                         @DataDog/documentation @DataDog/agent-integrations
 **/manifest.json                         @DataDog/documentation @DataDog/agent-integrations
-**/assets/dashboards                     @Datadog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
-**/assets/monitors                       @Datadog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+**/assets/dashboards                     @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+**/assets/monitors                       @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
 **/assets/logs/                          @DataDog/agent-integrations @DataDog/logs-backend
 
 # Community partners
@@ -224,430 +224,1007 @@
 /singlestoredb_cloud/                    @tdasarathan @DataDog/ecosystems-review
 /emqx/                                   @zhongwencool @zmstone @DataDog/ecosystems-review
 
+# buffer
+/assets/dashboards                    @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/assets/monitors                      @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/assets/logs/                         @DataDog/agent-integrations @DataDog/logs-backend
+# macro
+}"aPkvt/yjPj0Pj0Pkkkf wvnhyj0f wPj0f wPj0f wPj
+# end test
+
 # Community Partners + Documentation
+/1e/*metadata.csv                        support@1e.com @DataDog/documentation @DataDog/ecosystems-review
 /1e/manifest.json                        support@1e.com @DataDog/documentation @DataDog/ecosystems-review
 /1e/README.md                            support@1e.com @DataDog/documentation @DataDog/ecosystems-review
+/1e/assets/dashboards                    support@1e.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/1e/assets/monitors                      support@1e.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/1e/assets/logs/                         support@1e.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /ably/*metadata.csv                      @ably support@ably.com @DataDog/documentation @DataDog/ecosystems-review
 /ably/manifest.json                      @ably support@ably.com @DataDog/documentation @DataDog/ecosystems-review
 /ably/README.md                          @ably support@ably.com @DataDog/documentation @DataDog/ecosystems-review
+/ably/assets/dashboards                   @ably support@ably.com  @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/ably/assets/monitors                      @ably support@ably.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/ably/assets/logs/                         @ably support@ably.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /agora_analytic/*metadata.csv            @Zhangpeizhe zhangpeizhe@agora.io @DataDog/documentation
 /agora_analytic/manifest.json            @Zhangpeizhe zhangpeizhe@agora.io @DataDog/documentation
 /agora_analytic/README.md                @Zhangpeizhe zhangpeizhe@agora.io @DataDog/documentation
+/agora_analytic/assets/dashboards                    @Zhangpeizhe zhangpeizhe@agora.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/agora_analytic/assets/monitors                      @Zhangpeizhe zhangpeizhe@agora.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/agora_analytic/assets/logs/                         @Zhangpeizhe zhangpeizhe@agora.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /alertnow/*metadata.csv                  @Uijong-Kim uijong.kim@bespinglobal.com @DataDog/documentation
 /alertnow/manifest.json                  @Uijong-Kim uijong.kim@bespinglobal.com @DataDog/documentation
 /alertnow/README.md                      @Uijong-Kim uijong.kim@bespinglobal.com @DataDog/documentation
+/alertnow/assets/dashboards                    @Uijong-Kim uijong.kim@bespinglobal.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/alertnow/assets/monitors                      @Uijong-Kim uijong.kim@bespinglobal.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/alertnow/assets/logs/                         @Uijong-Kim uijong.kim@bespinglobal.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /algorithmia/*metadata.csv               @koverholt support@algorithmia.io @DataDog/documentation
 /algorithmia/manifest.json               @koverholt support@algorithmia.io @DataDog/documentation
 /algorithmia/README.md                   @koverholt support@algorithmia.io @DataDog/documentation
+/algorithmia/assets/dashboards                    @koverholt support@algorithmia.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/algorithmia/assets/monitors                      @koverholt support@algorithmia.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/algorithmia/assets/logs/                         @koverholt support@algorithmia.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /altostra/*metadata.csv                  @yevk @altostra/engineering @DataDog/documentation
 /altostra/manifest.json                  @yevk @altostra/engineering @DataDog/documentation
 /altostra/README.md                      @yevk @altostra/engineering @DataDog/documentation
+/altostra/assets/dashboards                    @yevk @altostra/engineering @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/altostra/assets/monitors                      @yevk @altostra/engineering @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/altostra/assets/logs/                         @yevk @altostra/engineering @DataDog/agent-integrations @DataDog/logs-backend
+
 /ambassador/*metadata.csv                @datawire hello@datawire.io @DataDog/documentation
 /ambassador/manifest.json                @datawire hello@datawire.io @DataDog/documentation
 /ambassador/README.md                    @datawire hello@datawire.io @DataDog/documentation
+/ambassador/assets/dashboards                    @datawire hello@datawire.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/ambassador/assets/monitors                      @datawire hello@datawire.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/ambassador/assets/logs/                         @datawire hello@datawire.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /amixr/*metadata.csv                     @iskhakov ildar@amixr.io @DataDog/documentation
 /amixr/manifest.json                     @iskhakov ildar@amixr.io @DataDog/documentation
 /amixr/README.md                         @iskhakov ildar@amixr.io @DataDog/documentation
+/amixr/assets/dashboards                    @iskhakov ildar@amixr.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/amixr/assets/monitors                      @iskhakov ildar@amixr.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/amixr/assets/logs/                         @iskhakov ildar@amixr.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /apache-apisix/*metadata.csv             @bisakhmondal bisakhmondal00@gmail.com @DataDog/documentation
 /apache-apisix/manifest.json             @bisakhmondal bisakhmondal00@gmail.com @DataDog/documentation
 /apache-apisix/README.md                 @bisakhmondal bisakhmondal00@gmail.com @DataDog/documentation
+/apache-apisix/assets/dashboards                    @bisakhmondal bisakhmondal00@gmail.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/apache-apisix/assets/monitors                      @bisakhmondal bisakhmondal00@gmail.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/apache-apisix/assets/logs/                         @bisakhmondal bisakhmondal00@gmail.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /apollo/*metadata.csv                    @sachindshinde sachin@apollographql.com @DataDog/documentation
 /apollo/manifest.json                    @sachindshinde sachin@apollographql.com @DataDog/documentation
 /apollo/README.md                        @sachindshinde sachin@apollographql.com @DataDog/documentation
+/apollo/assets/dashboards                    @sachindshinde sachin@apollographql.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/apollo/assets/monitors                      @sachindshinde sachin@apollographql.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/apollo/assets/logs/                         @sachindshinde sachin@apollographql.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /appkeeper/*metadata.csv                 @numno1 @DataDog/documentation
 /appkeeper/manifest.json                 @numno1 @DataDog/documentation
 /appkeeper/README.md                     @numno1 @DataDog/documentation
+/appkeeper/assets/dashboards                    @numno1 @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/appkeeper/assets/monitors                      @numno1 @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/appkeeper/assets/logs/                         @numno1 @DataDog/agent-integrations @DataDog/logs-backend
+
+XXXXX
 /aqua/*metadata.csv                      @DataDog/container-integrations @DataDog/documentation
 /aqua/manifest.json                      @DataDog/container-integrations @DataDog/documentation
 /aqua/README.md                          @DataDog/container-integrations @DataDog/documentation
+/aqua/assets/dashboards                    @DataDog/container-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/aqua/assets/monitors                      @DataDog/container-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/aqua/assets/logs/                         @DataDog/container-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
+XXXX
 /auth0/*metadata.csv                     @DataDog/agent-integrations @DataDog/documentation
 /auth0/manifest.json                     @DataDog/agent-integrations @DataDog/documentation
 /auth0/README.md                         @DataDog/agent-integrations @DataDog/documentation
+/auth0/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/auth0/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/auth0/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /aws_pricing/*metadata.csv               @tsein-bc tsein@brightcove.com @DataDog/documentation
 /aws_pricing/manifest.json               @tsein-bc tsein@brightcove.com @DataDog/documentation
 /aws_pricing/README.md                   @tsein-bc tsein@brightcove.com @DataDog/documentation
+/aws_pricing/assets/dashboards                    @tsein-bc tsein@brightcove.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/aws_pricing/assets/monitors                      @tsein-bc tsein@brightcove.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/aws_pricing/assets/logs/                         @tsein-bc tsein@brightcove.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /bind9/*metadata.csv                     @ashuvyas45 ashuvyas45@gmail.com @DataDog/documentation
 /bind9/manifest.json                     @ashuvyas45 ashuvyas45@gmail.com @DataDog/documentation
 /bind9/README.md                         @ashuvyas45 ashuvyas45@gmail.com @DataDog/documentation
+/bind9/assets/dashboards                    @ashuvyas45 ashuvyas45@gmail.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/bind9/assets/monitors                      @ashuvyas45 ashuvyas45@gmail.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/bind9/assets/logs/                         @ashuvyas45 ashuvyas45@gmail.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /blink/*metadata.csv                     @liavt liav@blinkops.com @ozhey @DataDog/documentation @DataDog/ecosystems-review
 /blink/manifest.json                     @liavt liav@blinkops.com @ozhey @DataDog/documentation @DataDog/ecosystems-review
 /blink/README.md                         @liavt liav@blinkops.com @ozhey @DataDog/documentation @DataDog/ecosystems-review
+/blink/assets/dashboards                    @liavt liav@blinkops.com @ozhey @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/blink/assets/monitors                      @liavt liav@blinkops.com @ozhey @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/blink/assets/logs/                         @liavt liav@blinkops.com @ozhey @DataDog/agent-integrations @DataDog/logs-backend
+
 /bluematador/*metadata.csv               support@bluematador.com @DataDog/documentation
 /bluematador/manifest.json               support@bluematador.com @DataDog/documentation
 /bluematador/README.md                   support@bluematador.com @DataDog/documentation
+/bluematador/assets/dashboards                    support@bluematador.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/bluematador/assets/monitors                      support@bluematador.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/bluematador/assets/logs/                         support@bluematador.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /bonsai/*metadata.csv                    dev@onemorecloud.com @DataDog/documentation
 /bonsai/manifest.json                    dev@onemorecloud.com @DataDog/documentation
 /bonsai/README.md                        dev@onemorecloud.com @DataDog/documentation
+/bonsai/assets/dashboards                    dev@onemorecloud.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/bonsai/assets/monitors                      dev@onemorecloud.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/bonsai/assets/logs/                         dev@onemorecloud.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /botprise/*metadata.csv                  @codechefnisha-bp nisha.kumari@botprise.com @DataDog/documentation
 /botprise/manifest.json                  @codechefnisha-bp nisha.kumari@botprise.com @DataDog/documentation
 /botprise/README.md                      @codechefnisha-bp nisha.kumari@botprise.com @DataDog/documentation
+/botprise/assets/dashboards                    @codechefnisha-bp nisha.kumari@botprise.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/botprise/assets/monitors                      @codechefnisha-bp nisha.kumari@botprise.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/botprise/assets/logs/                         @codechefnisha-bp nisha.kumari@botprise.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /buddy/*metadata.csv                     support@buddy.works @DataDog/documentation
 /buddy/manifest.json                     support@buddy.works @DataDog/documentation
 /buddy/README.md                         support@buddy.works @DataDog/documentation
+/buddy/assets/dashboards                    support@buddy.works @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/buddy/assets/monitors                      support@buddy.works @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/buddy/assets/logs/                         support@buddy.works @DataDog/agent-integrations @DataDog/logs-backend
+
 /census/*metadata.csv                    @sankalp04 support@getcensus.com @DataDog/documentation
 /census/manifest.json                    @sankalp04 support@getcensus.com @DataDog/documentation
 /census/README.md                        @sankalp04 support@getcensus.com @DataDog/documentation
+/census/assets/dashboards                    @sankalp04 support@getcensus.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/census/assets/monitors                      @sankalp04 support@getcensus.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/census/assets/logs/                         @sankalp04 support@getcensus.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /cloudsmith/*metadata.csv                @cloudsmith ccarey@cloudsmith.io @DataDog/documentation @DataDog/ecosystems-review
 /cloudsmith/manifest.json                @cloudsmith ccarey@cloudsmith.io @DataDog/documentation @DataDog/ecosystems-review
 /cloudsmith/README.md                    @cloudsmith ccarey@cloudsmith.io @DataDog/documentation @DataDog/ecosystems-review
+/cloudsmith/assets/dashboards                    @cloudsmith ccarey@cloudsmith.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/cloudsmith/assets/monitors                      @cloudsmith ccarey@cloudsmith.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/cloudsmith/assets/logs/                         @cloudsmith ccarey@cloudsmith.io @DataDog/agent-integrations @DataDog/logs-backend
+
+XXXXXX
 /concourse_ci/*metadata.csv              @DataDog/agent-integrations @DataDog/documentation
 /concourse_ci/manifest.json              @DataDog/agent-integrations @DataDog/documentation
 /concourse_ci/README.md                  @DataDog/agent-integrations @DataDog/documentation
+/concourse_ci/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/concourse_ci/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/concourse_ci/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /configcat/*metadata.csv                 @configcat @DataDog/documentation
 /configcat/manifest.json                 @configcat @DataDog/documentation
 /configcat/README.md                     @configcat @DataDog/documentation
+/configcat/assets/dashboards                    @configcat @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/configcat/assets/monitors                      @configcat @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/configcat/assets/logs/                         @configcat @DataDog/agent-integrations @DataDog/logs-backend
+
 /contrastsecurity/*metadata.csv          @kristianamitchellcontrastsecurity kristiana.mitchell@contrastsecurity.com @DataDog/documentation
 /contrastsecurity/manifest.json          @kristianamitchellcontrastsecurity kristiana.mitchell@contrastsecurity.com @DataDog/documentation
 /contrastsecurity/README.md              @kristianamitchellcontrastsecurity kristiana.mitchell@contrastsecurity.com @DataDog/documentation
+/contrastsecurity/assets/dashboards                    @kristianamitchellcontrastsecurity kristiana.mitchell@contrastsecurity.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/contrastsecurity/assets/monitors                      @kristianamitchellcontrastsecurity kristiana.mitchell@contrastsecurity.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/contrastsecurity/assets/logs/                         @kristianamitchellcontrastsecurity kristiana.mitchell@contrastsecurity.com @DataDog/agent-integrations @DataDog/logs-backend
+
+XXXX
 /convox/*metadata.csv                    @DataDog/agent-integrations @DataDog/documentation
 /convox/manifest.json                    @DataDog/agent-integrations @DataDog/documentation
 /convox/README.md                        @DataDog/agent-integrations @DataDog/documentation
+/convox/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/convox/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/convox/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /cortex/*metadata.csv                    @cortexapps/engineering support@getcortexapp.com @DataDog/documentation
 /cortex/manifest.json                    @cortexapps/engineering support@getcortexapp.com @DataDog/documentation
 /cortex/README.md                        @cortexapps/engineering support@getcortexapp.com @DataDog/documentation
+/cortex/assets/dashboards                    @cortexapps/engineering support@getcortexapp.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/cortex/assets/monitors                      @cortexapps/engineering support@getcortexapp.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/cortex/assets/logs/                         @cortexapps/engineering support@getcortexapp.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /cribl_stream/*metadata.csv              @criblio @amiracle @Datadog/documentation
 /cribl_stream/manifest.json              @criblio @amiracle @Datadog/documentation
 /cribl_stream/README.md                  @criblio @amiracle @Datadog/documentation
+/cribl_stream/assets/dashboards                    @criblio @amiracle @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/cribl_stream/assets/monitors                      @criblio @amiracle @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/cribl_stream/assets/logs/                         @criblio @amiracle @DataDog/agent-integrations @DataDog/logs-backend
+
 /cybersixgill_actionable_alerts/*metadata.csv         @shahul-loginsoft sshaik@loginsoft.com @DataDog/documentation @DataDog/ecosystems-review
 /cybersixgill_actionable_alerts/manifest.json         @shahul-loginsoft sshaik@loginsoft.com @DataDog/documentation @DataDog/ecosystems-review
 /cybersixgill_actionable_alerts/README.md              @shahul-loginsoft sshaik@loginsoft.com @DataDog/documentation @DataDog/ecosystems-review
+/cybersixgill_actionable_alerts/assets/dashboards                    @shahul-loginsoft sshaik@loginsoft.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/cybersixgill_actionable_alerts/assets/monitors                      @shahul-loginsoft sshaik@loginsoft.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/cybersixgill_actionable_alerts/assets/logs/                         @shahul-loginsoft sshaik@loginsoft.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /cyral/*metadata.csv                     @tyrannosaurus-becks product@cyral.com @DataDog/documentation
 /cyral/manifest.json                     @tyrannosaurus-becks product@cyral.com @DataDog/documentation
 /cyral/README.md                         @tyrannosaurus-becks product@cyral.com @DataDog/documentation
+/cyral/assets/dashboards                    @tyrannosaurus-becks product@cyral.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/cyral/assets/monitors                      @tyrannosaurus-becks product@cyral.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/cyral/assets/logs/                         @tyrannosaurus-becks product@cyral.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /drata/*metadata.csv                     @jason-drata support@drata.com @DataDog/documentation @DataDog/ecosystems-review
 /drata/manifest.json                     @jason-drata support@drata.com @DataDog/documentation @DataDog/ecosystems-review
 /drata/README.md                         @jason-drata support@drata.com @DataDog/documentation @DataDog/ecosystems-review
+/drata/assets/dashboards                    @jason-drata support@drata.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/drata/assets/monitors                      @jason-drata support@drata.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/drata/assets/logs/                         @jason-drata support@drata.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /embrace_mobile/*metadata.csv            @jpmunz @joage @DataDog/documentation @DataDog/ecosystems-review
 /embrace_mobile/manifest.json            @jpmunz @joage @DataDog/documentation @DataDog/ecosystems-review
 /embrace_mobile/README.md                @jpmunz @joage @DataDog/documentation @DataDog/ecosystems-review
+/embrace_mobile/assets/dashboards                    @jpmunz @joage @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/embrace_mobile/assets/monitors                      @jpmunz @joage @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/embrace_mobile/assets/logs/                         @jpmunz @joage @DataDog/agent-integrations @DataDog/logs-backend
+
 /eventstore/*metadata.csv                @xorima @DataDog/documentation
 /eventstore/manifest.json                @xorima @DataDog/documentation
 /eventstore/README.md                    @xorima @DataDog/documentation
+/eventstore/assets/dashboards                    @xorima @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/eventstore/assets/monitors                      @xorima @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/eventstore/assets/logs/                         @xorima @DataDog/agent-integrations @DataDog/logs-backend
+
 /federatorai/*metadata.csv               @chenyingtz @yummydsky @DataDog/documentation
 /federatorai/manifest.json               @chenyingtz @yummydsky @DataDog/documentation
 /federatorai/README.md                   @chenyingtz @yummydsky @DataDog/documentation
+/federatorai/assets/dashboards                    @chenyingtz @yummydsky @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/federatorai/assets/monitors                      @chenyingtz @yummydsky @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/federatorai/assets/logs/                         @chenyingtz @yummydsky @DataDog/agent-integrations @DataDog/logs-backend
+
 /filebeat/*metadata.csv                  @wk8 jean@tripping.com @DataDog/documentation
 /filebeat/manifest.json                  @wk8 jean@tripping.com @DataDog/documentation
 /filebeat/README.md                      @wk8 jean@tripping.com @DataDog/documentation
+/filebeat/assets/dashboards                    @wk8 jean@tripping.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/filebeat/assets/monitors                      @wk8 jean@tripping.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/filebeat/assets/logs/                         @wk8 jean@tripping.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /flagsmith/*metadata.csv                 @benjarom3 support@flagsmith.com @DataDog/documentation
 /flagsmith/manifest.json                 @benjarom3 support@flagsmith.com @DataDog/documentation
 /flagsmith/README.md                     @benjarom3 support@flagsmith.com @DataDog/documentation
+/flagsmith/assets/dashboards                    @benjarom3 support@flagsmith.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/flagsmith/assets/monitors                      @benjarom3 support@flagsmith.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/flagsmith/assets/logs/                         @benjarom3 support@flagsmith.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /flagsmith-rum/*metadata.csv             @benjarom3 support@flagsmith.com @DataDog/documentation
 /flagsmith-rum/manifest.json             @benjarom3 support@flagsmith.com @DataDog/documentation
 /flagsmith-rum/README.md                 @benjarom3 support@flagsmith.com @DataDog/documentation
+/flagsmith-rum/assets/dashboards                    @benjarom3 support@flagsmith.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/flagsmith-rum/assets/monitors                      @benjarom3 support@flagsmith.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/flagsmith-rum/assets/logs/                         @benjarom3 support@flagsmith.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /flume/*metadata.csv                     @KealanMaas @DataDog/documentation
 /flume/manifest.json                     @KealanMaas @DataDog/documentation
 /flume/README.md                         @KealanMaas @DataDog/documentation
+/flume/assets/dashboards                    @KealanMaas @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/flume/assets/monitors                      @KealanMaas @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/flume/assets/logs/                         @KealanMaas @DataDog/agent-integrations @DataDog/logs-backend
+
 /gatekeeper/*metadata.csv                @arapulido ara.pulido@datadoghq.com @DataDog/documentation
 /gatekeeper/manifest.json                @arapulido ara.pulido@datadoghq.com @DataDog/documentation
 /gatekeeper/README.md                    @arapulido ara.pulido@datadoghq.com @DataDog/documentation
+/gatekeeper/assets/dashboards                    @arapulido ara.pulido@datadoghq.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/gatekeeper/assets/monitors                      @arapulido ara.pulido@datadoghq.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/gatekeeper/assets/logs/                         @arapulido ara.pulido@datadoghq.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /gitea/*metadata.csv                     @FlorentClarret @DataDog/documentation
 /gitea/manifest.json                     @FlorentClarret @DataDog/documentation
 /gitea/README.md                         @FlorentClarret @DataDog/documentation
+/gitea/assets/dashboards                    @FlorentClarret @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/gitea/assets/monitors                      @FlorentClarret @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/gitea/assets/logs/                         @FlorentClarret @DataDog/agent-integrations @DataDog/logs-backend
+
 /gnatsd_streaming/*metadata.csv          @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation
 /gnatsd_streaming/manifest.json          @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation
 /gnatsd_streaming/README.md              @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation
+/gnatsd_streaming/assets/dashboards                    @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/gnatsd_streaming/assets/monitors                      @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/gnatsd_streaming/assets/logs/                         @stephenprater @jaredhoyt dev@goldstar.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /gnatsd/*metadata.csv                    @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation
 /gnatsd/manifest.json                    @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation
 /gnatsd/README.md                        @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation
+/gnatsd/assets/dashboards                    @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/gnatsd/assets/monitors                      @stephenprater @jaredhoyt dev@goldstar.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/gnatsd/assets/logs/                         @stephenprater @jaredhoyt dev@goldstar.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /go_pprof_scraper/*metadata.csv          @nsrip-dd @DataDog/documentation
 /go_pprof_scraper/manifest.json          @nsrip-dd @DataDog/documentation
 /go_pprof_scraper/README.md              @nsrip-dd @DataDog/documentation
+/go_pprof_scraper/assets/dashboards                    @nsrip-dd @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/go_pprof_scraper/assets/monitors                      @nsrip-dd @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/go_pprof_scraper/assets/logs/                         @nsrip-dd @DataDog/agent-integrations @DataDog/logs-backend
+
 /gremlin/*metadata.csv                   support@gremlin.com @DataDog/documentation
 /gremlin/manifest.json                   support@gremlin.com @DataDog/documentation
 /gremlin/README.md                       support@gremlin.com @DataDog/documentation
+/gremlin/assets/dashboards                    support@gremlin.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/gremlin/assets/monitors                      support@gremlin.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/gremlin/assets/logs/                         support@gremlin.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /grpc_check/*metadata.csv                @keisku @DataDog/documentation
 /grpc_check/manifest.json                @keisku @DataDog/documentation
 /grpc_check/README.md                    @keisku @DataDog/documentation
+/grpc_check/assets/dashboards                    @keisku @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/grpc_check/assets/monitors                      @keisku @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/grpc_check/assets/logs/                         @keisku @DataDog/agent-integrations @DataDog/logs-backend
+
 /hasura_cloud/*metadata.csv              @ShraddhaAg @shahidhk support@hasura.io @DataDog/documentation
 /hasura_cloud/manifest.json              @ShraddhaAg @shahidhk support@hasura.io @DataDog/documentation
 /hasura_cloud/README.md                  @ShraddhaAg @shahidhk support@hasura.io @DataDog/documentation
+/hasura_cloud/assets/dashboards                    @ShraddhaAg @shahidhk support@hasura.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/hasura_cloud/assets/monitors                      @ShraddhaAg @shahidhk support@hasura.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/hasura_cloud/assets/logs/                         @ShraddhaAg @shahidhk support@hasura.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /hbase_master/*metadata.csv              @everpeace @DataDog/documentation
 /hbase_master/manifest.json              @everpeace @DataDog/documentation
 /hbase_master/README.md                  @everpeace @DataDog/documentation
+/hbase_master/assets/dashboards                    @everpeace @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/hbase_master/assets/monitors                      @everpeace @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/hbase_master/assets/logs/                         @everpeace @DataDog/agent-integrations @DataDog/logs-backend
+
 /hbase_regionserver/*metadata.csv        @everpeace @DataDog/documentation
 /hbase_regionserver/manifest.json        @everpeace @DataDog/documentation
 /hbase_regionserver/README.md            @everpeace @DataDog/documentation
+/hbase_regionserver/assets/dashboards                    @everpeace @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/hbase_regionserver/assets/monitors                      @everpeace @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/hbase_regionserver/assets/logs/                         @everpeace @DataDog/agent-integrations @DataDog/logs-backend
+
 /hikaricp/*metadata.csv                  @bertaudamien @DataDog/documentation
 /hikaricp/manifest.json                  @bertaudamien @DataDog/documentation
 /hikaricp/README.md                      @bertaudamien @DataDog/documentation
+/hikaricp/assets/dashboards                    @bertaudamien @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/hikaricp/assets/monitors                      @bertaudamien @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/hikaricp/assets/logs/                         @bertaudamien @DataDog/agent-integrations @DataDog/logs-backend
+
 /instabug/manifest.json                  @AbdallahHemdan ahemdan@instabug.com @DataDog/documentation
 /instabug/README.md                      @AbdallahHemdan ahemdan@instabug.com @DataDog/documentation
+/instabug/assets/dashboards                    @AbdallahHemdan ahemdan@instabug.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/instabug/assets/monitors                      @AbdallahHemdan ahemdan@instabug.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/instabug/assets/logs/                         @AbdallahHemdan ahemdan@instabug.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /instabug/*metadata.csv                  @AbdallahHemdan ahemdan@instabug.com @DataDog/documentation
 /ilert/*metadata.csv                     @yacut support@ilert.com @DataDog/documentation
 /ilert/manifest.json                     @yacut support@ilert.com @DataDog/documentation
 /ilert/README.md                         @yacut support@ilert.com @DataDog/documentation
+/ilert/assets/dashboards                    @yacut support@ilert.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/ilert/assets/monitors                      @yacut support@ilert.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/ilert/assets/logs/                         @yacut support@ilert.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /insightfinder/*metadata.csv             @dearmore @erinlmcmahon @DataDog/documentation @DataDog/ecosystems-review
 /insightfinder/manifest.json             @dearmore @erinlmcmahon @DataDog/documentation @DataDog/ecosystems-review
 /insightfinder/README.md                 @dearmore @erinlmcmahon @DataDog/documentation @DataDog/ecosystems-review
+/insightfinder/assets/dashboards                    @dearmore @erinlmcmahon @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/insightfinder/assets/monitors                      @dearmore @erinlmcmahon @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/insightfinder/assets/logs/                         @dearmore @erinlmcmahon @DataDog/agent-integrations @DataDog/logs-backend
+
 /invary/*metadata.csv  @tim-invary @DataDog/documentation @DataDog/ecosystems-review
 /invary/manifest.json  @tim-invary @DataDog/documentation @DataDog/ecosystems-review
 /invary/README.md      @tim-invary @DataDog/documentation @DataDog/ecosystems-review
+/invary/assets/dashboards                    @tim-invary @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/invary/assets/monitors                      @tim-invary @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/invary/assets/logs/                         @tim-invary @DataDog/agent-integrations @DataDog/logs-backend
+
 /isdown/*metadata.csv                    @ntomas support@isdown.app @DataDog/documentation @DataDog/ecosystems-review
 /isdown/manifest.json                    @ntomas support@isdown.app @DataDog/documentation @DataDog/ecosystems-review
 /isdown/README.md                        @ntomas support@isdown.app @DataDog/documentation @DataDog/ecosystems-review
+/isdown/assets/dashboards                    @ntomas support@isdown.app @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/isdown/assets/monitors                      @ntomas support@isdown.app @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/isdown/assets/logs/                         @ntomas support@isdown.app @DataDog/agent-integrations @DataDog/logs-backend
+
 /jfrog_platform_cloud/*metadata.csv      @jfrog/partner-engineering @DataDog/documentation @DataDog/ecosystems-review
 /jfrog_platform_cloud/manifest.json      @jfrog/partner-engineering @DataDog/documentation @DataDog/ecosystems-review
 /jfrog_platform_cloud/README.md          @jfrog/partner-engineering @DataDog/documentation @DataDog/ecosystems-review
+/jfrog_platform_cloud/assets/dashboards                    @jfrog/partner-engineering @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/jfrog_platform_cloud/assets/monitors                      @jfrog/partner-engineering @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/jfrog_platform_cloud/assets/logs/                         @jfrog/partner-engineering @DataDog/agent-integrations @DataDog/logs-backend
+
 /jfrog_platform_self_hosted/*metadata.csv            @jfrog/partner-engineering @DataDog/documentation @DataDog/ecosystems-review
 /jfrog_platform_self_hosted/manifest.json            @jfrog/partner-engineering @DataDog/documentation @DataDog/ecosystems-review
 /jfrog_platform_self_hosted/README.md                @jfrog/partner-engineering @DataDog/documentation @DataDog/ecosystems-review
+/jfrog_platform_self_hosted/assets/dashboards                    @jfrog/partner-engineering @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/jfrog_platform_self_hosted/assets/monitors                      @jfrog/partner-engineering @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/jfrog_platform_self_hosted/assets/logs/                         @jfrog/partner-engineering @DataDog/agent-integrations @DataDog/logs-backend
+
 /k6/*metadata.csv                        @ppcano support@k6.io @DataDog/documentation
 /k6/manifest.json                        @ppcano support@k6.io @DataDog/documentation
 /k6/README.md                            @ppcano support@k6.io @DataDog/documentation
+/k6/assets/dashboards                    @ppcano support@k6.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/k6/assets/monitors                      @ppcano support@k6.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/k6/assets/logs/                         @ppcano support@k6.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /kernelcare/*metadata.csv                @grubberr schvaliuk@cloudlinux.com @DataDog/documentation
 /kernelcare/manifest.json                @grubberr schvaliuk@cloudlinux.com @DataDog/documentation
 /kernelcare/README.md                    @grubberr schvaliuk@cloudlinux.com @DataDog/documentation
+/kernelcare/assets/dashboards                    @grubberr schvaliuk@cloudlinux.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/kernelcare/assets/monitors                      @grubberr schvaliuk@cloudlinux.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/kernelcare/assets/logs/                         @grubberr schvaliuk@cloudlinux.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /lacework/*metadata.csv                  @DataDog/agent-integrations @DataDog/documentation
 /lacework/manifest.json                  @DataDog/agent-integrations @DataDog/documentation
 /lacework/README.md                      @DataDog/agent-integrations @DataDog/documentation
+/lacework/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/lacework/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/lacework/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /launchdarkly/*metadata.csv              support@launchdarkly.com @DataDog/documentation @DataDog/ecosystems-review
 /launchdarkly/manifest.json              support@launchdarkly.com @DataDog/documentation @DataDog/ecosystems-review
 /launchdarkly/README.md                  support@launchdarkly.com @DataDog/documentation @DataDog/ecosystems-review
+/launchdarkly/assets/dashboards                    support@launchdarkly.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/launchdarkly/assets/monitors                      support@launchdarkly.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/launchdarkly/assets/logs/                         support@launchdarkly.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /lighthouse/*metadata.csv                @DataDog/agent-integrations @DataDog/documentation
 /lighthouse/manifest.json                @DataDog/agent-integrations @DataDog/documentation
 /lighthouse/README.md                    @DataDog/agent-integrations @DataDog/documentation
+/lighthouse/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/lighthouse/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/lighthouse/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /logstash/*metadata.csv                  @ervansetiawan ervansetiawan@gmail.com @DataDog/documentation
 /logstash/manifest.json                  @ervansetiawan ervansetiawan@gmail.com @DataDog/documentation
 /logstash/README.md                      @ervansetiawan ervansetiawan@gmail.com @DataDog/documentation
+/logstash/assets/dashboards                    @ervansetiawan ervansetiawan@gmail.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/logstash/assets/monitors                      @ervansetiawan ervansetiawan@gmail.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/logstash/assets/logs/                         @ervansetiawan ervansetiawan@gmail.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /logzio/*metadata.csv                    @DataDog/agent-integrations @DataDog/documentation
 /logzio/manifest.json                    @DataDog/agent-integrations @DataDog/documentation
 /logzio/README.md                        @DataDog/agent-integrations @DataDog/documentation
+/logzio/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/logzio/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/logzio/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /mendix/*metadata.csv                    @mendix/cloud @DataDog/agent-integrations @DataDog/documentation
 /mendix/manifest.json                    @mendix/cloud @DataDog/agent-integrations @DataDog/documentation
 /mendix/README.md                        @mendix/cloud @DataDog/agent-integrations @DataDog/documentation
+/mendix/assets/dashboards                    @mendix/cloud @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/mendix/assets/monitors                      @mendix/cloud @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/mendix/assets/logs/                         @mendix/cloud @DataDog/agent-integrations @DataDog/logs-backend
+
 /mergify/*metadata.csv                   @Mergifyio/oss-integrations @DataDog/documentation
 /mergify/manifest.json                   @Mergifyio/oss-integrations @DataDog/documentation
 /mergify/README.md                       @Mergifyio/oss-integrations @DataDog/documentation
+/mergify/assets/dashboards                    @Mergifyio/oss-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/mergify/assets/monitors                      @Mergifyio/oss-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/mergify/assets/logs/                         @Mergifyio/oss-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /n2ws/*metadata.csv                      @eliadeini eliad.eini@n2ws.com @DataDog/documentation
 /n2ws/manifest.json                      @eliadeini eliad.eini@n2ws.com @DataDog/documentation
 /n2ws/README.md                          @eliadeini eliad.eini@n2ws.com @DataDog/documentation
+/n2ws/assets/dashboards                    @eliadeini eliad.eini@n2ws.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/n2ws/assets/monitors                      @eliadeini eliad.eini@n2ws.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/n2ws/assets/logs/                         @eliadeini eliad.eini@n2ws.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /neo4j/*metadata.csv                     @davidfauth help@neo4j.com @DataDog/documentation
 /neo4j/manifest.json                     @davidfauth help@neo4j.com @DataDog/documentation
 /neo4j/README.md                         @davidfauth help@neo4j.com @DataDog/documentation
+/neo4j/assets/dashboards                    @davidfauth help@neo4j.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/neo4j/assets/monitors                      @davidfauth help@neo4j.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/neo4j/assets/logs/                         @davidfauth help@neo4j.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /neoload/*metadata.csv                   @Neotys-Labs/r-d @DataDog/documentation @DataDog/ecosystems-review
 /neoload/manifest.json                   @Neotys-Labs/r-d @DataDog/documentation @DataDog/ecosystems-review
 /neoload/README.md                       @Neotys-Labs/r-d @DataDog/documentation @DataDog/ecosystems-review
+/neoload/assets/dashboards                    @Neotys-Labs/r-d @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/neoload/assets/monitors                      @Neotys-Labs/r-d @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/neoload/assets/logs/                         @Neotys-Labs/r-d @DataDog/agent-integrations @DataDog/logs-backend
+
 /neutrona/*metadata.csv                  @DavidFlamini david@neutrona.com @DataDog/documentation
 /neutrona/manifest.json                  @DavidFlamini david@neutrona.com @DataDog/documentation
 /neutrona/README.md                      @DavidFlamini david@neutrona.com @DataDog/documentation
+/neutrona/assets/dashboards                    @DavidFlamini david@neutrona.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/neutrona/assets/monitors                      @DavidFlamini david@neutrona.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/neutrona/assets/logs/                         @DavidFlamini david@neutrona.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /nextcloud/*metadata.csv                 @eplanet @DataDog/documentation
 /nextcloud/manifest.json                 @eplanet @DataDog/documentation
 /nextcloud/README.md                     @eplanet @DataDog/documentation
+/nextcloud/assets/dashboards                    @eplanet @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/nextcloud/assets/monitors                      @eplanet @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/nextcloud/assets/logs/                         @eplanet @DataDog/agent-integrations @DataDog/logs-backend
+
 /ngrok/*metadata.csv                     @mkarnowski @DataDog/documentation @DataDog/ecosystems-review
 /ngrok/manifest.json                     @mkarnowski @DataDog/documentation @DataDog/ecosystems-review
 /ngrok/README.json                       @mkarnowski @DataDog/documentation @DataDog/ecosystems-review
+/ngrok/assets/dashboards                    @mkarnowski @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/ngrok/assets/monitors                      @mkarnowski @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/ngrok/assets/logs/                         @mkarnowski @DataDog/agent-integrations @DataDog/logs-backend
+
 /nomad/*metadata.csv                     @irabinovitch @DataDog/documentation
 /nomad/manifest.json                     @irabinovitch @DataDog/documentation
 /nomad/README.md                         @irabinovitch @DataDog/documentation
+/nomad/assets/dashboards                    @irabinovitch @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/nomad/assets/monitors                      @irabinovitch @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/nomad/assets/logs/                         @irabinovitch @DataDog/agent-integrations @DataDog/logs-backend
+
 /notion/*metadata.csv                    @makenotion/public-api @DataDog/documentation @DataDog/ecosystems-review
 /notion/manifest.json                    @makenotion/public-api @DataDog/documentation @DataDog/ecosystems-review
 /notion/README.md                        @makenotion/public-api @DataDog/documentation @DataDog/ecosystems-review
+/notion/assets/dashboards                    @makenotion/public-api @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/notion/assets/monitors                      @makenotion/public-api @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/notion/assets/logs/                         @makenotion/public-api @DataDog/agent-integrations @DataDog/logs-backend
+
 /ns1/*metadata.csv                       @dblagojevic-daitan dblagojevic@daitan.com @DataDog/documentation @DataDog/ecosystems-review
 /ns1/manifest.json                       @dblagojevic-daitan dblagojevic@daitan.com @DataDog/documentation @DataDog/ecosystems-review
 /ns1/README.md                           @dblagojevic-daitan dblagojevic@daitan.com @DataDog/documentation @DataDog/ecosystems-review
+/ns1/assets/dashboards                    @dblagojevic-daitan dblagojevic@daitan.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/ns1/assets/monitors                      @dblagojevic-daitan dblagojevic@daitan.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/ns1/assets/logs/                         @dblagojevic-daitan dblagojevic@daitan.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /nvml/*metadata.csv                      @cep21 @DataDog/documentation
 /nvml/manifest.json                      @cep21 @DataDog/documentation
 /nvml/README.md                          @cep21 @DataDog/documentation
+/nvml/assets/dashboards                    @cep21 @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/nvml/assets/monitors                      @cep21 @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/nvml/assets/logs/                         @cep21 @DataDog/agent-integrations @DataDog/logs-backend
+
 /octoprint/*metadata.csv                 @gwaldo gwaldo@gmail.com @DataDog/documentation
 /octoprint/manifest.json                 @gwaldo gwaldo@gmail.com @DataDog/documentation
 /octoprint/README.md                     @gwaldo gwaldo@gmail.com @DataDog/documentation
+/octoprint/assets/dashboards                    @gwaldo gwaldo@gmail.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/octoprint/assets/monitors                      @gwaldo gwaldo@gmail.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/octoprint/assets/logs/                         @gwaldo gwaldo@gmail.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /open_policy_agent/*metadata.csv         @arapulido ara.pulido@datadoghq.com @DataDog/documentation
 /open_policy_agent/manifest.json         @arapulido ara.pulido@datadoghq.com @DataDog/documentation
 /open_policy_agent/README.md             @arapulido ara.pulido@datadoghq.com @DataDog/documentation
+/open_policy_agent/assets/dashboards                    @arapulido ara.pulido@datadoghq.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/open_policy_agent/assets/monitors                      @arapulido ara.pulido@datadoghq.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/open_policy_agent/assets/logs/                         @arapulido ara.pulido@datadoghq.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /perimeterx/*metadata.csv                support@perimeterx.com @DataDog/documentation
 /perimeterx/manifest.json                support@perimeterx.com @DataDog/documentation
 /perimeterx/README.md                    support@perimeterx.com @DataDog/documentation
+/perimeterx/assets/dashboards                    support@perimeterx.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/perimeterx/assets/monitors                      support@perimeterx.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/perimeterx/assets/logs/                         support@perimeterx.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /php_apcu/*metadata.csv                  @withgod noname@withgod.jp @DataDog/documentation
 /php_apcu/manifest.json                  @withgod noname@withgod.jp @DataDog/documentation
 /php_apcu/README.md                      @withgod noname@withgod.jp @DataDog/documentation
+/php_apcu/assets/dashboards                    @withgod noname@withgod.jp @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/php_apcu/assets/monitors                      @withgod noname@withgod.jp @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/php_apcu/assets/logs/                         @withgod noname@withgod.jp @DataDog/agent-integrations @DataDog/logs-backend
+
 /php_opcache/*metadata.csv               @withgod noname@withgod.jp @DataDog/documentation
 /php_opcache/manifest.json               @withgod noname@withgod.jp @DataDog/documentation
 /php_opcache/README.md                   @withgod noname@withgod.jp @DataDog/documentation
+/php_opcache/assets/dashboards                    @withgod noname@withgod.jp @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/php_opcache/assets/monitors                      @withgod noname@withgod.jp @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/php_opcache/assets/logs/                         @withgod noname@withgod.jp @DataDog/agent-integrations @DataDog/logs-backend
+
 /pihole/*metadata.csv                    @monganai @DataDog/documentation
 /pihole/manifest.json                    @monganai @DataDog/documentation
 /pihole/README.md                        @monganai @DataDog/documentation
+/pihole/assets/dashboards                    @monganai @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/pihole/assets/monitors                      @monganai @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/pihole/assets/logs/                         @monganai @DataDog/agent-integrations @DataDog/logs-backend
+
 /ping/*metadata.csv                      @jstanton617 @DataDog/documentation
 /ping/manifest.json                      @jstanton617 @DataDog/documentation
 /ping/README.md                          @jstanton617 @DataDog/documentation
+/ping/assets/dashboards                    @jstanton617 @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/ping/assets/monitors                      @jstanton617 @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/ping/assets/logs/                         @jstanton617 @DataDog/agent-integrations @DataDog/logs-backend
+
 /pliant/*metadata.csv                    @hello-pliant hello@pliant.io @DataDog/documentation
 /pliant/manifest.json                    @hello-pliant hello@pliant.io @DataDog/documentation
 /pliant/README.md                        @hello-pliant hello@pliant.io @DataDog/documentation
+/pliant/assets/dashboards                    @hello-pliant hello@pliant.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/pliant/assets/monitors                      @hello-pliant hello@pliant.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/pliant/assets/logs/                         @hello-pliant hello@pliant.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /portworx/*metadata.csv                  @pault84 paul@portworx.com @DataDog/documentation
 /portworx/manifest.json                  @pault84 paul@portworx.com @DataDog/documentation
 /portworx/README.md                      @pault84 paul@portworx.com @DataDog/documentation
+/portworx/assets/dashboards                    @pault84 paul@portworx.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/portworx/assets/monitors                      @pault84 paul@portworx.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/portworx/assets/logs/                         @pault84 paul@portworx.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /postman/*metadata.csv                   @shashankawasthi88  integrations-partnerships@postman.com @DataDog/documentation
 /postman/manifest.json                   @shashankawasthi88  integrations-partnerships@postman.com @DataDog/documentation
 /postman/README.md                       @shashankawasthi88  integrations-partnerships@postman.com @DataDog/documentation
+/postman/assets/dashboards                    @shashankawasthi88  integrations-partnerships@postman.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/postman/assets/monitors                      @shashankawasthi88  integrations-partnerships@postman.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/postman/assets/logs/                         @shashankawasthi88  integrations-partnerships@postman.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /pulsar/*metadata.csv                    @zzzming itestmycode@gmail.com @DataDog/documentation
 /pulsar/manifest.json                    @zzzming itestmycode@gmail.com @DataDog/documentation
 /pulsar/README.md                        @zzzming itestmycode@gmail.com @DataDog/documentation
+/pulsar/assets/dashboards                    @zzzming itestmycode@gmail.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/pulsar/assets/monitors                      @zzzming itestmycode@gmail.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/pulsar/assets/logs/                         @zzzming itestmycode@gmail.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /pulumi/*metadata.csv                    @isaac-pulumi team@pulumi.com @DataDog/documentation @DataDog/ecosystems-review
 /pulumi/manifest.json                    @isaac-pulumi team@pulumi.com @DataDog/documentation @DataDog/ecosystems-review
 /pulumi/README.md                        @isaac-pulumi team@pulumi.com @DataDog/documentation @DataDog/ecosystems-review
+/pulumi/assets/dashboards                    @isaac-pulumi team@pulumi.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/pulumi/assets/monitors                      @isaac-pulumi team@pulumi.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/pulumi/assets/logs/                         @isaac-pulumi team@pulumi.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /puma/*metadata.csv                      @plasticine @DataDog/documentation
 /puma/manifest.json                      @plasticine @DataDog/documentation
 /puma/README.md                          @plasticine @DataDog/documentation
+/puma/assets/dashboards                    @plasticine @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/puma/assets/monitors                      @plasticine @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/puma/assets/logs/                         @plasticine @DataDog/agent-integrations @DataDog/logs-backend
+
 /radarr/*metadata.csv                    @HadrienPatte @DataDog/documentation
 /radarr/manifest.json                    @HadrienPatte @DataDog/documentation
 /radarr/README.md                        @HadrienPatte @DataDog/documentation
+/radarr/assets/dashboards                    @HadrienPatte @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/radarr/assets/monitors                      @HadrienPatte @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/radarr/assets/logs/                         @HadrienPatte @DataDog/agent-integrations @DataDog/logs-backend
+
 /rbltracker/*metadata.csv                @DataDog/agent-integrations @DataDog/documentation
 /rbltracker/manifest.json                @DataDog/agent-integrations @DataDog/documentation
 /rbltracker/README.md                    @DataDog/agent-integrations @DataDog/documentation
+/rbltracker/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/rbltracker/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/rbltracker/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /reboot_required/*metadata.csv           @montdidier support@krugerheavyindustries.com @DataDog/documentation
 /reboot_required/manifest.json           @montdidier support@krugerheavyindustries.com @DataDog/documentation
 /reboot_required/README.md               @montdidier support@krugerheavyindustries.com @DataDog/documentation
+/reboot_required/assets/dashboards                    @montdidier support@krugerheavyindustries.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/reboot_required/assets/monitors                      @montdidier support@krugerheavyindustries.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/reboot_required/assets/logs/                         @montdidier support@krugerheavyindustries.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /redis_sentinel/*metadata.csv            @DataDog/agent-integrations @DataDog/documentation
 /redis_sentinel/manifest.json            @DataDog/agent-integrations @DataDog/documentation
 /redis_sentinel/README.md                @DataDog/agent-integrations @DataDog/documentation
+/redis_sentinel/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/redis_sentinel/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/redis_sentinel/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /redisenterprise/manifest.json           @maguec christian@redislabs.com @DataDog/documentation
 /redisenterprise/README.md               @maguec christian@redislabs.com @DataDog/documentation
+/redisenterprise/assets/dashboards                    @maguec christian@redislabs.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/redisenterprise/assets/monitors                      @maguec christian@redislabs.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/redisenterprise/assets/logs/                         @maguec christian@redislabs.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /resin/*metadata.csv                     @brentm5 @DataDog/documentation
 /resin/manifest.json                     @brentm5 @DataDog/documentation
 /resin/README.md                         @brentm5 @DataDog/documentation
+/resin/assets/dashboards                    @brentm5 @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/resin/assets/monitors                      @brentm5 @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/resin/assets/logs/                         @brentm5 @DataDog/agent-integrations @DataDog/logs-backend
+
 /retool/*metadata.csv                    @jamiecuffe @DataDog/documentation
 /retool/manifest.json                    @jamiecuffe @DataDog/documentation
 /retool/README.md                        @jamiecuffe @DataDog/documentation
+/retool/assets/dashboards                    @jamiecuffe @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/retool/assets/monitors                      @jamiecuffe @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/retool/assets/logs/                         @jamiecuffe @DataDog/agent-integrations @DataDog/logs-backend
+
 /riak_repl/*metadata.csv                 @abtreece @DataDog/documentation
 /riak_repl/manifest.json                 @abtreece @DataDog/documentation
 /riak_repl/README.md                     @abtreece @DataDog/documentation
+/riak_repl/assets/dashboards                    @abtreece @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/riak_repl/assets/monitors                      @abtreece @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/riak_repl/assets/logs/                         @abtreece @DataDog/agent-integrations @DataDog/logs-backend
+
 /rigor/*metadata.csv                     support@rigor.com @DataDog/documentation
 /rigor/manifest.json                     support@rigor.com @DataDog/documentation
 /rigor/README.md                         support@rigor.com @DataDog/documentation
+/rigor/assets/dashboards                    support@rigor.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/rigor/assets/monitors                      support@rigor.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/rigor/assets/logs/                         support@rigor.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /rookout/*metadata.csv                   support@rookout.com @DataDog/documentation @DataDog/ecosystems-review
 /rookout/manifest.json                   support@rookout.com @DataDog/documentation @DataDog/ecosystems-review
 /rookout/README.md                       support@rookout.com @DataDog/documentation @DataDog/ecosystems-review
+/rookout/assets/dashboards                    support@rookout.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/rookout/assets/monitors                      support@rookout.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/rookout/assets/logs/                         support@rookout.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /rundeck/*metadata.csv                   forrest@rundeck.com @DataDog/documentation
 /rundeck/manifest.json                   forrest@rundeck.com @DataDog/documentation
 /rundeck/README.md                       forrest@rundeck.com @DataDog/documentation
+/rundeck/assets/dashboards                    forrest@rundeck.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/rundeck/assets/monitors                      forrest@rundeck.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/rundeck/assets/logs/                         forrest@rundeck.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /scalr/*metadata.csv                     @soltysss @DataDog/documentation @DataDog/ecosystems-review
 /scalr/manifest.json                     @soltysss @DataDog/documentation @DataDog/ecosystems-review
 /scalr/README.md                         @soltysss @DataDog/documentation @DataDog/ecosystems-review
+/scalr/assets/dashboards                    @soltysss @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/scalr/assets/monitors                      @soltysss @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/scalr/assets/logs/                         @soltysss @DataDog/agent-integrations @DataDog/logs-backend
+
 /seagence/*metadata.csv                  @srinivas-bitla @DataDog/documentation @DataDog/ecosystems-review
 /seagence/manifest.json                  @srinivas-bitla @DataDog/documentation @DataDog/ecosystems-review
 /seagence/README.md                      @srinivas-bitla @DataDog/documentation @DataDog/ecosystems-review
+/seagence/assets/dashboards                    @srinivas-bitla @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/seagence/assets/monitors                      @srinivas-bitla @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/seagence/assets/logs/                         @srinivas-bitla @DataDog/agent-integrations @DataDog/logs-backend
+
 /sendmail/*metadata.csv                  @dabcoder david.bouchare@datadoghq.com @DataDog/documentation
 /sendmail/manifest.json                  @dabcoder david.bouchare@datadoghq.com @DataDog/documentation
 /sendmail/README.md                      @dabcoder david.bouchare@datadoghq.com @DataDog/documentation
+/sendmail/assets/dashboards                    @dabcoder david.bouchare@datadoghq.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/sendmail/assets/monitors                      @dabcoder david.bouchare@datadoghq.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/sendmail/assets/logs/                         @dabcoder david.bouchare@datadoghq.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /signl4/*metadata.csv                    @rons4 ron@signl4.com @DataDog/documentation
 /signl4/manifest.json                    @rons4 ron@signl4.com @DataDog/documentation
 /signl4/README.md                        @rons4 ron@signl4.com @DataDog/documentation
+/signl4/assets/dashboards                    @rons4 ron@signl4.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/signl4/assets/monitors                      @rons4 ron@signl4.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/signl4/assets/logs/                         @rons4 ron@signl4.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /sigsci/*metadata.csv                    @signalsciences info@signalsciences.com @DataDog/documentation
 /sigsci/manifest.json                    @signalsciences info@signalsciences.com @DataDog/documentation
 /sigsci/README.md                        @signalsciences info@signalsciences.com @DataDog/documentation
+/sigsci/assets/dashboards                    @signalsciences info@signalsciences.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/sigsci/assets/monitors                      @signalsciences info@signalsciences.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/sigsci/assets/logs/                         @signalsciences info@signalsciences.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /shoreline/*metadata.csv                 @ytnytn1 support@shoreline.io @DataDog/documentation @DataDog/ecosystems-review
 /shoreline/manifest.json                 @ytnytn1 support@shoreline.io @DataDog/documentation @DataDog/ecosystems-review
 /shoreline/README.md                     @ytnytn1 support@shoreline.io @DataDog/documentation @DataDog/ecosystems-review
+/shoreline/assets/dashboards                    @ytnytn1 support@shoreline.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/shoreline/assets/monitors                      @ytnytn1 support@shoreline.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/shoreline/assets/logs/                         @ytnytn1 support@shoreline.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /sleuth/*metadata.csv                    @mtbnut pleal@sleuth.io @DataDog/documentation
 /sleuth/manifest.json                    @mtbnut pleal@sleuth.io @DataDog/documentation
 /sleuth/README.md                        @mtbnut pleal@sleuth.io @DataDog/documentation
+/sleuth/assets/dashboards                    @mtbnut pleal@sleuth.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/sleuth/assets/monitors                      @mtbnut pleal@sleuth.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/sleuth/assets/logs/                         @mtbnut pleal@sleuth.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /snmpwalk/*metadata.csv                  @DataDog/agent-integrations @DataDog/documentation
 /snmpwalk/manifest.json                  @DataDog/agent-integrations @DataDog/documentation
 /snmpwalk/README.md                      @DataDog/agent-integrations @DataDog/documentation
+/snmpwalk/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/snmpwalk/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/snmpwalk/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /sonarr/*metadata.csv                    @HadrienPatte @DataDog/documentation
 /sonarr/manifest.json                    @HadrienPatte @DataDog/documentation
 /sonarr/README.md                        @HadrienPatte @DataDog/documentation
+/sonarr/assets/dashboards                    @HadrienPatte @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/sonarr/assets/monitors                      @HadrienPatte @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/sonarr/assets/logs/                         @HadrienPatte @DataDog/agent-integrations @DataDog/logs-backend
+
 /sortdb/*metadata.csv                    @namrata4 namrata.deshpande4@gmail.com @DataDog/documentation
 /sortdb/manifest.json                    @namrata4 namrata.deshpande4@gmail.com @DataDog/documentation
 /sortdb/README.md                        @namrata4 namrata.deshpande4@gmail.com @DataDog/documentation
+/sortdb/assets/dashboards                    @namrata4 namrata.deshpande4@gmail.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/sortdb/assets/monitors                      @namrata4 namrata.deshpande4@gmail.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/sortdb/assets/logs/                         @namrata4 namrata.deshpande4@gmail.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /speedtest/*metadata.csv                 @platinummonkey @DataDog/documentation
 /speedtest/manifest.json                 @platinummonkey @DataDog/documentation
 /speedtest/README.md                     @platinummonkey @DataDog/documentation
+/speedtest/assets/dashboards                    @platinummonkey @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/speedtest/assets/monitors                      @platinummonkey @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/speedtest/assets/logs/                         @platinummonkey @DataDog/agent-integrations @DataDog/logs-backend
+
 /split/*metadata.csv                     @jeremy-lq @DataDog/documentation
 /split/manifest.json                     @jeremy-lq @DataDog/documentation
 /split/README.md                         @jeremy-lq @DataDog/documentation
+/split/assets/dashboards                    @jeremy-lq @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/split/assets/monitors                      @jeremy-lq @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/split/assets/logs/                         @jeremy-lq @DataDog/agent-integrations @DataDog/logs-backend
+
 /sqreen/*metadata.csv                    @DataDog/agent-integrations @DataDog/documentation
 /sqreen/manifest.json                    @DataDog/agent-integrations @DataDog/documentation
 /sqreen/README.md                        @DataDog/agent-integrations @DataDog/documentation
+/sqreen/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/sqreen/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/sqreen/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /squadcast/*metadata.csv                 it@squadcast.com @DataDog/documentation
 /squadcast/manifest.json                 it@squadcast.com @DataDog/documentation
 /squadcast/README.md                     it@squadcast.com @DataDog/documentation
+/squadcast/assets/dashboards                    it@squadcast.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/squadcast/assets/monitors                      it@squadcast.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/squadcast/assets/logs/                         it@squadcast.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /stackpulse/*metadata.csv                @stackpulse/rnd support@stackpulse.io @DataDog/documentation
 /stackpulse/manifest.json                @stackpulse/rnd support@stackpulse.io @DataDog/documentation
 /stackpulse/README.md                    @stackpulse/rnd support@stackpulse.io @DataDog/documentation
+/stackpulse/assets/dashboards                    @stackpulse/rnd support@stackpulse.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/stackpulse/assets/monitors                      @stackpulse/rnd support@stackpulse.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/stackpulse/assets/logs/                         @stackpulse/rnd support@stackpulse.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /stardog/*metadata.csv                   @buzztroll support@stardog.com @DataDog/documentation
 /stardog/manifest.json                   @buzztroll support@stardog.com @DataDog/documentation
 /stardog/README.md                       @buzztroll support@stardog.com @DataDog/documentation
+/stardog/assets/dashboards                    @buzztroll support@stardog.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/stardog/assets/monitors                      @buzztroll support@stardog.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/stardog/assets/logs/                         @buzztroll support@stardog.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /statsig/*metadata.csv                   @marcos-statsig support@statsig.com @DataDog/documentation
 /statsig/manifest.json                   @marcos-statsig support@statsig.com @DataDog/documentation
 /statsig/README.md                       @marcos-statsig support@statsig.com @DataDog/documentation
+/statsig/assets/dashboards                    @marcos-statsig support@statsig.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/statsig/assets/monitors                      @marcos-statsig support@statsig.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/statsig/assets/logs/                         @marcos-statsig support@statsig.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /steadybit/*metadata.csv                 @bripkens support@steadybit.com @DataDog/documentation @DataDog/ecosystems-review
 /steadybit/manifest.json                 @bripkens support@steadybit.com @DataDog/documentation @DataDog/ecosystems-review
 /steadybit/README.md                     @bripkens support@steadybit.com @DataDog/documentation @DataDog/ecosystems-review
+/steadybit/assets/dashboards                    @bripkens support@steadybit.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/steadybit/assets/monitors                      @bripkens support@steadybit.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/steadybit/assets/logs/                         @bripkens support@steadybit.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /storm/*metadata.csv                     @platinummonkey @DataDog/documentation
 /storm/manifest.json                     @platinummonkey @DataDog/documentation
 /storm/README.md                         @platinummonkey @DataDog/documentation
+/storm/assets/dashboards                    @platinummonkey @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/storm/assets/monitors                      @platinummonkey @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/storm/assets/logs/                         @platinummonkey @DataDog/agent-integrations @DataDog/logs-backend
+
 /stormforge/*metadata.csv                @bradbeam @tperol support@stormforge.io @DataDog/documentation @DataDog/ecosystems-review
 /stormforge/manifest.json                @bradbeam @tperol support@stormforge.io @DataDog/documentation @DataDog/ecosystems-review
 /stormforge/README.md                    @bradbeam @tperol support@stormforge.io @DataDog/documentation @DataDog/ecosystems-review
+/stormforge/assets/dashboards                    @bradbeam @tperol support@stormforge.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/stormforge/assets/monitors                      @bradbeam @tperol support@stormforge.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/stormforge/assets/logs/                         @bradbeam @tperol support@stormforge.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /syncthing/*metadata.csv                 @sashacmc @DataDog/documentation
 /syncthing/manifest.json                 @sashacmc @DataDog/documentation
 /syncthing/README.md                     @sashacmc @DataDog/documentation
+/syncthing/assets/dashboards                    @sashacmc @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/syncthing/assets/monitors                      @sashacmc @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/syncthing/assets/logs/                         @sashacmc @DataDog/agent-integrations @DataDog/logs-backend
+
 /tailscale/                              @DataDog/documentation @DataDog/saas-integrations
 /taskcall/manifest.json                  @taskcall support@taskcallapp.com @DataDog/documentation @DataDog/ecosystems-review
 /taskcall/README.md                      @taskcall support@taskcallapp.com @DataDog/documentation @DataDog/ecosystems-review
+/taskcall/assets/dashboards                    @taskcall support@taskcallapp.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/taskcall/assets/monitors                      @taskcall support@taskcallapp.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/taskcall/assets/logs/                         @taskcall support@taskcallapp.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /tidb/*metadata.csv                      @SabaPing xuyifan02@pingcap.com @DataDog/documentation @DataDog/ecosystems-review
 /tidb/manifest.json                      @SabaPing xuyifan02@pingcap.com @DataDog/documentation @DataDog/ecosystems-review
 /tidb/README.md                          @SabaPing xuyifan02@pingcap.com @DataDog/documentation @DataDog/ecosystems-review
+/tidb/assets/dashboards                    @SabaPing xuyifan02@pingcap.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/tidb/assets/monitors                      @SabaPing xuyifan02@pingcap.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/tidb/assets/logs/                         @SabaPing xuyifan02@pingcap.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /traefik/*metadata.csv                   @renaudhager @DataDog/documentation
 /traefik/manifest.json                   @renaudhager @DataDog/documentation
 /traefik/README.md                       @renaudhager @DataDog/documentation
+/traefik/assets/dashboards                    @renaudhager @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/traefik/assets/monitors                      @renaudhager @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/traefik/assets/logs/                         @renaudhager @DataDog/agent-integrations @DataDog/logs-backend
+
+XXXX
 /twingate/manifest.json                  @emrul partnerships@twingate.com @DataDog/documentation @DataDog/ecosystems-review
 /twingate/README.md                      @emrul partnerships@twingate.com @DataDog/documentation @DataDog/ecosystems-review
+
 /tyk/*metadata.csv                       @letzya @DataDog/documentation
 /tyk/manifest.json                       @letzya @DataDog/documentation
 /tyk/README.md                           @letzya @DataDog/documentation
+/tyk/assets/dashboards                    @letzya @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/tyk/assets/monitors                      @letzya @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/tyk/assets/logs/                         @letzya @DataDog/agent-integrations @DataDog/logs-backend
+
 /unbound/*metadata.csv                   @dbyron0 david.byron@avast.com @DataDog/documentation
 /unbound/manifest.json                   @dbyron0 david.byron@avast.com @DataDog/documentation
 /unbound/README.md                       @dbyron0 david.byron@avast.com @DataDog/documentation
+/unbound/assets/dashboards                    @dbyron0 david.byron@avast.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/unbound/assets/monitors                      @dbyron0 david.byron@avast.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/unbound/assets/logs/                         @dbyron0 david.byron@avast.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /upbound_uxp/*metadata.csv               @humoflife support@upbound.io @DataDog/documentation
 /upbound_uxp/manifest.json               @humoflife support@upbound.io @DataDog/documentation
 /upbound_uxp/README.md                   @humoflife support@upbound.io @DataDog/documentation
+/upbound_uxp/assets/dashboards                    @humoflife support@upbound.io @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/upbound_uxp/assets/monitors                      @humoflife support@upbound.io @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/upbound_uxp/assets/logs/                         @humoflife support@upbound.io @DataDog/agent-integrations @DataDog/logs-backend
+
 /unifi_console/*metadata.csv             @abruneau @DataDog/documentation
 /unifi_console/manifest.json             @abruneau @DataDog/documentation
 /unifi_console/README.md                 @abruneau @DataDog/documentation
+/unifi_console/assets/dashboards                    @abruneau @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/unifi_console/assets/monitors                      @abruneau @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/unifi_console/assets/logs/                         @abruneau @DataDog/agent-integrations @DataDog/logs-backend
+
 /upsc/*metadata.csv                      @platinummonkey @DataDog/documentation
 /upsc/manifest.json                      @platinummonkey @DataDog/documentation
 /upsc/README.md                          @platinummonkey @DataDog/documentation
+/upsc/assets/dashboards                    @platinummonkey @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/upsc/assets/monitors                      @platinummonkey @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/upsc/assets/logs/                         @platinummonkey @DataDog/agent-integrations @DataDog/logs-backend
+
 /uptime/*metadata.csv                    @jeremy-lq @DataDog/documentation
 /uptime/manifest.json                    @jeremy-lq @DataDog/documentation
 /uptime/README.md                        @jeremy-lq @DataDog/documentation
+/uptime/assets/dashboards                    @jeremy-lq @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/uptime/assets/monitors                      @jeremy-lq @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/uptime/assets/logs/                         @jeremy-lq @DataDog/agent-integrations @DataDog/logs-backend
+
 /vespa/*metadata.csv                     @gjoranv dd@vespa.ai @DataDog/documentation
 /vespa/manifest.json                     @gjoranv dd@vespa.ai @DataDog/documentation
 /vespa/README.md                         @gjoranv dd@vespa.ai @DataDog/documentation
+/vespa/assets/dashboards                    @gjoranv dd@vespa.ai @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/vespa/assets/monitors                      @gjoranv dd@vespa.ai @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/vespa/assets/logs/                         @gjoranv dd@vespa.ai @DataDog/agent-integrations @DataDog/logs-backend
+
 /vns3/*metadata.csv                      @DataDog/agent-integrations @DataDog/documentation
 /vns3/manifest.json                      @DataDog/agent-integrations @DataDog/documentation
 /vns3/README.md                          @DataDog/agent-integrations @DataDog/documentation
+/vns3/assets/dashboards                    @DataDog/agent-integrations @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/vns3/assets/monitors                      @DataDog/agent-integrations @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/vns3/assets/logs/                         @DataDog/agent-integrations @DataDog/agent-integrations @DataDog/logs-backend
+
 /zabbix/*metadata.csv                    @KosukeKamiya @DataDog/documentation
 /zabbix/manifest.json                    @KosukeKamiya @DataDog/documentation
 /zabbix/README.md                        @KosukeKamiya @DataDog/documentation
+/zabbix/assets/dashboards                    @KosukeKamiya @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/zabbix/assets/monitors                      @KosukeKamiya @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/zabbix/assets/logs/                         @KosukeKamiya @DataDog/agent-integrations @DataDog/logs-backend
+
 /zenduty/*metadata.csv                   @zenbeam shubham@zenduty.com @DataDog/documentation @DataDog/ecosystems-review
 /zenduty/manifest.json                   @zenbeam shubham@zenduty.com @DataDog/documentation @DataDog/ecosystems-review
 /zenduty/README.md                       @zenbeam shubham@zenduty.com @DataDog/documentation @DataDog/ecosystems-review
+/zenduty/assets/dashboards                    @zenbeam shubham@zenduty.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/zenduty/assets/monitors                      @zenbeam shubham@zenduty.com @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/zenduty/assets/logs/                         @zenbeam shubham@zenduty.com @DataDog/agent-integrations @DataDog/logs-backend
+
 /rookout/*metadata.csv                    @rookout/product @DataDog/documentation
 /rookout/manifest.json                    @rookout/product @DataDog/documentation
 /rookout/README.md                        @rookout/product @DataDog/documentation
+/rookout/assets/dashboards                    @rookout/product @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/rookout/assets/monitors                      @rookout/product @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/rookout/assets/logs/                         @rookout/product @DataDog/agent-integrations @DataDog/logs-backend
+
 /lambdatest/*metadata.csv                 @prateeksainilambdatest @DataDog/documentation @DataDog/ecosystems-review
 /lambdatest/manifest.json                 @prateeksainilambdatest @DataDog/documentation @DataDog/ecosystems-review
 /lambdatest/README.md                     @prateeksainilambdatest @DataDog/documentation @DataDog/ecosystems-review
+
 /sosivio/*metadata.csv                 @danarlowski @DataDog/documentation @DataDog/ecosystems-review
 /sosivio/manifest.json                 @danarlowski @DataDog/documentation @DataDog/ecosystems-review
 /sosivio/README.md                     @danarlowski @DataDog/documentation @DataDog/ecosystems-review
+/sosivio/assets/dashboards                    @danarlowski @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/sosivio/assets/monitors                      @danarlowski @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/sosivio/assets/logs/                         @danarlowski @DataDog/agent-integrations @DataDog/logs-backend
+
+XXXX
 /emnify/*metadata.csv                  @DataDog/documentation @EMnify/development @EMnify/rademade
 /emnify/manifest.json                  @DataDog/documentation @EMnify/development @EMnify/rademade
 /emnify/README.md                      @DataDog/documentation @EMnify/development @EMnify/rademade
+
 /adaptive_shield/*metadata.csv         @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
 /adaptive_shield/manifest.json         @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
 /adaptive_shield/README.md             @adaptiveshield @DataDog/documentation @DataDog/ecosystems-review
+/adaptive_shield/assets/dashboards                    @adaptiveshield @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/adaptive_shield/assets/monitors                      @adaptiveshield @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/adaptive_shield/assets/logs/                         @adaptiveshield @DataDog/agent-integrations @DataDog/logs-backend
+
 /typingdna_activelock/*metadata.csv    @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/documentation @DataDog/ecosystems-review
 /typingdna_activelock/manifest.json    @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/documentation @DataDog/ecosystems-review
 /typingdna_activelock/README.md        @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/documentation @DataDog/ecosystems-review
+/typingdna_activelock/assets/dashboards                    @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/typingdna_activelock/assets/monitors                      @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/typingdna_activelock/assets/logs/                         @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/agent-integrations @DataDog/logs-backend
+
 /sofy_sofy/*metadata.csv               @Sofy @DataDog/documentation @DataDog/ecosystems-review
 /sofy_sofy/manifest.json               @Sofy @DataDog/documentation @DataDog/ecosystems-review
 /sofy_sofy/README.md                   @Sofy @DataDog/documentation @DataDog/ecosystems-review
+/sofy_sofy/assets/dashboards                    @Sofy @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/sofy_sofy/assets/monitors                      @Sofy @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/sofy_sofy/assets/logs/                         @Sofy @DataDog/agent-integrations @DataDog/logs-backend
+
 /singlestoredb_cloud/*metadata.csv     @tdasarathan @DataDog/ecosystems-review
 /singlestoredb_cloud/manifest.json     @tdasarathan @DataDog/ecosystems-review
 /singlestoredb_cloud/README.md         @tdasarathan @DataDog/ecosystems-review
+/singlestoredb_cloud/assets/dashboards                    @tdasarathan @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/singlestoredb_cloud/assets/monitors                      @tdasarathan @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/singlestoredb_cloud/assets/logs/                         @tdasarathan @DataDog/agent-integrations @DataDog/logs-backend
+
 /emqx/*metadata.csv                    @zhongwencool @zmstone @DataDog/documentation @DataDog/ecosystems-review
 /emqx/manifest.json                    @zhongwencool @zmstone @DataDog/documentation @DataDog/ecosystems-review
+/emqx/assets/dashboards                    @zhongwencool @zmstone @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+/emqx/assets/monitors                      @zhongwencool @zmstone @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+/emqx/assets/logs/                         @zhongwencool @zmstone @DataDog/agent-integrations @DataDog/logs-backend
 /emqx/README.md                        @zhongwencool @zmstone @DataDog/documentation @DataDog/ecosystems-review


### PR DESCRIPTION
### What does this PR do?

This PR updates CODEOWNERS to reflect that each integration folder/owner owns their underlying assets, while preserving the DataDog team that wants to review those asset types (dashboards, monitors and logs specifically)

### Motivation

The primary goal was to ensure that `logs-backend` has a chance to review Logs Integration Pipelines as they've requested
But during this PR, we realized that other asset team's were expecting ownership of their assets (the top of the file had some wildcards for assets/dashboards and assets/monitors, but because CODEOWNERS is bottom to top, they were being overwritten) So we updated each integration specific ownership to include those asset types.  

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
