### PR TITLE
(docs build) Add media key to cloudquery-cloud manifest

### DIFF
--- a/cloudquery-cloud/manifest.json
+++ b/cloudquery-cloud/manifest.json
@@ -5,6 +5,7 @@
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
+    "media": [],
     "configuration": "README.md#Setup",
     "support": "README.md#Support",
     "uninstallation": "README.md#Uninstallation",


### PR DESCRIPTION
### What does this PR do?

Adds a media key to the manifest

### Motivation

This is currently breaking the docs build.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
