### PR TITLE
Accept Merge Group events to trigger the required CI check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
     - master
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}


### PR DESCRIPTION
### What does this PR do?

Allow accepting "merge group" events that get triggered from Merge Queue lifecycle actions

### Motivation

We ultimately want to enable Merge Queues in this repository to provide stronger CI validations; however with `test` being a required workflow, the CI must be updated to support the Merge Queue event types - https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues

This PR doesn't enable Merge Queues itself, but rather is a pre-req for enabling the feature when we're ready. 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
