### PR TITLE
[ecos 1459] Move all marketplace further reading readme sections to the manifest

### DIFF
--- a/akamai_datastream_2/manifest.json
+++ b/akamai_datastream_2/manifest.json
@@ -17,6 +17,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/monitor-akamai-datastream2/"
+      }
     ]
   },
   "author": {

--- a/apache-apisix/manifest.json
+++ b/apache-apisix/manifest.json
@@ -17,6 +17,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://apisix.apache.org/blog/2021/11/12/apisix-datadog"
+      }
     ]
   },
   "author": {

--- a/apptrail/manifest.json
+++ b/apptrail/manifest.json
@@ -48,24 +48,6 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
-    ],
-    "resources": [
-      {
-        "resource_type": "documentation",
-        "url": "https://apptrail.com/docs/consumers/guide"
-      },
-      {
-        "resource_type": "documentation",
-        "url": "https://apptrail.com/docs/consumers/guide/event-delivery/integrations/datadog"
-      },
-      {
-        "resource_type": "documentation",
-        "url": "https://apptrail.com/docs/consumers/guide/event-format"
-      },
-      {
-        "resource_type": "documentation",
-        "url": "https://apptrail.com/docs/consumers/guide/event-delivery/#trails"
-      }
     ]
   },
   "author": {

--- a/apptrail/manifest.json
+++ b/apptrail/manifest.json
@@ -48,6 +48,24 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "documentation",
+        "url": "https://apptrail.com/docs/consumers/guide"
+      },
+      {
+        "resource_type": "documentation",
+        "url": "https://apptrail.com/docs/consumers/guide/event-delivery/integrations/datadog"
+      },
+      {
+        "resource_type": "documentation",
+        "url": "https://apptrail.com/docs/consumers/guide/event-format"
+      },
+      {
+        "resource_type": "documentation",
+        "url": "https://apptrail.com/docs/consumers/guide/event-delivery/#trails"
+      }
     ]
   },
   "author": {

--- a/cloudnatix/manifest.json
+++ b/cloudnatix/manifest.json
@@ -34,6 +34,12 @@
       "Supported OS::macOS",
       "Submitted Data Type::Metrics",
       "Offering::Integration"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/infrastructure-optimization-rightsizing-cloudnatix-datadog/"
+      }
     ]
   },
   "assets": {

--- a/convox/manifest.json
+++ b/convox/manifest.json
@@ -18,6 +18,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/monitor-aws-ecs-convox-integration/"
+      }
     ]
   },
   "author": {

--- a/datazoom/manifest.json
+++ b/datazoom/manifest.json
@@ -16,6 +16,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/monitor-datazoom/"
+      }
     ]
   },
   "author": {

--- a/devcycle/manifest.json
+++ b/devcycle/manifest.json
@@ -1,30 +1,40 @@
 {
-    "manifest_version": "2.0.0",
-    "app_uuid": "a550d328-e35d-445b-8d13-d12b2c7da5d2",
-    "app_id": "devcycle",
-    "display_on_public_website": true,
-    "tile": {
-        "overview": "README.md#Overview",
-        "configuration": "README.md#Setup",
-        "support": "README.md#Support",
-        "changelog": "CHANGELOG.md",
-        "description": "Feature Flags That Work the Way You Code",
-        "title": "DevCycle",
-        "media": [],
-        "classifier_tags": [
-            "Category::Configuration & Deployment",
-            "Category::Notifications",
-            "Offering::Integration",
-            "Supported OS::Linux",
-            "Supported OS::Windows",
-            "Supported OS::macOS"
-        ]
-    },
-    "assets": {},
-    "author": {
-        "support_email": "support@devcycle.com",
-        "name": "DevCycle",
-        "homepage": "https://devcycle.com",
-        "sales_email": "sales@devcycle.com"
-    }
+  "manifest_version": "2.0.0",
+  "app_uuid": "a550d328-e35d-445b-8d13-d12b2c7da5d2",
+  "app_id": "devcycle",
+  "display_on_public_website": true,
+  "tile": {
+    "overview": "README.md#Overview",
+    "configuration": "README.md#Setup",
+    "support": "README.md#Support",
+    "changelog": "CHANGELOG.md",
+    "description": "Feature Flags That Work the Way You Code",
+    "title": "DevCycle",
+    "media": [],
+    "classifier_tags": [
+      "Category::Configuration & Deployment",
+      "Category::Notifications",
+      "Offering::Integration",
+      "Supported OS::Linux",
+      "Supported OS::Windows",
+      "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "other",
+        "url": "https://devcycle.com"
+      },
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.devcycle.com/tools-and-integrations/datadog-rum"
+      }
+    ]
+  },
+  "assets": {},
+  "author": {
+    "support_email": "support@devcycle.com",
+    "name": "DevCycle",
+    "homepage": "https://devcycle.com",
+    "sales_email": "sales@devcycle.com"
+  }
 }

