### PR TITLE
Update metadata csv link to correct repo

### DIFF
--- a/jfrog_platform_self_hosted/README.md
+++ b/jfrog_platform_self_hosted/README.md
@@ -68,7 +68,7 @@ A: At launch, the SaaS version of the integration will only stream the artifacto
 [3]: https://docs.datadoghq.com/logs/explorer/facets/
 [4]: https://github.com/jfrog/log-analytics-datadog
 [5]: https://app.datadoghq.com/organization-settings/api-keys
-[6]: https://github.com/DataDog/integrations-extras/blob/master/jfrog_platform/metadata.csv
+[6]: https://github.com/DataDog/integrations-extras/blob/master/jfrog_platform_self_hosted/metadata.csv
 [7]: https://support.jfrog.com/s/login/?language=en_US&ec=302&startURL=%2Fs%2F
 [8]: https://github.com/jfrog/log-analytics-datadog#os--virtual-machine
 [9]: https://github.com/jfrog/log-analytics-datadog#docker


### PR DESCRIPTION
### What does this PR do?

Updates the link to the csv located within the repo this document is located within.

### Motivation

When assisting a customer with the JFrog integration noticed the link to the metadata.csv which displayed the supported metrics had linked to to the repo integrations-extras/jfrog_platform resulting in a 404 error.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
