### PR TITLE
unifi_console: add @smart_retry decoration to status() method to avoid 401 errors

### DIFF
--- a/unifi_console/datadog_checks/unifi_console/unifi.py
+++ b/unifi_console/datadog_checks/unifi_console/unifi.py
@@ -80,6 +80,7 @@ class Unifi:
             err_msg = "Connection to {} failed: {}".format(self.__path(APILoginPath), e)
             raise APIConnectionError(err_msg) from None
 
+    @smart_retry
     def status(self) -> ControllerInfo:
         resp = self._get_json(APIStatusPath)
         return ControllerInfo(resp)


### PR DESCRIPTION
### What does this PR do?

The Unifi integration uses the API to connect to the auth/login endpoint and then uses the `persist_connections` feature to store the cookies and send them with further requests.
For some reason, after some time this seems to expire and it leads to 401 errors.

### Motivation

I received a custom build from Datadog support which included this fix. I tested it and it looks fine for me to add to the actual unifi_console check.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests

This fixes the issue https://github.com/DataDog/integrations-extras/issues/2558 

