### PR TITLE
Update Modal uninstallation instructions

### DIFF
--- a/modal/README.md
+++ b/modal/README.md
@@ -45,10 +45,14 @@ There are no metrics collected for this integration.
 Once this integration has been uninstalled, any previous authorizations are
 revoked and logs/metrics stop being emitted to Datadog.
 
-1. On the **Configure** tab in the **Modal** integration tile in Datadog, click **Uninstall Integration**.
-
-2. Ensure that all API keys associated with this integration have been disabled
-   by searching for the integration name on the [API Keys page][4].
+1. Navigate to the [Modal metrics settings page](http://modal.com/settings/metrics)
+   and select **Delete Datadog Integration**.
+2. On the **Configure** tab in the Modal integration tile in Datadog,
+   click **Uninstall Integration**.
+3. Confirm that you want to uninstall the integration.
+4. Ensure that all API keys associated with this integration have been
+   disabled by searching for the integration name on the [API Keys](https://app.datadoghq.com/organization-settings/api-keys?filter=Modal)
+   page.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What does this PR do?

This commit updates the Modal uninstallation instructions to include details about actuating the change Modal-side.

### Motivation

We recently changed our uninstallation process, and we want the tile to match the instructions in our docs:
https://modal.com/docs/guide/datadog-integration#uninstalling-the-integration

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If this PR includes a log pipeline, please add a description describing the remappers and processors. 
