### PR TITLE
[ECOS-141] Removed deprecated Monitoring category

### DIFF
--- a/cybersixgill_actionable_alerts/manifest.json
+++ b/cybersixgill_actionable_alerts/manifest.json
@@ -38,7 +38,6 @@
       "Supported OS::Windows",
       "Supported OS::macOS",
       "Category::Security",
-      "Category::Monitoring",
       "Category::Event Management",
       "Submitted Data Type::Events"
     ]

--- a/instabug/manifest.json
+++ b/instabug/manifest.json
@@ -48,7 +48,6 @@
       "Supported OS::Windows",
       "Supported OS::macOS",
       "Category::Alerting",
-      "Category::Monitoring",
       "Category::Issue Tracking"
     ]
   },

--- a/seagence/manifest.json
+++ b/seagence/manifest.json
@@ -40,7 +40,6 @@
       "Category::Automation",
       "Category::Event Management",
       "Category::Developer Tools",
-      "Category::Monitoring",
       "Offering::Integration"
     ]
   },

--- a/snmpwalk/manifest.json
+++ b/snmpwalk/manifest.json
@@ -15,7 +15,6 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Monitoring",
       "Category::Notifications",
       "Category::Network"
     ]


### PR DESCRIPTION
### What does this PR do?
Remove deprecated `Monitoring` category from integration manifests so we can complete the deprecation process

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
