### PR TITLE
Allow lighthouse to accept parameters

### DIFF
--- a/lighthouse/datadog_checks/lighthouse/data/conf.yaml.example
+++ b/lighthouse/datadog_checks/lighthouse/data/conf.yaml.example
@@ -43,6 +43,15 @@ instances:
     #   - <FLAG_1>
     #   - <FLAG_2>
 
+    ## @param lighthouse_parameters - list - optional
+    ## List of lighthouse parameters in addition to `--output json --quiet --chrome-flags='{}'`
+    ##
+    ## Learn more about flags: https://github.com/GoogleChrome/lighthouse
+    #
+    # lighthouse_parameters:
+    #   - <FLAG_1>
+    #   - <FLAG_2>
+
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.
     ##

--- a/lighthouse/datadog_checks/lighthouse/lighthouse.py
+++ b/lighthouse/datadog_checks/lighthouse/lighthouse.py
@@ -15,6 +15,7 @@ class LighthouseCheck(AgentCheck):
         lighthouse_urls = instance.get('urls', [])
         lighthouse_name = instance.get('name')
         extra_chrome_flags = instance.get('extra_chrome_flags', [])
+        lighthouse_parameters = instance.get('lighthouse_parameters', [])
         form_factor = instance.get('form_factor')
 
         if backward_compatible_lighthouse_url:
@@ -43,6 +44,10 @@ class LighthouseCheck(AgentCheck):
                 cmd.append("--form-factor=" + form_factor)
                 if form_factor == "desktop":
                     cmd.append("--preset=desktop")
+
+            if lighthouse_parameters:
+                for parameter in lighthouse_parameters:
+                    cmd.append(parameter)
 
             json_string, error_message, exit_code = LighthouseCheck._get_lighthouse_report(cmd, self.log, False)
 


### PR DESCRIPTION
### What does this PR do?

Allows parameters to be defined in the config file that will be passed to lighthouse.

### Motivation

The goal was to bypass an issue where lighthouse ignores the user agent passed by `--chrome-args`, so this change helps facilitate the user agent to be passed to lighthouse through `--emulatedUserAgent`

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
