### PR TITLE
add missing offering integration classifier tag to all listings

### DIFF
--- a/akamai_datastream_2/manifest.json
+++ b/akamai_datastream_2/manifest.json
@@ -16,7 +16,8 @@
       "Category::Log Collection",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/alertnow/manifest.json
+++ b/alertnow/manifest.json
@@ -19,7 +19,8 @@
       "Category::Mobile",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/algorithmia/manifest.json
+++ b/algorithmia/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Category::Metrics",
       "Category::AI/ML",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/altostra/manifest.json
+++ b/altostra/manifest.json
@@ -18,7 +18,8 @@
       "Category::Automation",
       "Category::Cloud",
       "Category::Configuration & Deployment",
-      "Category::Log Collection"
+      "Category::Log Collection",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/ambassador/manifest.json
+++ b/ambassador/manifest.json
@@ -18,7 +18,8 @@
       "Category::Orchestration",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/amixr/manifest.json
+++ b/amixr/manifest.json
@@ -20,7 +20,8 @@
       "Category::Orchestration",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/apache-apisix/manifest.json
+++ b/apache-apisix/manifest.json
@@ -16,7 +16,8 @@
       "Category::Metrics",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/apollo/manifest.json
+++ b/apollo/manifest.json
@@ -15,7 +15,8 @@
       "Category::Caching",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/appkeeper/manifest.json
+++ b/appkeeper/manifest.json
@@ -16,7 +16,8 @@
       "Category::Cloud",
       "Category::Notifications",
       "Supported OS::Linux",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/apptrail/manifest.json
+++ b/apptrail/manifest.json
@@ -47,7 +47,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/aqua/manifest.json
+++ b/aqua/manifest.json
@@ -17,7 +17,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/auth0/manifest.json
+++ b/auth0/manifest.json
@@ -17,7 +17,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/aws_pricing/manifest.json
+++ b/aws_pricing/manifest.json
@@ -17,7 +17,8 @@
       "Supported OS::Windows",
       "Category::AWS",
       "Category::Cloud",
-      "Category::Cost Management"
+      "Category::Cost Management",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/backstage/manifest.json
+++ b/backstage/manifest.json
@@ -15,7 +15,8 @@
       "Category::Developer Tools",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/bind9/manifest.json
+++ b/bind9/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Category::Network",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/bluematador/manifest.json
+++ b/bluematador/manifest.json
@@ -16,7 +16,8 @@
       "Category::Automation",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/bonsai/manifest.json
+++ b/bonsai/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Category::Metrics",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/botprise/manifest.json
+++ b/botprise/manifest.json
@@ -15,7 +15,8 @@
       "Category::Alerting",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/buddy/manifest.json
+++ b/buddy/manifest.json
@@ -17,7 +17,8 @@
       "Category::Event Management",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/cfssl/manifest.json
+++ b/cfssl/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Network"
+      "Category::Network",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/cloudsmith/manifest.json
+++ b/cloudsmith/manifest.json
@@ -16,7 +16,8 @@
       "Category::Metrics",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/cockroachdb_dedicated/manifest.json
+++ b/cockroachdb_dedicated/manifest.json
@@ -15,7 +15,8 @@
       "Category::Data Stores",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/concourse_ci/manifest.json
+++ b/concourse_ci/manifest.json
@@ -15,7 +15,8 @@
       "Category::Automation",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/configcat/manifest.json
+++ b/configcat/manifest.json
@@ -17,7 +17,8 @@
       "Category::Provisioning",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/contrastsecurity/manifest.json
+++ b/contrastsecurity/manifest.json
@@ -16,7 +16,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/convox/manifest.json
+++ b/convox/manifest.json
@@ -17,7 +17,8 @@
       "Category::Containers",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/cortex/manifest.json
+++ b/cortex/manifest.json
@@ -15,7 +15,8 @@
       "Category::Incidents",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/cribl_stream/manifest.json
+++ b/cribl_stream/manifest.json
@@ -36,7 +36,8 @@
       "Category::Google Cloud",
       "Category::Log Collection",
       "Category::Security",
-      "Category::Metrics"
+      "Category::Metrics",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/cyral/manifest.json
+++ b/cyral/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Category::Data Stores",
       "Category::Security",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/data_runner/manifest.json
