### PR TITLE
[MA-5658] Migrate monitor name in manifest to be aligned with monitor asset title

### DIFF
--- a/algorithmia/manifest.json
+++ b/algorithmia/manifest.json
@@ -46,7 +46,7 @@
       "Algorithmia": "assets/dashboards/algorithmia.json"
     },
     "monitors": {
-      "Algorithmia": "assets/monitors/algorithm_duration.json"
+      "Algorithm is taking too long to execute": "assets/monitors/algorithm_duration.json"
     }
   }
 }

--- a/bottomline_recordandreplay/manifest.json
+++ b/bottomline_recordandreplay/manifest.json
@@ -68,7 +68,7 @@
       "Bottomline Record and Replay Overview": "assets/dashboards/bottomline_activity_overview.json"
     },
     "monitors": {
-      "Mainframe resource taking long time to respond": "assets/monitors/bottomline_mainframe_resource_has_problem.json"
+      "Resource response time is very slow": "assets/monitors/bottomline_mainframe_resource_has_problem.json"
     }
   }
 }

--- a/emnify/manifest.json
+++ b/emnify/manifest.json
@@ -71,10 +71,10 @@
       "EMnify Dashboard": "assets/dashboards/emnify_dashboard.json"
     },
     "monitors": {
-      "Daily Traffic Forecast": "assets/monitors/emnify_data_usage_forecast.json",
-      "High Incoming Traffic": "assets/monitors/emnify_data_usage_high_rx.json",
-      "High Outgoing Traffic": "assets/monitors/emnify_data_usage_high_tx.json",
-      "Traffic Transmition Stopped": "assets/monitors/emnify_data_usage_host_stopped.json"
+      "Forecasted data usage is more than expected": "assets/monitors/emnify_data_usage_forecast.json",
+      "Receiving traffic is abnormally high": "assets/monitors/emnify_data_usage_high_rx.json",
+      "Data transmission is abnormally high": "assets/monitors/emnify_data_usage_high_tx.json",
+      "Data exchange has stopped unexpectedly": "assets/monitors/emnify_data_usage_host_stopped.json"
     }
   }
 }

--- a/federatorai/manifest.json
+++ b/federatorai/manifest.json
@@ -54,8 +54,8 @@
       "ProphetStor Federator.ai Cost Management - Namespace": "assets/dashboards/cost-management-namespace-overview.json"
     },
     "monitors": {
-      "Node CPU Load Prediction in Next 24 Hours is High": "assets/monitors/federatorai_node_cpu_prediction.json",
-      "Node Memory Usage Prediction in Next 24 Hours is High": "assets/monitors/federatorai_node_mem_prediction.json"
+      "Node CPU Load prediction is high": "assets/monitors/federatorai_node_cpu_prediction.json",
+      "Node memory usage prediction is high": "assets/monitors/federatorai_node_mem_prediction.json"
     }
   }
 }

--- a/mongodb_atlas/manifest.json
+++ b/mongodb_atlas/manifest.json
@@ -60,11 +60,11 @@
       "source_type_id": 230
     },
     "monitors": {
-      "[MongoDB Atlas] CPU usage is higher than average on host: {{host.name}}": "assets/monitors/high_cpu.json",
-      "[MongoDB Atlas] Memory usage is higher than average on host: {{host.name}}": "assets/monitors/memory.json",
-      "[MongoDB Atlas] Efficiency of queries is degrading": "assets/monitors/query_efficiency.json",
-      "[MongoDB Atlas] Read Latency is higher than average for host: {{host.name}}": "assets/monitors/read_latency.json",
-      "[MongoDB Atlas] Write Latency is higher than average for host: {{host.name}}": "assets/monitors/write_latency.json"
+      "CPU usage is higher than expected": "assets/monitors/high_cpu.json",
+      "Memory usage is higher than normal": "assets/monitors/memory.json",
+      "Query efficiency is degrading": "assets/monitors/query_efficiency.json",
+      "Read latency is higher than expected": "assets/monitors/read_latency.json",
+      "Write latency is higher than expected": "assets/monitors/write_latency.json"
     },
     "dashboards": {
       "MongoDB-Atlas-Overview": "assets/dashboards/MongoDB-Atlas-Overview_dashboard.json",

--- a/nn_sdwan/manifest.json
+++ b/nn_sdwan/manifest.json
@@ -53,8 +53,8 @@
       "Netnology SD-WAN Overview": "assets/dashboards/nn_sdwan_overview.json"
     },
     "monitors": {
-      "High Latency Monitor": "assets/monitors/high-latency-monitor.json",
-      "Packet Loss Monitor": "assets/monitors/packet-loss-monitor.json"
+      "Link latency is high": "assets/monitors/high-latency-monitor.json",
+      "Packet loss percentage is high": "assets/monitors/packet-loss-monitor.json"
     }
   }
 }

--- a/nomad/manifest.json
+++ b/nomad/manifest.json
@@ -47,11 +47,11 @@
       "Nomad Overview": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "Nomad Excessive Leadership Losses": "assets/monitors/nomad_excessive_leadership_losses.json",
-      "Nomad No Jobs Running": "assets/monitors/nomad_no_jobs_running.json",
-      "Nomad Pending Jobs": "assets/monitors/nomad_pending_jobs.json",
-      "Nomad Job Is Failing": "assets/monitors/nomad_job_is_failing.json",
-      "Nomad Heartbeats Received": "assets/monitors/nomad_heartbeats_received.json"
+      "Nomad has excessive leadership losses": "assets/monitors/nomad_excessive_leadership_losses.json",
+      "No Jobs Running": "assets/monitors/nomad_no_jobs_running.json",
+      "Jobs are in pending status": "assets/monitors/nomad_pending_jobs.json",
+      "Nomad jobs are failing": "assets/monitors/nomad_job_is_failing.json",
+      "Nomad heartbeats is low": "assets/monitors/nomad_heartbeats_received.json"
     }
   }
 }

