### PR TITLE
INTPLAT-231: dismiss-stale-reviews

### DIFF
--- a/.github/workflows/dismiss-stale-reviews.yaml
+++ b/.github/workflows/dismiss-stale-reviews.yaml
@@ -1,0 +1,28 @@
+name: 'dismiss-stale-reviews'
+on:
+  pull_request:
+
+jobs:
+  dismiss-stale-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the git history must be fetched until merge-base commit of pull-request
+          fetch-depth: 0
+
+      # in case you use team handles in your CODEOWNERS file, you need to get a GitHub App token with advanced permissions:
+      # repository contents: read
+      # repository pull requests: write
+      # organization members: read
+      #
+      # for more info on how to use GitHub App token check https://github.com/actions/create-github-app-token
+      - uses: actions/create-github-app-token@v1
+        id: get-token
+        with:
+          private-key: ${{ secrets.DD_INTEGRATIONS_PLATFORM_PRIVATE_KEY }}
+          app-id: ${{ vars.DD_INTEGRATIONS_PLATFORM_APP_ID }}
+
+      - uses: balvajs/dismiss-stale-reviews@v3
+        with:
+          token: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
### What does this PR do?

This yaml file defines a workflow that uses balvajs/dismiss-stale-reviews@v3 GitHub action to dismiss stale reviews based on file ownerships (smarter compared to default GitHub behavior). For example:

1. User1 makes a PR that changes file-a, owned by group-a, and file-b, owned by group-b.
2. The PR was approved by both group-a and group-b.
3. User1 updated file-b.
4a. (GitHub default behavior) Approvals from both group-a and group-b are dismissed.
4b. (New behavior) Group-b's approval is dismissed. Group-a's approval is still valid.

See [here](https://github.com/DataDog/crawler-sdk/pull/205) for a real example.

This is already added to [integrations-internal-core](https://github.com/DataDog/integrations-internal-core/blob/main/.github/workflows/dismiss-stale-reviews.yaml) for a week and we haven't see any issues so far.

To use this we need to:

- [ ] Merge in this PR
- [x] Grant @davidfeng-datadog the repo superpower to add repo secrets and variables for DD_INTEGRATIONS_PLATFORM_PRIVATE_KEY and DD_INTEGRATIONS_PLATFORM_APP_ID
- [x] File a freshservice ticket to install the [GitHub app](https://github.com/apps/dd-integrations-platform) in this repo.
- [ ] @davidfeng-datadog to check the PRs after a few days to make sure it is working as intended.

[PR for integrations-core](https://github.com/DataDog/integrations-core/pull/18699)
### Motivation


### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
