### PR TITLE
 [codeowners] Swap monitor-app for alerting product

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 **/*metadata.csv                         @DataDog/documentation @DataDog/agent-integrations
 **/manifest.json                         @DataDog/documentation @DataDog/agent-integrations
 **/assets/dashboards                     @DataDog/documentation @DataDog/reporting-and-sharing @DataDog/agent-integrations
-**/assets/monitors                       @DataDog/documentation @DataDog/monitor-app @DataDog/agent-integrations
+**/assets/monitors                       @DataDog/documentation @DataDog/alerting-product @DataDog/agent-integrations
 
 # Community partners
 /1e/                                     support@1e.com @DataDog/ecosystems-review


### PR DESCRIPTION
### What does this PR do?

Use the newly created alerting-product team for ownership of recommended monitors. This is more appropriate as Monitor App engineering is less well placed to guide other teams on creating these monitors.

### Motivation

What inspired you to submit this pull request?

Updating codeowners across integration repos.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
