### PR TITLE
Clarify which repo to clone in hikaricp/README.md

### DIFF
--- a/hikaricp/README.md
+++ b/hikaricp/README.md
@@ -14,11 +14,13 @@ To install the HikariCP check on your host:
 1. Install the [developer toolkit][10]
  on any machine.
 
-2. Run `ddev release build hikaricp` to build the package.
+2. Clone the [integrations-extras][12] repo and navigate into the directory.
 
-3. [Download the Datadog Agent][2].
+3. Run `ddev release build hikaricp` to build the package.
 
-4. Upload the build artifact to any host with an Agent and
+4. [Download the Datadog Agent][2].
+
+5. Upload the build artifact to any host with an Agent and
  run `datadog-agent integration install -w
  path/to/hikaricp/dist/<ARTIFACT_NAME>.whl`.
 
@@ -61,4 +63,4 @@ Need help? Contact [Datadog support][9].
 [9]: https://docs.datadoghq.com/help/
 [10]: https://docs.datadoghq.com/developers/integrations/python/
 [11]: https://github.com/DataDog/integrations-extras/blob/master/hikaricp/assets/service_checks.json
-
+[12]: https://github.com/DataDog/integrations-extras


### PR DESCRIPTION
### What does this PR do?
This PR clarifies an additional step to install the HikariCP integration. 

### Motivation
The following doc doesn't say that you need to clone `integration-extra` repo before running ddev.
https://docs.datadoghq.com/integrations/hikaricp/

If you don't know this repo, you might get stuck with the setup.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
