### PR TITLE
Add lint rule to ignore B017

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ exclude = '''
 '''
 include = '\.pyi?$'
 line-length = 120
-py36 = false
 skip-string-normalization = true
 
 [tool.ruff]
@@ -36,7 +35,7 @@ exclude = [
 target-version = "py38"
 line-length = 120
 # Import settings from legacy flake8 config
-select = [
+lint.select = [
   "B",
   "C",
   "E",
@@ -45,7 +44,7 @@ select = [
   "W",
   "I",
 ]
-ignore = [
+lint.ignore = [
   # From legacy flake8 settings
   "E722",
   "E741",
@@ -55,19 +54,20 @@ ignore = [
   "B027",
   # Ignore McCabe complexity
   "C901",
+  "B017",
 ]
-unfixable = [
+lint.unfixable = [
   # Don't touch unused imports
   "F401",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["{template_config['package_name']}"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 #Tests can use assertions and relative imports
 "**/tests/**/*" = ["S101", "TID252"]
 "tests/models/config_models/deprecations.py" = ["E501"]


### PR DESCRIPTION
### What does this PR do?

This gets rid of the lint errors running in our CI:
```
B017 `pytest.raises(Exception)` should be considered evil
```

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
