### PR TITLE
Update reference link to the fluent bit log collection docs

### DIFF
--- a/fluentbit/README.md
+++ b/fluentbit/README.md
@@ -44,7 +44,6 @@ For Agent v7.21+ / v6.21+, follow the instructions below to install the Fluent B
 
 2. [Restart the Agent][6].
 
-
 ### Validation
 
 [Run the Agent's status subcommand][7] and look for `fluentbit` under the Checks section.

--- a/fluentbit/README.md
+++ b/fluentbit/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This check monitors [Fluent Bit][1] metrics through the Datadog Agent. For sending logs to Datadog with Fluent Bit, see the [Fluent Bit][11] documentation to learn about the Datadog Fluent Bit output plugin.
+This check monitors [Fluent Bit][1] metrics through the Datadog Agent. To send logs to Datadog with Fluent Bit and to learn about the Datadog Fluent Bit output plugin, see the [Fluent Bit][11] documentation.
 
 ## Fluent Bit configuration
 Fluent Bit doesn't expose its internal metrics by default. You need to enable the built-in HTTP server that exposes the metrics endpoint.
@@ -15,8 +15,6 @@ See the official [documentation][2] for more information.
 ## Setup
 
 Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][4] for guidance on applying these instructions.
-
-### Installation
 
 ### Installation
 
@@ -46,6 +44,7 @@ For Agent v7.21+ / v6.21+, follow the instructions below to install the Fluent B
 
 2. [Restart the Agent][6].
 
+
 ### Validation
 
 [Run the Agent's status subcommand][7] and look for `fluentbit` under the Checks section.
@@ -68,6 +67,12 @@ The Fluent Bit integration does not include any service checks.
 
 Need help? Contact [Datadog support][10].
 
+## Further Reading
+
+Additional helpful documentation, links, and articles:
+
+- [Send Fluent Bit Logs to Datadog][11]
+
 
 [1]: https://fluentbit.io
 [2]: https://docs.fluentbit.io/manual/administration/monitoring
@@ -79,5 +84,5 @@ Need help? Contact [Datadog support][10].
 [8]: https://github.com/DataDog/integrations-extras/blob/master/fluentbit/metadata.csv
 [9]: https://github.com/DataDog/integrations-extras/blob/master/fluentbit/assets/service_checks.json
 [10]: https://docs.datadoghq.com/help/
-[11]: https://docs.datadoghq.com/integrations/fluentbit/
+[11]: https://docs.datadoghq.com/logs/guide/fluentbit/
 [12]: https://docs.datadoghq.com/developers/integrations/python/

--- a/fluentbit/datadog_checks/fluentbit/config_models/instance.py
+++ b/fluentbit/datadog_checks/fluentbit/config_models/instance.py
@@ -25,7 +25,7 @@ class AuthToken(BaseModel):
     writer: Optional[MappingProxyType[str, Any]] = None
 
 
-class ExtraMetric(BaseModel):
+class ExtraMetrics(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         extra='allow',
@@ -44,7 +44,7 @@ class MetricPatterns(BaseModel):
     include: Optional[tuple[str, ...]] = None
 
 
-class Metric(BaseModel):
+class Metrics(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         extra='allow',
@@ -64,7 +64,7 @@ class Proxy(BaseModel):
     no_proxy: Optional[tuple[str, ...]] = None
 
 
-class ShareLabel(BaseModel):
+class ShareLabels(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         frozen=True,
@@ -97,7 +97,7 @@ class InstanceConfig(BaseModel):
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
-    extra_metrics: Optional[tuple[Union[str, MappingProxyType[str, Union[str, ExtraMetric]]], ...]] = None
+    extra_metrics: Optional[tuple[Union[str, MappingProxyType[str, Union[str, ExtraMetrics]]], ...]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
     histogram_buckets_as_distributions: Optional[bool] = None
     hostname_format: Optional[str] = None
@@ -114,7 +114,7 @@ class InstanceConfig(BaseModel):
     kerberos_principal: Optional[str] = None
     log_requests: Optional[bool] = None
     metric_patterns: Optional[MetricPatterns] = None
-    metrics: Optional[tuple[Union[str, MappingProxyType[str, Union[str, Metric]]], ...]] = None
+    metrics: Optional[tuple[Union[str, MappingProxyType[str, Union[str, Metrics]]], ...]] = None
     metrics_endpoint: str
     min_collection_interval: Optional[float] = None
     namespace: Optional[str] = Field(None, pattern='\\w*')
@@ -130,7 +130,7 @@ class InstanceConfig(BaseModel):
     rename_labels: Optional[MappingProxyType[str, Any]] = None
     request_size: Optional[float] = None
     service: Optional[str] = None
-    share_labels: Optional[MappingProxyType[str, Union[bool, ShareLabel]]] = None
+    share_labels: Optional[MappingProxyType[str, Union[bool, ShareLabels]]] = None
     skip_proxy: Optional[bool] = None
     tag_by_endpoint: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None


### PR DESCRIPTION
### What does this PR do?

Update reference link to the fluent bit log collection guide

### Motivation
- Moved the log collection docs so the agent check docs are the default integration information available for users.
- Merge after [Docs PR is merged](https://github.com/DataDog/documentation/pull/26980)

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
