### PR TITLE
[Logstash] Replace `distutils.version` with `looseversion`

### DIFF
--- a/logstash/CHANGELOG.md
+++ b/logstash/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - Logstash
 
+## 1.2.0
+
+***Fixed***:
+
+* distutils is deprecated with removal planned for Python 3.12.
+
 ## 1.1.0
 
 ***Added***:

--- a/logstash/CHANGELOG.md
+++ b/logstash/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Fixed***:
 
-* distutils is deprecated with removal planned for Python 3.12.
+* replace `distutils.version` with `looseversion` since `disutils` was removed in Python 3.12.
 
 ## 1.1.0
 

--- a/logstash/datadog_checks/logstash/logstash.py
+++ b/logstash/datadog_checks/logstash/logstash.py
@@ -1,8 +1,8 @@
 # stdlib
 from collections import namedtuple
-from looseversion import LooseVersion
 
 # 3rd party
+from looseversion import LooseVersion
 from six import iteritems
 from six.moves.urllib.parse import urljoin, urlparse
 

--- a/logstash/datadog_checks/logstash/logstash.py
+++ b/logstash/datadog_checks/logstash/logstash.py
@@ -1,6 +1,6 @@
 # stdlib
 from collections import namedtuple
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 
 # 3rd party
 from six import iteritems

--- a/logstash/hatch.toml
+++ b/logstash/hatch.toml
@@ -7,4 +7,5 @@ python = ["3.12"]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [envs.default]
+dependencies = ["looseversion"]
 e2e-env = false


### PR DESCRIPTION
### What does this PR do?

 Replace `distutils.version` with `looseversion`.

### Motivation

- https://docs.python.org/3.12/library/distutils.html
- https://github.com/DataDog/datadog-agent/pull/29664
- https://pypi.org/project/looseversion/

We can not use Logstash since `7.58.x` that requires python 3.12.

```bash
docker run --name datadog-agent -d --cgroupns host --pid host \
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-e DD_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
-e DD_LOG_LEVEL=debug \
$(docker build -t datadog-agent --quiet -<<-EOD
FROM datadog/agent:7.58.2
RUN <<RUN1
agent integration install -t -r datadog-logstash==1.1.0
RUN1
COPY --chmod=755 <<"CONFIG1" /etc/datadog-agent/conf.d/logstash.yaml
init_config:
instances:
- url: http://localhost:9600/
CONFIG1
EOD
)
```

we cannot load python module, `logstash`.

```
# 7.57.0
2024-11-15 05:11:29 UTC | CORE | DEBUG | (pkg/collector/python/loader.go:235 in Load) | python loader: done loading check logstash (version 1.1.0)

# 7.58.0
2024-11-15 05:02:06 UTC | CORE | DEBUG | (pkg/collector/python/loader.go:162 in Load) | Unable to load python module - datadog_checks.logstash: unable to import module 'datadog_checks.logstash': Traceback (most recent call last):
2024-11-15 05:02:06 UTC | CORE | DEBUG | (pkg/collector/python/loader.go:162 in Load) | Unable to load python module - logstash: unable to import module 'logstash': No module named 'logstash'
2024-11-15 05:02:06 UTC | CORE | DEBUG | (pkg/collector/python/loader.go:170 in Load) | PyLoader returning unable to import module 'logstash': No module named 'logstash' for logstash
```

After running `sed -i 's/from distutils\.version import LooseVersion/from looseversion import LooseVersion/g' /opt/datadog-agent/embedded/lib/python3.12/site-packages/datadog_checks/logstash/*.py` and `/opt/datadog-agent/embedded/bin/python -m pip install looseversion`, it works!!

```bash
docker run --name datadog-agent -d --cgroupns host --pid host \
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-e DD_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
$(docker build -t datadog-agent --quiet -<<-EOD
FROM datadog/agent:7.59.0
RUN <<RUN1
agent integration install -t -r datadog-logstash==1.1.0
/opt/datadog-agent/embedded/bin/python -m pip install looseversion
sed -i 's/from distutils\.version import LooseVersion/from looseversion import LooseVersion/g' /opt/datadog-agent/embedded/lib/python3.12/site-packages/datadog_checks/logstash/*.py
RUN1
COPY --chmod=755 <<"COPY1"/etc/datadog-agent/conf.d/logstash.d/conf.yaml
init_config:
instances:
- url: http://localhost:9600/
COPY1
EOD
)
```

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
