### PR TITLE
Update broken blog link to link to relevant configuration instructions instead

### DIFF
--- a/mongodb_atlas/README.md
+++ b/mongodb_atlas/README.md
@@ -48,7 +48,7 @@ Additional helpful documentation, links, and articles:
 [1]: https://app.datadoghq.com/organization-settings/api-keys
 [2]: https://docs.atlas.mongodb.com/tutorial/monitoring-integrations/#procedure
 [3]: https://github.com/DataDog/integrations-extras/blob/master/mongodb_atlas/metadata.csv
-[4]: https://www.mongodb.com/blog/post/push-your-mongodb-atlas-alerts-to-datadog
+[4]: https://www.mongodb.com/docs/atlas/configure-alerts/#std-label-notification-options
 [5]: https://docs.datadoghq.com/help/
 [6]: https://www.datadoghq.com/blog/monitor-atlas-performance-metrics-with-datadog/
 [7]: https://www.mongodb.com/products/platform/atlas-for-government


### PR DESCRIPTION
### What does this PR do?

Updates a broken blog link (which now just redirects to the Mongo Atlas home page) to a more relevant target that includes information on configuring alerts to be sent to Datadog.

### Motivation

DOCS-7461

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