--- a/php_apcu/manifest.json
+++ b/php_apcu/manifest.json
@@ -46,8 +46,8 @@
       "auto_install": true
     },
     "monitors": {
-      "[php_apcu] Detected High Cache Usage": "assets/monitors/php-apcu_high_usage.json",
-      "[php_apcu] Cache Full has been detected": "assets/monitors/php-apcu_expunges.json"
+      "Cache usage is high": "assets/monitors/php-apcu_high_usage.json",
+      "Cache is Full": "assets/monitors/php-apcu_expunges.json"
     }
   }
 }

--- a/php_opcache/manifest.json
+++ b/php_opcache/manifest.json
@@ -45,7 +45,7 @@
       "auto_install": true
     },
     "monitors": {
-      "[php_opcache] Cache Full has been detected": "assets/monitors/php-opcache_expunges.json"
+      "OPcache is full": "assets/monitors/php-opcache_expunges.json"
     }
   }
 }

--- a/seagence/manifest.json
+++ b/seagence/manifest.json
@@ -66,7 +66,7 @@
       "seagence_overview": "assets/dashboards/seagence_overview.json"
     },
     "monitors": {
-      "Seagence Defect Detection": "assets/monitors/defect_detection_monitor.json"
+      "Seagence detected a defect": "assets/monitors/defect_detection_monitor.json"
     },
     "oauth": "assets/oauth_clients.json"
   },

--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -53,7 +53,7 @@
       "sigsci": "assets/dashboards/overview.json"
     },
     "monitors": {
-      "Excessive blocked http requests": "assets/monitors/excessiveblockedHTTP.json"
+      "Firewall is blocking a high number of requests": "assets/monitors/excessiveblockedHTTP.json"
     }
   }
 }

--- a/syncthing/manifest.json
+++ b/syncthing/manifest.json
@@ -52,7 +52,7 @@
     "monitors": {
       "No active connections": "assets/monitors/syncthing_disconnected.json",
       "Files out of sync": "assets/monitors/syncthing_out_of_sync.json",
-      "System errorsr": "assets/monitors/syncthing_system_error.json",
+      "System errors": "assets/monitors/syncthing_system_error.json",
       "Folder errors": "assets/monitors/syncthing_folder_error.json",
       "Service is failed": "assets/monitors/syncthing_service_error.json",
       "Device is not connected": "assets/monitors/syncthing_device_not_connected.json"

--- a/syncthing/manifest.json
+++ b/syncthing/manifest.json
@@ -50,12 +50,12 @@
       "Syncthing Overview": "assets/dashboards/syncthing_overview.json"
     },
     "monitors": {
-      "[Syncthing] Disconnected": "assets/monitors/syncthing_disconnected.json",
-      "[Syncthing] Out of sync": "assets/monitors/syncthing_out_of_sync.json",
-      "[Syncthing] System error": "assets/monitors/syncthing_system_error.json",
-      "[Syncthing] Folder error": "assets/monitors/syncthing_folder_error.json",
-      "[Syncthing] Service error": "assets/monitors/syncthing_service_error.json",
-      "[Syncthing] Device not connected": "assets/monitors/syncthing_device_not_connected.json"
+      "No active connections": "assets/monitors/syncthing_disconnected.json",
+      "Files out of sync": "assets/monitors/syncthing_out_of_sync.json",
+      "System errorsr": "assets/monitors/syncthing_system_error.json",
+      "Folder errors": "assets/monitors/syncthing_folder_error.json",
+      "Service is failed": "assets/monitors/syncthing_service_error.json",
+      "Device is not connected": "assets/monitors/syncthing_device_not_connected.json"
     }
   }
 }

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -45,8 +45,8 @@
       "tailscale-overview": "assets/dashboards/tailscale_overview.json"
     },
     "monitors": {
-      "Virtual Bytes Received by Destination": "assets/monitors/virtual_traffic_received.json",
-      "Physical Bytes Received by Destination": "assets/monitors/physical_traffic_received.json"
+      "High Virtual Traffic Received by Destination": "assets/monitors/virtual_traffic_received.json",
+      "High Physical Traffic Received by Destination": "assets/monitors/physical_traffic_received.json"
     }
   },
   "author": {

--- a/upbound_uxp/manifest.json
+++ b/upbound_uxp/manifest.json
@@ -60,7 +60,7 @@
       "upbound_uxp_min_set": "assets/dashboards/upbound_uxp_min_set.json"
     },
     "monitors": {
-      "[upbound] monitor controller runtime reconcoile error": "assets/monitors/controller_runtime_reconcile_error.json"
+      "Upbound UXP encountered reconciliation errors": "assets/monitors/controller_runtime_reconcile_error.json"
     },
     "logs": {}
   },

--- a/zenoh_router/manifest.json
+++ b/zenoh_router/manifest.json
@@ -46,7 +46,7 @@
       "Zenoh routers - Overview": "assets/dashboards/zenoh_routers_overview.json"
 	},
     "monitors": {
-      "[Zenoh router] Disconnected": "assets/monitors/zenoh_router_disconnected.json"
+      "No active sessions": "assets/monitors/zenoh_router_disconnected.json"
 	}
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?

change manifest monitor titles to match titles specified in monitor asset file.


### Motivation

https://datadoghq.atlassian.net/browse/MA-5658

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