--- a/f5-distributed-cloud/manifest.json
+++ b/f5-distributed-cloud/manifest.json
@@ -30,6 +30,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "other",
+        "url": "https://www.f5.com/cloud"
+      }
     ]
   },
   "author": {

--- a/gremlin/manifest.json
+++ b/gremlin/manifest.json
@@ -16,6 +16,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/gremlin-datadog/"
+      }
     ]
   },
   "author": {

--- a/instabug/manifest.json
+++ b/instabug/manifest.json
@@ -49,6 +49,12 @@
       "Supported OS::macOS",
       "Category::Alerting",
       "Category::Issue Tracking"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/instabug-mobile-usability/"
+      }
     ]
   },
   "assets": {

--- a/isdown/manifest.json
+++ b/isdown/manifest.json
@@ -34,6 +34,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/track-provider-outages-isdown-datadog/"
+      }
     ]
   },
   "assets": {

--- a/launchdarkly/manifest.json
+++ b/launchdarkly/manifest.json
@@ -36,6 +36,16 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "other",
+        "url": "https://launchdarkly.com"
+      },
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.launchdarkly.com/integrations/datadog/events"
+      }
     ]
   },
   "author": {

--- a/mongodb_atlas/manifest.json
+++ b/mongodb_atlas/manifest.json
@@ -16,6 +16,16 @@
       "Supported OS::Windows",
       "Supported OS::macOS",
       "Category::Metrics"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/monitor-atlas-performance-metrics-with-datadog/"
+      },
+      {
+        "resource_type": "other",
+        "url": "https://www.mongodb.com/products/platform/atlas-for-government"
+      }
     ]
   },
   "assets": {

--- a/ngrok/manifest.json
+++ b/ngrok/manifest.json
@@ -35,6 +35,12 @@
       "Supported OS::Windows",
       "Supported OS::macOS",
       "Queried Data Type::Logs"
+    ],
+    "resources": [
+      {
+        "resource_type": "other",
+        "url": "https://ngrok.com/solutions"
+      }
     ]
   },
   "assets": {

--- a/ns1/manifest.json
+++ b/ns1/manifest.json
@@ -16,6 +16,16 @@
       "Supported OS::Windows",
       "Category::Network",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "documentation",
+        "url": "https://help.ns1.com/hc/en-us/articles/4402752547219"
+      },
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/ns1-monitoring-datadog/"
+      }
     ]
   },
   "author": {

--- a/portworx/manifest.json
+++ b/portworx/manifest.json
@@ -15,6 +15,12 @@
       "Category::Kubernetes",
       "Category::Data Stores",
       "Supported OS::Linux"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/portworx-integration/"
+      }
     ]
   },
   "author": {

--- a/rum_android/manifest.json
+++ b/rum_android/manifest.json
@@ -18,6 +18,12 @@
       "Category::Network",
       "Category::Tracing",
       "Supported OS::Android"
+    ],
+    "resources": [
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.datadoghq.com/real_user_monitoring/android/"
+      }
     ]
   },
   "author": {

--- a/rum_expo/manifest.json
+++ b/rum_expo/manifest.json
@@ -19,6 +19,16 @@
       "Category::Tracing",
       "Supported OS::Android",
       "Supported OS::iOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.datadoghq.com/real_user_monitoring/reactnative/expo/"
+      },
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.datadoghq.com/real_user_monitoring/error_tracking/expo/"
+      }
     ]
   },
   "author": {

--- a/rum_roku/manifest.json
+++ b/rum_roku/manifest.json
@@ -16,6 +16,16 @@
       "Category::Metrics",
       "Category::Network",
       "Category::Tracing"
+    ],
+    "resources": [
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.datadoghq.com/real_user_monitoring/roku/"
+      },
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/monitor-roku-with-rum/"
+      }
     ]
   },
   "author": {

--- a/scalr/manifest.json
+++ b/scalr/manifest.json
@@ -25,6 +25,16 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.scalr.com"
+      },
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.scalr.com/en/latest/integrations.html#datadog"
+      }
     ]
   },
   "assets": {

--- a/seagence/manifest.json
+++ b/seagence/manifest.json
@@ -41,6 +41,12 @@
       "Category::Event Management",
       "Category::Developer Tools",
       "Offering::Integration"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/seagence-datadog-marketplace/"
+      }
     ]
   },
   "assets": {

--- a/shoreline/manifest.json
+++ b/shoreline/manifest.json
@@ -37,6 +37,12 @@
       "Category::Incidents",
       "Offering::UI Extension",
       "Supported OS::Linux"
+    ],
+    "resources": [
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.shoreline.io/"
+      }
     ]
   },
   "author": {

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -16,6 +16,12 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Security"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.signalsciences.com/blog/"
+      }
     ]
   },
   "author": {

--- a/sofy_sofy/manifest.json
+++ b/sofy_sofy/manifest.json
@@ -41,6 +41,16 @@
       "Category::Mobile",
       "Offering::Integration",
       "Submitted Data Type::Metrics"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/sofy-mobile-tests/"
+      },
+      {
+        "resource_type": "documentation",
+        "url": "https://docs.sofy.ai"
+      }
     ]
   },
   "assets": {

--- a/statsig/manifest.json
+++ b/statsig/manifest.json
@@ -16,6 +16,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/feature-monitoring-statsig-datadog-marketplace/"
+      }
     ]
   },
   "author": {

--- a/superwise/manifest.json
+++ b/superwise/manifest.json
@@ -17,6 +17,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/superwise-datadog-marketplace/"
+      }
     ]
   },
   "author": {

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -19,6 +19,12 @@
       "Category::Log Collection",
       "Category::Network",
       "Submitted Data Type::Logs"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/monitor-tailscale-with-datadog/"
+      }
     ]
   },
   "assets": {

--- a/twingate/manifest.json
+++ b/twingate/manifest.json
@@ -29,6 +29,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/monitor-network-access-with-twingate/"
+      }
     ]
   },
   "author": {

--- a/zebrium/manifest.json
+++ b/zebrium/manifest.json
@@ -36,6 +36,12 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"
+    ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/find-the-root-cause-faster-with-zebrium/"
+      }
     ]
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?

Migrates README further reading sections to new manifest field

### Motivation

A new `tile.resources` field was added to the manifest to display rich link previews for further reading resources in the app listings

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
