### PR TITLE
Reset all vantage fields except scopes

### DIFF
--- a/vantage/assets/oauth_clients.json
+++ b/vantage/assets/oauth_clients.json
@@ -1,18 +1,17 @@
 {
   "integration": {
-    "description": "Vantage Development Integration",
     "scopes": [
       "usage_read",
       "timeseries_query",
       "metrics_read"
     ],
+    "name": "Vantage",
+    "client_role": "integration",
     "onboarding_url": "https://console.vantage.sh/settings/integrations",
     "redirect_uris": [
-      "https://console-staging.vantage.sh/auth/datadog/callback",
       "https://console.vantage.sh/auth/datadog/callback"
     ],
-    "client_role": "integration",
-    "name": "Vantage Development",
+    "description": "Vantage Cost Integration",
     "id": "c32aa33c-4594-11ed-9ca8-da7ad0900002"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Resets all vantage integration oauth client fields to what they were before the most recent change since they were accidentally changed. Keep the new scopes

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
