### PR TITLE
Fix datadog port in docs

### DIFF
--- a/tyk/README.md
+++ b/tyk/README.md
@@ -50,7 +50,7 @@ pump.conf:
    "dogstatsd": {
       "type": "dogstatsd",
       "meta": {
-        "address": "dd-agent:8126",
+        "address": "dd-agent:8125",
         "namespace": "tyk",
         "async_uds": true,
         "async_uds_write_timeout_seconds": 2,


### PR DESCRIPTION
Based on datadog documentation the port of the example/instructions was wrong, this change only corrects the port.

Source docs: https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent

### What does this PR do?

Corrects the port in the config example

### Motivation

I've realized that the port was wrong when integrating datadog and tyk

### Review checklist

- [ x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

