### PR TITLE
Update support email for nvml integration

### DIFF
--- a/nvml/manifest.json
+++ b/nvml/manifest.json
@@ -21,9 +21,9 @@
     ]
   },
   "author": {
-    "support_email": "help@datadoghq.com",
+    "support_email": "cep221@gmail.com",
     "homepage": "https://github.com/DataDog/integrations-extras",
-    "sales_email": "help@datadoghq.com",
+    "sales_email": "cep221@gmail.com",
     "name": "Community"
   },
   "assets": {


### PR DESCRIPTION
### What does this PR do?

Updates the `nvml` check support and sales email address in `manifest.json`
### Motivation

Hi @cep21, 

I'm a support engineer at Datadog, and recently had a customer reach out because the nvml integration stopped working with the most recent Datadog Agent. As you're listed in the `CODEOWNERS` file, I wanted to update the `manifest.json` to match and make it clearer for users of this integration to contact you for similar issues. This matches other integrations in the repo - no update to the `README.md`.

If you do not agree to this, please let me know. I'll then work to make sure this integration is marked as orphaned instead, to prevent anyone from reaching out to you in future.

Internal ticket reference (not publicly viewable): https://datadog.zendesk.com/agent/tickets/1645334

The error in question, for reference:
```
2024-04-12 05:47:11 UTC | CORE | DEBUG | (pkg/collector/python/loader.go:157 in Load) | Unable to load python module - datadog_checks.nvml: unable to import module 'datadog_checks.nvml': Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/nvml/__init__.py", line 5, in <module>
    from .nvml import NvmlCheck
  File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/nvml/nvml.py", line 16, in <module>
    from .api_pb2 import ListPodResourcesRequest
  File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/datadog_checks/nvml/api_pb2.py", line 25, in <module>
    _LISTPODRESOURCESREQUEST = _descriptor.Descriptor(
                               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/datadog-agent/embedded/lib/python3.11/site-packages/google/protobuf/descriptor.py", line 296, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

This was resolved with:
`sudo -u dd-agent -H /opt/datadog-agent/embedded/bin/pip3 install grpcio pynvml==11.5.0 protobuf==3.20.3`

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
