### PR TITLE
Deprecate previous Redis Enterprise integration

### DIFF
--- a/redisenterprise/README.md
+++ b/redisenterprise/README.md
@@ -1,4 +1,6 @@
-# Redis Enterprise
+# Redis Enterprise (Deprecated)
+
+** This integration is now deprecated. Please use the latest [Redis Enterprise Datadog Integration](https://app.datadoghq.com/integrations/redis-enterprise) going forward. This new integration exposes all of the latest Redis Enterprise metrics and includes updated dashboards.**
 
 ![img](https://raw.githubusercontent.com/DataDog/integrations-extras/master/redisenterprise/images/redis-enterprise.jpg)
 

--- a/redisenterprise/manifest.json
+++ b/redisenterprise/manifest.json
@@ -9,7 +9,7 @@
     "support": "README.md#Support",
     "changelog": "CHANGELOG.md",
     "description": "Redis Enterprise Observability",
-    "title": "RedisEnterprise",
+    "title": "RedisEnterprise (Deprecated)",
     "media": [],
     "classifier_tags": [
       "Supported OS::Linux",


### PR DESCRIPTION
### What does this PR do?

Marks the previous Redis Enterprise integration as deprecated.

### Motivation

We've published a new integration, which now live: [Redis Enterprise Integration](https://github.com/redis-field-engineering/datadog-integrations-extras/pull/new/deprecate-redisenterprise-integration)

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [X] Feature or bugfix has tests
- [X] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
