### PR TITLE
[CODEOWNERS] Assign ownership of Dashboard Assets to the reporting-and-sharing team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 **/README.md                             @DataDog/documentation @DataDog/agent-integrations
 **/*metadata.csv                         @DataDog/documentation @DataDog/agent-integrations
 **/manifest.json                         @DataDog/documentation @DataDog/agent-integrations
-**/assets/dashboards                     @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations
+**/assets/dashboards                     @DataDog/documentation @DataDog/reporting-and-sharing @DataDog/agent-integrations
 **/assets/monitors                       @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
 **/assets/logs/                          @DataDog/agent-integrations @DataDog/logs-backend
 


### PR DESCRIPTION
### What does this PR do?

Updates `CODEOWNERS` to reflect a change in ownership.

### Motivation

The reporting-and-sharing team is taking over ownership of Dashboard Assets.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
