### PR TITLE
Set the uninstallation field in the manifest if the README has uninstallation instructions

### DIFF
--- a/keep/manifest.json
+++ b/keep/manifest.json
@@ -6,6 +6,7 @@
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
+    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Send monitor metrics from Keep's AIOps platform into Datadog",

--- a/notion/manifest.json
+++ b/notion/manifest.json
@@ -6,6 +6,7 @@
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
+    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Monitor your Notion workspace events and customize detections in Datadog",

--- a/sofy_sofy/manifest.json
+++ b/sofy_sofy/manifest.json
@@ -6,6 +6,7 @@
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
+    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Monitors device metrics during automated test case runs",

--- a/yugabytedb_managed/manifest.json
+++ b/yugabytedb_managed/manifest.json
@@ -6,6 +6,7 @@
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",
+    "uninstallation": "README.md#Uninstallation",
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Export YugabyteDB Managed cluster metrics to Datadog",


### PR DESCRIPTION
### What does this PR do?

A few integrations contain Uninstallation instructions in their README but aren't referenced in the manifest. Because of this, they don't render in the in-app tile as expected. 

This PR ensures that they are referenced in the manifest. 

### Motivation

While working on a migration, we noticed a discrepancy in the fact that these integrations have uninstallation steps, but weren't in the manifest. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
