### PR TITLE
Fix log assets codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,11 +8,13 @@
 **/assets/monitors                       @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
 **/assets/logs/                          @DataDog/agent-integrations @DataDog/logs-backend
 
+
 # Community partners
 /1e/                                     support@1e.com @DataDog/ecosystems-review
 /ably/                                   @ably support@ably.com @DataDog/ecosystems-review
 /agora_analytics/                        @Agora zhangpeizhe@agora.io @DataDog/ecosystems-review
 /akamai_datastream_2/                    @DataDog/saas-integrations
+/akamai_datastream_2/assets/logs/        @DataDog/saas-integrations @DataDog/logs-backend
 /akeyless_gateway/                       @akljph support@akeyless.io  @DataDog/ecosystems-review
 /alertnow/                               @Uijong-Kim uijong.kim@bespinglobal.com
 /algorithmia/                            @koverholt support@algorithmia.io @DataDog/ecosystems-review
@@ -33,6 +35,7 @@
 /bonsai/                                 dev@onemorecloud.com
 /botprise/                               @codechefnisha-bp nisha.kumari@botprise.com
 /bottomline_recordandreplay/             @nbk96f1 Andrew.Leon@bottomline.com @DataDog/ecosystems-review
+/bottomline_recordandreplay/assets/logs/ @nbk96f1 Andrew.Leon@bottomline.com @DataDog/ecosystems-review @DataDog/logs-backend
 /buddy/                                  support@buddy.works
 /buoyant_cloud/                          @BuoyantIO/buoys @DataDog/ecosystems-review
 /census/                                 @sankalp04 support@getcensus.com @DataDog/ecosystems-review
@@ -51,6 +54,7 @@
 /cyral/                                  @tyrannosaurus-becks product@cyral.com @DataDog/ecosystems-review
 /data_runner/                            @DataDog/apps-sdk @DataDog/ecosystems-review
 /datazoom/                               @DataDog/saas-integrations @DataDog/saas-integrations
+/datazoom/assets/logs/                   @DataDog/saas-integrations @DataDog/saas-integrations @DataDog/logs-backend
 /devcycle/                               @nikolasleblanc
 /drata/                                  @jason-drata support@drata.com @DataDog/ecosystems-review
 /docontrol/                              @lielran @DataDog/ecosystems-review
@@ -93,6 +97,7 @@
 /insightfinder/                          @dearmore @erinlmcmahon support@insightfinder.com @DataDog/ecosystems-review
 /isdown/                                 @ntomas support@isdown.app @DataDog/ecosystems-review
 /jamf_protect/                           @DataDog/saas-integrations
+/jamf_protect/assets/logs/               @DataDog/saas-integrations @DataDog/logs-backend
 /rum_javascript/                         @DataDog/rum-app
 /k6/                                     @ppcano support@k6.io
 /kernelcare/                             @grubberr schvaliuk@cloudlinux.com
@@ -101,6 +106,7 @@
 /launchdarkly/                           support@launchdarkly.com @DataDog/ecosystems-review
 /lacework/                               @DataDog/agent-integrations
 /lambdatest/                             @prateeksainilambdatest @DataDog/ecosystems-review
+/lambdatest/assets/logs/                 @prateeksainilambdatest @DataDog/ecosystems-review @DataDog/logs-backend
 /launchdarkly/                           support@launchdarkly.com
 /lighthouse/                             @DataDog/agent-integrations
 /loadrunner_professional/                @mihneavelinOT
@@ -109,6 +115,7 @@
 /logzio/                                 @DataDog/agent-integrations
 /mongodb_atlas/                          @DataDog/saas-integrations
 /modal/                                  @modal-labs support@modal.com @irfansharif irfan@modal.com
+/modal/assets/logs/                      @modal-labs support@modal.com @irfansharif irfan@modal.com @DataDog/logs-backend
 /mendix/                                 @mendix/cloud @DataDog/agent-integrations @DataDog/ecosystems-review
 /mergify/                                @Mergifyio/oss-integrations
 /n2ws/                                   @eliadeini eliad.eini@n2ws.com @DataDog/ecosystems-review
@@ -189,6 +196,7 @@
 /syncthing/                              @sashacmc
 /taskcall/                               @taskcall support@taskcallapp.com @DataDog/ecosystems-review
 /tailscale/                              @DataDog/saas-integrations
+/tailscale/assets/logs/                  @DataDog/saas-integrations @DataDog/logs-backend
 /tidb/                                   @SabaPing xuyifan02@pingcap.com @DataDog/ecosystems-review
 /tidb_cloud/                             @SabaPing xuyifan02@pingcap.com @DataDog/ecosystems-review
 /torq/                                   @torqio/rnd support@torq.io
@@ -207,6 +215,7 @@
 /uptycs/                                 @cgadde-uptycs support@uptycs.com
 /vantage/                                @brookemckim support@vantage.sh @DataDog/ecosystems-review
 /vercel/                                 @Datadog/serverless
+/vercel/assets/logs/                     @Datadog/serverless @DataDog/logs-backend
 /vespa/                                  @gjoranv dd@vespa.ai
 /vns3/                                   @DataDog/agent-integrations
 /wayfinder/                              @jonny-scott80 jonny_scott@outlook.com
@@ -216,8 +225,10 @@
 /zenduty/                                @zenbeam shubham@zenduty.com @DataDog/ecosystems-review
 /zenoh_router/                           @sashacmc
 /zscaler/                                @BoyangHuang @DataDog/saas-integrations
+/zscaler/assets/logs/                    @BoyangHuang @DataDog/saas-integrations @DataDog/logs-backend
 /sosivio/                                @danarlowski info@sosiv.io @DataDog/ecosystems-review
-/sym/                                  @symopsio/eng
+/sym/                                    @symopsio/eng
+/sym/assets/logs/                        @symopsio/eng @DataDog/logs-backend
 /emnify/                                 @EMnify/development @EMnify/rademade
 /adaptive_shield/                        @adaptiveshield @DataDog/ecosystems-review
 /typingdna_activelock/                   @TypingDNA/logintegrations @raulpopa @endresstefan @DataDog/ecosystems-review


### PR DESCRIPTION
### What does this PR do?

Some log assets were not being owned by logs-backend. This PR is fixing it.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
