### PR TITLE
Update Ably dashboard logo

### DIFF
--- a/ably/assets/dashboards/ably.json
+++ b/ably/assets/dashboards/ably.json
@@ -6,7 +6,7 @@
             "id": 5523507568971988,
             "definition": {
                 "type": "image",
-                "url": "https://cdn.bfldr.com/6MCW1TOJ/at/kx2chb7987nf3swh288z3p/ably-logo-col-horiz-rgb.png?auto=webp&format=png",
+                "url": "https://files.ably.com/website/images/brand/v2021/Primary%20Logo/ably-logo-col-pos-reg-512w.png",
                 "sizing": "contain",
                 "margin": "md",
                 "has_background": false,


### PR DESCRIPTION
New Ably logo used in default dashboard.

### What does this PR do?

The Ably logo used in the default Ably dashboard is no longer available. This PR replaces the image with a new version.

### Motivation

Currently the default Ably dashboard has no logo image.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