+++ b/data_runner/manifest.json
@@ -21,7 +21,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Offering::UI Extension"
+      "Offering::UI Extension",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/datazoom/manifest.json
+++ b/datazoom/manifest.json
@@ -15,7 +15,8 @@
       "Category::Log Collection",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/discord/manifest.json
+++ b/discord/manifest.json
@@ -15,11 +15,11 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS",
-      "Category::Collaboration"
+      "Category::Collaboration",
+      "Offering::Integration"
     ]
   },
-  "assets": {
-  },
+  "assets": {},
   "author": {
     "support_email": "help@datadoghq.com",
     "name": "Datadog",

--- a/docontrol/manifest.json
+++ b/docontrol/manifest.json
@@ -53,7 +53,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/dylibso-webassembly/manifest.json
+++ b/dylibso-webassembly/manifest.json
@@ -24,7 +24,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS",
-      "Submitted Data Type::Traces"
+      "Submitted Data Type::Traces",
+      "Offering::Integration"
     ]
   },
   "assets": {},

--- a/embrace_mobile/manifest.json
+++ b/embrace_mobile/manifest.json
@@ -45,7 +45,8 @@
       "Offering::UI Extension",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/emnify/manifest.json
+++ b/emnify/manifest.json
@@ -39,7 +39,8 @@
     ],
     "classifier_tags": [
       "Category::IoT",
-      "Category::Metrics"
+      "Category::Metrics",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/emqx/manifest.json
+++ b/emqx/manifest.json
@@ -43,7 +43,8 @@
       "Supported OS::macOS",
       "Category::Metrics",
       "Category::IoT",
-      "Submitted Data Type::Metrics"
+      "Submitted Data Type::Metrics",
+      "Offering::Integration"
     ]
   },
   "assets": {
@@ -57,7 +58,9 @@
       },
       "metrics": {
         "prefix": "emqx.",
-        "check": ["emqx.cluster.nodes_running"],
+        "check": [
+          "emqx.cluster.nodes_running"
+        ],
         "metadata_path": "metadata.csv"
       },
       "service_checks": {
@@ -66,9 +69,9 @@
       "source_type_id": 6726047,
       "auto_install": true
     },
