### PR TITLE
fix: low emqx's datadog-checks-base to 32.6.0

### DIFF
--- a/emqx/CHANGELOG.md
+++ b/emqx/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - EMQX
 
+## 1.1.0 / 2024-03-13
+
+***Fixed***:
+
+* Lower datadog-checks-base to `32.6.0` to fix the agent installation compatible issue [#2317](https://github.com/DataDog/integrations-extras/pull/2317)
 
 ## 1.0.0 / 2023-12-20
 

--- a/emqx/README.md
+++ b/emqx/README.md
@@ -28,7 +28,7 @@ The integration of EMQX with Datadog enriches monitoring capabilities, providing
 
 Manually install the EMQX check (note that [instructions may change based on your environment][2]):
 
-Run `datadog-agent integration install -t datadog-emqx==1.0.0`.
+Run `datadog-agent integration install -t datadog-emqx==1.1.0`.
 
 ### Configuration
 

--- a/emqx/pyproject.toml
+++ b/emqx/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=36.1.0",
+    "datadog-checks-base>=32.6.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
emqx only use `OpenMetricsBaseCheckV2` class, it's introduce in `32.6.0`

I previously set it to `36.1.0` because I saw that this was the latest version here https://pypi.org/project/datadog-checks-base/ is `36.1.0`, but the latest agent on macOS(7.51.1) does not include 36.1.0 yet.

FYI: https://github.com/DataDog/integrations-extras/pull/2175#discussion_r1475698227
close https://github.com/DataDog/integrations-extras/issues/2313

