### PR TITLE
Update manifest.json - toggle public_website to true

### DIFF
--- a/cribl_stream/manifest.json
+++ b/cribl_stream/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2ef15aea-af91-4769-940c-2b124e4d04a6",
   "app_id": "cribl-stream",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?

Changed `display_on_public_website` to true

### Motivation

Tried searching for `Cribl` and `Stream` on the [Datadog Integrations page](https://docs.datadoghq.com/integrations/) with no results

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [N/A] Feature or bugfix has tests
- [X] Git history is clean
- [N/A] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [N/A] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes
