### PR TITLE
Update Renamed Trino JMX Beans

### DIFF
--- a/trino/datadog_checks/trino/data/metrics.yaml
+++ b/trino/datadog_checks/trino/data/metrics.yaml
@@ -120,18 +120,18 @@ jmx_metrics:
         WallInputBytesRate.OneMinute.P95:
           alias: trino.execution.wall_input_bytes_rate.one_minute.p95
   - include:
-      bean: trino.execution.executor:name=TaskExecutor
+      bean: trino.execution.executor.timesharing:name=TimeSharingTaskExecutor
       attribute:
         BlockedSplits:
-          alias: trino.execution.executor.blocked_splits
+          alias: trino.execution.executor.timesharing.blocked_splits
         ProcessorExecutor.QueuedTaskCount:
-          alias: trino.execution.executor.processor_executor.queued_task_count
+          alias: trino.execution.executor.timesharing.processor_executor.queued_task_count
         RunningSplits:
-          alias: trino.execution.executor.running_splits
+          alias: trino.execution.executor.timesharing.running_splits
         TotalSplits:
-          alias: trino.execution.executor.total_splits
+          alias: trino.execution.executor.timesharing.total_splits
         WaitingSplits:
-          alias: trino.execution.executor.waiting_splits
+          alias: trino.execution.executor.timesharing.waiting_splits
   - include:
       domain: trino.memory
       attribute:


### PR DESCRIPTION
### What does this PR do?

[This PR ](https://github.com/trinodb/trino/pull/22914) renamed some Trino JMX beans. This PR updates the Trino JMX integration to use the new bean names.

### Motivation

Some Trino metrics have been missing from our Trino dashboards due to this. These metrics include examples like blocked splits and total splits.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

N/A
