### PR TITLE
 Update CODEOWNERS to fix failing validations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1102,7 +1102,6 @@
 /syncthing/assets/monitors                      @sashacmc @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
 /syncthing/assets/logs/                         @sashacmc @DataDog/agent-integrations @DataDog/logs-backend
 
-/tailscale/                              @DataDog/documentation @DataDog/saas-integrations
 /taskcall/manifest.json                  @taskcall support@taskcallapp.com @DataDog/documentation @DataDog/ecosystems-review
 /taskcall/README.md                      @taskcall support@taskcallapp.com @DataDog/documentation @DataDog/ecosystems-review
 /taskcall/assets/dashboards                    @taskcall support@taskcallapp.com @DataDog/documentation @DataDog/dashboards-backend @DataDog/agent-integrations


### PR DESCRIPTION
### What does this PR do?
remove superfluous codeowner entry

### Motivation
This is causing validation issues in other PRs (I think it's overriding the logs-backend entry earlier in the file)

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
