### PR TITLE
Update k6 output parameter

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -48,7 +48,7 @@ For the detailed instructions, follow the [k6 documentation][2].
     Once the Datadog Agent service is running, run the k6 test and send the metrics to the Agent with:
 
     ```shell
-    K6_STATSD_ENABLE_TAGS=true k6 run --out statsd script.js
+    K6_STATSD_ENABLE_TAGS=true k6 run --out xk6-output-statsd script.js
     ```
 
 4. Visualize the k6 metrics in Datadog.


### PR DESCRIPTION
### What does this PR do?

Updates the output parameter in the example output command. K6 no longer supports `statsd` output. The replacement is `xk6-output-statsd`. Reference: https://datadog.zendesk.com/agent/tickets/1997585.

### Motivation

Requested in #documentation Slack by solutions engineer Axel Ulises Ramirez Hernandez.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