-      "dashboards": {
-        "EMQX Overview": "assets/dashboards/overview.json"
-      }
+    "dashboards": {
+      "EMQX Overview": "assets/dashboards/overview.json"
+    }
   },
   "author": {
     "support_email": "contact@emqx.io",

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -16,7 +16,8 @@
       "Category::Data Stores",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/eversql/manifest.json
+++ b/eversql/manifest.json
@@ -38,7 +38,8 @@
       "Category::Developer Tools",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/exim/manifest.json
+++ b/exim/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/fairwinds_insights_ui/manifest.json
+++ b/fairwinds_insights_ui/manifest.json
@@ -22,7 +22,8 @@
       "Offering::UI Extension",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/federatorai/manifest.json
+++ b/federatorai/manifest.json
@@ -16,7 +16,8 @@
       "Category::Kubernetes",
       "Category::AI/ML",
       "Category::Orchestration",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -15,7 +15,8 @@
       "Category::OS & System",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/filemage/manifest.json
+++ b/filemage/manifest.json
@@ -21,7 +21,8 @@
       "Category::Cloud",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "assets": {

--- a/finout/manifest.json
+++ b/finout/manifest.json
@@ -37,7 +37,8 @@
       "Offering::UI Extension",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/fluentbit/manifest.json
+++ b/fluentbit/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Metrics"
+      "Category::Metrics",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/flume/manifest.json
+++ b/flume/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::macOS",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/gatekeeper/manifest.json
+++ b/gatekeeper/manifest.json
@@ -17,7 +17,8 @@
       "Category::Configuration & Deployment",
       "Category::Containers",
       "Category::Security",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/gitea/manifest.json
+++ b/gitea/manifest.json
@@ -16,7 +16,8 @@
       "Category::Source Control",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/gnatsd/manifest.json
+++ b/gnatsd/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Message Queues",
-      "Category::Notifications"
+      "Category::Notifications",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/gnatsd_streaming/manifest.json
+++ b/gnatsd_streaming/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Category::Network",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/go_pprof_scraper/manifest.json
+++ b/go_pprof_scraper/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::macOS",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/gremlin/manifest.json
+++ b/gremlin/manifest.json
@@ -15,7 +15,8 @@
       "Category::Issue Tracking",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/grpc_check/manifest.json
+++ b/grpc_check/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::macOS",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/harness_cloud_cost_management/manifest.json
+++ b/harness_cloud_cost_management/manifest.json
@@ -33,7 +33,8 @@
       "Offering::UI Extension",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/hasura_cloud/manifest.json
+++ b/hasura_cloud/manifest.json
@@ -17,7 +17,8 @@
       "Category::Tracing",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/hbase_master/manifest.json
+++ b/hbase_master/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Data Stores",
-      "Category::Log Collection"
+      "Category::Log Collection",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/hbase_regionserver/manifest.json
+++ b/hbase_regionserver/manifest.json
@@ -17,7 +17,8 @@
       "Category::Log Collection",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/hcp_vault/manifest.json
+++ b/hcp_vault/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::macOS",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/hikaricp/manifest.json
+++ b/hikaricp/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "assets": {

--- a/ilert/manifest.json
+++ b/ilert/manifest.json
@@ -25,7 +25,8 @@
       "Category::Notifications",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/insightfinder/manifest.json
+++ b/insightfinder/manifest.json
@@ -19,7 +19,8 @@
       "Category::AI/ML",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/instabug/manifest.json
+++ b/instabug/manifest.json
@@ -48,7 +48,8 @@
       "Supported OS::Windows",
       "Supported OS::macOS",
       "Category::Alerting",
-      "Category::Issue Tracking"
+      "Category::Issue Tracking",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/invary/manifest.json
+++ b/invary/manifest.json
@@ -23,7 +23,8 @@
       "Category::OS & System",
       "Category::Security",
       "Submitted Data Type::Logs",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "assets": {

--- a/jamf_protect/manifest.json
+++ b/jamf_protect/manifest.json
@@ -13,7 +13,8 @@
     "classifier_tags": [
       "Supported OS::Windows",
       "Supported OS::macOS",
-      "Category::Security"
+      "Category::Security",
+      "Offering::Integration"
     ],
     "media": []
   },

--- a/k6/manifest.json
+++ b/k6/manifest.json
@@ -16,7 +16,8 @@
       "Category::Testing",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/keep/manifest.json
+++ b/keep/manifest.json
@@ -46,7 +46,8 @@
       "Queried Data Type::Metrics",
       "Queried Data Type::Logs",
       "Queried Data Type::Events",
-      "Submitted Data Type::Metrics"
+      "Submitted Data Type::Metrics",
+      "Offering::Integration"
     ]
   },
   "assets": {

--- a/kernelcare/manifest.json
+++ b/kernelcare/manifest.json
@@ -16,7 +16,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/lacework/manifest.json
+++ b/lacework/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Security",
-      "Category::Log Collection"
+      "Category::Log Collection",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/lambdatest/manifest.json
+++ b/lambdatest/manifest.json
@@ -20,7 +20,8 @@
       "Category::Testing",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/lighthouse/manifest.json
+++ b/lighthouse/manifest.json
@@ -13,7 +13,8 @@
     "media": [],
     "classifier_tags": [
       "Category::Developer Tools",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Log Collection"
+      "Category::Log Collection",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/logzio/manifest.json
+++ b/logzio/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::Windows",
       "Category::Event Management",
       "Category::AI/ML",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/mergify/manifest.json
+++ b/mergify/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::Windows",
       "Supported OS::macOS",
       "Submitted Data Type::Metrics",
-      "Category::Developer Tools"
+      "Category::Developer Tools",
+      "Offering::Integration"
     ]
   },
   "assets": {

--- a/mongodb_atlas/manifest.json
+++ b/mongodb_atlas/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS",
-      "Category::Metrics"
+      "Category::Metrics",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/n2ws/manifest.json
+++ b/n2ws/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Cloud"
+      "Category::Cloud",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/neo4j/manifest.json
+++ b/neo4j/manifest.json
@@ -26,7 +26,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Data Stores"
+      "Category::Data Stores",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/neutrona/manifest.json
+++ b/neutrona/manifest.json
@@ -16,7 +16,8 @@
       "Category::Network",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/nextcloud/manifest.json
+++ b/nextcloud/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Collaboration"
+      "Category::Collaboration",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/ngrok/manifest.json
+++ b/ngrok/manifest.json
@@ -34,7 +34,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS",
-      "Queried Data Type::Logs"
+      "Queried Data Type::Logs",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/nn_sdwan/manifest.json
+++ b/nn_sdwan/manifest.json
@@ -16,7 +16,8 @@
       "Category::Notifications",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/nobl9/manifest.json
+++ b/nobl9/manifest.json
@@ -16,7 +16,8 @@
       "Category::Notifications",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/nomad/manifest.json
+++ b/nomad/manifest.json
@@ -15,7 +15,8 @@
       "Category::Configuration & Deployment",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/ns1/manifest.json
+++ b/ns1/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Category::Network",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/nvml/manifest.json
+++ b/nvml/manifest.json
@@ -17,7 +17,8 @@
       "Category::OS & System",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/octoprint/manifest.json
+++ b/octoprint/manifest.json
@@ -15,7 +15,8 @@
       "Category::Developer Tools",
       "Category::Log Collection",
       "Category::Orchestration",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/open_policy_agent/manifest.json
+++ b/open_policy_agent/manifest.json
@@ -17,7 +17,8 @@
       "Category::Containers",
       "Category::Log Collection",
       "Category::Security",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/pagerduty/manifest.json
+++ b/pagerduty/manifest.json
@@ -41,7 +41,8 @@
       "Offering::UI Extension",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/perimeterx/manifest.json
+++ b/perimeterx/manifest.json
@@ -16,7 +16,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/php_apcu/manifest.json
+++ b/php_apcu/manifest.json
@@ -15,7 +15,8 @@
       "Category::Caching",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/php_opcache/manifest.json
+++ b/php_opcache/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::macOS",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/pihole/manifest.json
+++ b/pihole/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Network",
-      "Category::Log Collection"
+      "Category::Log Collection",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/ping/manifest.json
+++ b/ping/manifest.json
@@ -16,7 +16,8 @@
       "Category::Network",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/planetscale/manifest.json
+++ b/planetscale/manifest.json
@@ -12,7 +12,8 @@
     "title": "PlanetScale",
     "media": [],
     "classifier_tags": [
-      "Category::Data Stores"
+      "Category::Data Stores",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/pliant/manifest.json
+++ b/pliant/manifest.json
@@ -19,7 +19,8 @@
       "Category::Provisioning",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/portworx/manifest.json
+++ b/portworx/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Category::Kubernetes",
       "Category::Data Stores",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/postman/manifest.json
+++ b/postman/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::macOS",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/pulumi/manifest.json
+++ b/pulumi/manifest.json
@@ -21,7 +21,8 @@
       "Category::Provisioning",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/puma/manifest.json
+++ b/puma/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Category::Metrics",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/radarr/manifest.json
+++ b/radarr/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "assets": {

--- a/rbltracker/manifest.json
+++ b/rbltracker/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Category::Security",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/reboot_required/manifest.json
+++ b/reboot_required/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Category::Developer Tools",
       "Category::OS & System",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/redis_sentinel/manifest.json
+++ b/redis_sentinel/manifest.json
@@ -15,7 +15,8 @@
       "Category::OS & System",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/redisenterprise/manifest.json
+++ b/redisenterprise/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Data Stores",
-      "Category::Caching"
+      "Category::Caching",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/redpanda/manifest.json
+++ b/redpanda/manifest.json
@@ -16,7 +16,8 @@
       "Category::Message Queues",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/resin/manifest.json
+++ b/resin/manifest.json
@@ -15,7 +15,8 @@
       "Category::Log Collection",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/retool/manifest.json
+++ b/retool/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Developer Tools"
+      "Category::Developer Tools",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/riak_repl/manifest.json
+++ b/riak_repl/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Data Stores"
+      "Category::Data Stores",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rigor/manifest.json
+++ b/rigor/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Category::Testing",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rookout/manifest.json
+++ b/rookout/manifest.json
@@ -32,7 +32,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Offering::UI Extension"
+      "Offering::UI Extension",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rum_android/manifest.json
+++ b/rum_android/manifest.json
@@ -17,7 +17,8 @@
       "Category::Mobile",
       "Category::Network",
       "Category::Tracing",
-      "Supported OS::Android"
+      "Supported OS::Android",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/rum_angular/manifest.json
+++ b/rum_angular/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Category::Metrics",
       "Category::Tracing",
-      "Supported OS::Any"
+      "Supported OS::Any",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rum_cypress/manifest.json
+++ b/rum_cypress/manifest.json
@@ -17,7 +17,8 @@
       "Category::Network",
       "Category::Testing",
       "Category::Tracing",
-      "Supported OS::Any"
+      "Supported OS::Any",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rum_expo/manifest.json
+++ b/rum_expo/manifest.json
@@ -18,7 +18,8 @@
       "Category::Network",
       "Category::Tracing",
       "Supported OS::Android",
-      "Supported OS::iOS"
+      "Supported OS::iOS",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/rum_flutter/manifest.json
+++ b/rum_flutter/manifest.json
@@ -18,7 +18,8 @@
       "Category::Network",
       "Category::Tracing",
       "Supported OS::Android",
-      "Supported OS::iOS"
+      "Supported OS::iOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rum_ios/manifest.json
+++ b/rum_ios/manifest.json
@@ -15,7 +15,8 @@
       "Category::Metrics",
       "Category::Mobile",
       "Category::Tracing",
-      "Supported OS::iOS"
+      "Supported OS::iOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rum_javascript/manifest.json
+++ b/rum_javascript/manifest.json
@@ -15,7 +15,8 @@
       "Category::Languages",
       "Category::Metrics",
       "Category::Tracing",
-      "Supported OS::Any"
+      "Supported OS::Any",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rum_react/manifest.json
+++ b/rum_react/manifest.json
@@ -19,7 +19,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::iOS",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rum_react_native/manifest.json
+++ b/rum_react_native/manifest.json
@@ -18,7 +18,8 @@
       "Category::Network",
       "Category::Tracing",
       "Supported OS::Android",
-      "Supported OS::iOS"
+      "Supported OS::iOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/rum_roku/manifest.json
+++ b/rum_roku/manifest.json
@@ -15,7 +15,8 @@
       "Category::Log Collection",
       "Category::Metrics",
       "Category::Network",
-      "Category::Tracing"
+      "Category::Tracing",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/rundeck/manifest.json
+++ b/rundeck/manifest.json
@@ -18,7 +18,8 @@
       "Category::Orchestration",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/sedai/manifest.json
+++ b/sedai/manifest.json
@@ -20,7 +20,8 @@
       "Category::Provisioning",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/sendmail/manifest.json
+++ b/sendmail/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Category::Metrics",
       "Category::Network",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/shoreline/manifest.json
+++ b/shoreline/manifest.json
@@ -36,7 +36,8 @@
       "Category::Automation",
       "Category::Incidents",
       "Offering::UI Extension",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/signl4/manifest.json
+++ b/signl4/manifest.json
@@ -19,7 +19,8 @@
       "Category::Notifications",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Security"
+      "Category::Security",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/sleuth/manifest.json
+++ b/sleuth/manifest.json
@@ -18,7 +18,8 @@
       "Category::Source Control",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/snmpwalk/manifest.json
+++ b/snmpwalk/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Notifications",
-      "Category::Network"
+      "Category::Network",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/sonarr/manifest.json
+++ b/sonarr/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "assets": {

--- a/sortdb/manifest.json
+++ b/sortdb/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Data Stores"
+      "Category::Data Stores",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/sosivio/manifest.json
+++ b/sosivio/manifest.json
@@ -24,7 +24,8 @@
       "Category::Network",
       "Category::Notifications",
       "Category::Orchestration",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/speedscale/manifest.json
+++ b/speedscale/manifest.json
@@ -18,7 +18,8 @@
       "Category::Testing",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/speedtest/manifest.json
+++ b/speedtest/manifest.json
@@ -17,7 +17,8 @@
       "Category::Testing",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/split/manifest.json
+++ b/split/manifest.json
@@ -17,7 +17,8 @@
       "Category::Event Management",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/sqreen/manifest.json
+++ b/sqreen/manifest.json
@@ -17,7 +17,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/squadcast/manifest.json
+++ b/squadcast/manifest.json
@@ -19,7 +19,8 @@
       "Category::Notifications",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/stackpulse/manifest.json
+++ b/stackpulse/manifest.json
@@ -19,7 +19,8 @@
       "Category::Orchestration",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/stardog/manifest.json
+++ b/stardog/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Category::Data Stores"
+      "Category::Data Stores",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/statsig/manifest.json
+++ b/statsig/manifest.json
@@ -15,7 +15,8 @@
       "Category::Configuration & Deployment",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::Windows",
       "Category::Metrics",
       "Category::Event Management",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/superwise/manifest.json
+++ b/superwise/manifest.json
@@ -16,7 +16,8 @@
       "Category::AI/ML",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/syncthing/manifest.json
+++ b/syncthing/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::Windows",
       "Category::Collaboration",
       "Category::Security",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -18,7 +18,8 @@
       "Category::Security",
       "Category::Log Collection",
       "Category::Network",
-      "Submitted Data Type::Logs"
+      "Submitted Data Type::Logs",
+      "Offering::Integration"
     ],
     "resources": [
       {

--- a/tidb/manifest.json
+++ b/tidb/manifest.json
@@ -17,7 +17,8 @@
       "Supported OS::Windows",
       "Category::Data Stores",
       "Category::Cloud",
-      "Category::Log Collection"
+      "Category::Log Collection",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/tidb_cloud/manifest.json
+++ b/tidb_cloud/manifest.json
@@ -16,7 +16,8 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Cloud",
-      "Category::Data Stores"
+      "Category::Data Stores",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/torq/manifest.json
+++ b/torq/manifest.json
@@ -18,7 +18,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/trino/manifest.json
+++ b/trino/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::macOS",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/twenty_forty_eight/manifest.json
+++ b/twenty_forty_eight/manifest.json
@@ -21,7 +21,8 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
-      "Offering::UI Extension"
+      "Offering::UI Extension",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/tyk/manifest.json
+++ b/tyk/manifest.json
@@ -15,7 +15,8 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Category::Metrics",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/unbound/manifest.json
+++ b/unbound/manifest.json
@@ -16,7 +16,8 @@
       "Category::Network",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/unifi_console/manifest.json
+++ b/unifi_console/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::macOS",
-      "Supported OS::Windows"
+      "Supported OS::Windows",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/upsc/manifest.json
+++ b/upsc/manifest.json
@@ -13,7 +13,8 @@
     "media": [],
     "classifier_tags": [
       "Category::OS & System",
-      "Supported OS::Linux"
+      "Supported OS::Linux",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/uptime/manifest.json
+++ b/uptime/manifest.json
@@ -19,7 +19,8 @@
       "Category::Testing",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/vercel/manifest.json
+++ b/vercel/manifest.json
@@ -18,7 +18,8 @@
       "Category::Provisioning",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/vespa/manifest.json
+++ b/vespa/manifest.json
@@ -13,7 +13,8 @@
     "media": [],
     "classifier_tags": [
       "Supported OS::Linux",
-      "Category::Data Stores"
+      "Category::Data Stores",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/vns3/manifest.json
+++ b/vns3/manifest.json
@@ -17,7 +17,8 @@
       "Category::Security",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/yugabytedb_managed/manifest.json
+++ b/yugabytedb_managed/manifest.json
@@ -51,7 +51,8 @@
       "Category::Azure",
       "Category::Google Cloud",
       "Category::Metrics",
-      "Submitted Data Type::Metrics"
+      "Submitted Data Type::Metrics",
+      "Offering::Integration"
     ]
   },
   "assets": {

--- a/zabbix/manifest.json
+++ b/zabbix/manifest.json
@@ -15,7 +15,8 @@
       "Category::Network",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/zscaler/manifest.json
+++ b/zscaler/manifest.json
@@ -15,7 +15,8 @@
       "Category::Cloud",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Offering::Integration"
     ]
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?

Adds `Offering::Integration` to all listings that are missing it

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
