### PR TITLE
📝 add rum-react documentation to the integration page

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,7 +103,6 @@
 /insightfinder/                          @dearmore @erinlmcmahon support@insightfinder.com @DataDog/ecosystems-review
 /isdown/                                 @ntomas support@isdown.app @DataDog/ecosystems-review
 /jamf_protect/                           @DataDog/saas-integrations
-/rum_javascript/                         @DataDog/rum-app
 /k6/                                     @ppcano support@k6.io
 /kameleoon/                              @slava-inyu product@kameleoon.com @DataDog/ecosystems-review
 /kernelcare/                             @grubberr schvaliuk@cloudlinux.com
@@ -170,13 +169,14 @@
 /rigor/                                  support@rigor.com
 /robust_intelligence_ai_firewall/        @MayankR
 /rookout/                                support@rookout.com @DataDog/ecosystems-review
+/rum_javascript/                         @DataDog/rum-app @DataDog/rum-browser
 /rum_android/                            @DataDog/rum-app @DataDog/rum-mobile @DataDog/rum-mobile-android
 /rum_angular/                            @DataDog/rum-app
 /rum_cypress/                            @DataDog/rum-app
 /rum_expo/                               @DataDog/rum-app @DataDog/rum-mobile
 /rum_flutter/                            @DataDog/rum-app @DataDog/rum-mobile
 /rum_ios/                                @DataDog/rum-app @DataDog/rum-mobile @DataDog/rum-mobile-ios
-/rum_react/                              @DataDog/rum-app
+/rum_react/                              @DataDog/rum-app @DataDog/rum-browser
 /rum_react_native/                       @DataDog/rum-app @DataDog/rum-mobile
 /rum_roku/                               @DataDog/rum-app @DataDog/rum-mobile
 /rundeck/                                forrest@rundeck.com

--- a/rum_react/CHANGELOG.md
+++ b/rum_react/CHANGELOG.md
@@ -1,8 +1,11 @@
 # CHANGELOG - React
 
+## 2.0.0
+
+- Add documentation for the RUM React integration plugin
+
 ## 1.0.0
 
-***Added***:
+**_Added_**:
 
-* Initial React RUM Integration Tile.
-
+- Initial React RUM Integration Tile.

--- a/rum_react/CHANGELOG.md
+++ b/rum_react/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 2.0.0
 
-- Add documentation for the RUM React integration plugin
+* Add documentation for the RUM React integration plugin
 
 ## 1.0.0
 
 **_Added_**:
 
-- Initial React RUM Integration Tile.
+* Initial React RUM Integration Tile.

--- a/rum_react/README.md
+++ b/rum_react/README.md
@@ -17,31 +17,13 @@ Monitor your React applications from end-to-end by:
 
 ## Setup
 
-First, make sure to [setup Datadog RUM][1] in your application.
-
-Then, install the `@datadog/browser-rum-react` NPM package using your package manager of choice. For example:
-
-```bash
-npm install @datadog/browser-rum-react
-```
-
-Finally, pass the `reactPlugin` to the `plugins` option of the `datadogRum.init` method:
-
-```javascript
-import { datadogRum } from '@datadog/browser-rum'
-import { reactPlugin } from '@datadog/browser-rum-react'
-
-datadogRum.init({
-  ...
-  plugins: [reactPlugin()],
-})
-```
+Make sure to [setup Datadog RUM][1] in your application. When creating a new RUM application within the Datadog App, make sure to select React. You can also edit an existing RUM application and change its type to React. The Datadog App will then show you the instructions to setup the Browser SDK [RUM-React plugin][2].
 
 ## Error Tracking
 
 To track React component rendering errors, use one of the following:
 
-- An `ErrorBoundary` component (see [React documentation][1]) that catches errors and reports them to Datadog.
+- An `ErrorBoundary` component (see [React documentation][3]) that catches errors and reports them to Datadog.
 - A function that you can use to report errors from your own `ErrorBoundary` component.
 
 #### `ErrorBoundary` usage
@@ -86,9 +68,9 @@ class MyErrorBoundary extends React.Component {
 
 `react-router` v6 allows you to declare routes using the following methods:
 
-- Create routers with [`createMemoryRouter`][3], [`createHashRouter`][4], or [`createBrowserRouter`][5] functions.
-- Use the [`useRoutes`][6] hook.
-- Use the [`Routes`][7] component.
+- Create routers with [`createMemoryRouter`][4], [`createHashRouter`][5], or [`createBrowserRouter`][6] functions.
+- Use the [`useRoutes`][7] hook.
+- Use the [`Routes`][8] component.
 
 To track route changes with the Datadog RUM Browser SDK, first initialize the `reactPlugin` with the `router: true` option, then replace those functions with their equivalent from `@datadog/browser-rum-react/react-router-v6`. Example:
 
@@ -119,35 +101,36 @@ ReactDOM.createRoot(document.getElementById('root')).render(<RouterProvider rout
 
 ### Traces
 
-Connect your RUM and trace data to get a complete view of your application's performance. See [Connect RUM and Traces][8].
+Connect your RUM and trace data to get a complete view of your application's performance. See [Connect RUM and Traces][9].
 
 ### Logs
 
-To start forwarding your React application's logs to Datadog, see [JavaScript Logs Collection][9].
+To start forwarding your React application's logs to Datadog, see [JavaScript Logs Collection][10].
 
 ### Metrics
 
-To generate custom metrics from your RUM application, see [Generate Metrics][10].
+To generate custom metrics from your RUM application, see [Generate Metrics][11].
 
 ## Troubleshooting
 
-Need help? Contact [Datadog Support][11].
+Need help? Contact [Datadog Support][12].
 
 ## Further Reading
 
 Additional helpful documentation, links, and articles:
 
-- [React Monitoring][12]
+- [React Monitoring][13]
 
 [1]: https://docs.datadoghq.com/real_user_monitoring/browser/setup/client
-[2]: https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
-[3]: https://reactrouter.com/en/main/routers/create-memory-router
-[4]: https://reactrouter.com/en/main/routers/create-hash-router
-[5]: https://reactrouter.com/en/main/routers/create-browser-router
-[6]: https://reactrouter.com/en/main/hooks/use-routes
-[7]: https://reactrouter.com/en/main/components/routes
-[8]: https://docs.datadoghq.com/real_user_monitoring/platform/connect_rum_and_traces/?tab=browserrum
-[9]: https://docs.datadoghq.com/logs/log_collection/javascript/
-[10]: https://docs.datadoghq.com/real_user_monitoring/generate_metrics
-[11]: https://docs.datadoghq.com/help/
-[12]: https://www.datadoghq.com/blog/datadog-rum-react-components/
+[2]: https://www.npmjs.com/package/@datadog/browser-rum-react
+[3]: https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+[4]: https://reactrouter.com/en/main/routers/create-memory-router
+[5]: https://reactrouter.com/en/main/routers/create-hash-router
+[6]: https://reactrouter.com/en/main/routers/create-browser-router
+[7]: https://reactrouter.com/en/main/hooks/use-routes
+[8]: https://reactrouter.com/en/main/components/routes
+[9]: https://docs.datadoghq.com/real_user_monitoring/platform/connect_rum_and_traces/?tab=browserrum
+[10]: https://docs.datadoghq.com/logs/log_collection/javascript/
+[11]: https://docs.datadoghq.com/real_user_monitoring/generate_metrics
+[12]: https://docs.datadoghq.com/help/
+[13]: https://www.datadoghq.com/blog/datadog-rum-react-components/

--- a/rum_react/README.md
+++ b/rum_react/README.md
@@ -39,7 +39,7 @@ function App() {
   )
 }
 
-function ErrorFallback({ resetError, error }: { resetError: () => void; error: unknown }) {
+function ErrorFallback({ resetError, error }) {
   return (
     <p>
       Oops, something went wrong! <strong>{String(error)}</strong> <button onClick={resetError}>Retry</button>
@@ -54,7 +54,7 @@ function ErrorFallback({ resetError, error }: { resetError: () => void; error: u
 import { addReactError } from '@datadog/browser-rum-react'
 
 class MyErrorBoundary extends React.Component {
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  componentDidCatch(error, errorInfo) {
     addReactError(error, errorInfo)
   }
 

--- a/rum_react/README.md
+++ b/rum_react/README.md
@@ -5,8 +5,8 @@
 With the Datadog RUM React integration, resolve performance issues quickly in React components by:
 
 - Debugging the root cause of performance bottlenecks, such as a slow server response time, render-blocking resource, or an error inside a component
-- Automatically correlating Web performance data with user journeys, HTTP calls, and logs
-- Alerting your engineering teams when crucial Web performance metrics (such as Core Web Vitals) fall below a threshold that results in a poor user experience
+- Automatically correlating web performance data with user journeys, HTTP calls, and logs
+- Alerting your engineering teams when crucial web performance metrics (such as Core Web Vitals) fall below a threshold that results in a poor user experience
 
 Monitor your React applications from end-to-end by:
 
@@ -17,7 +17,7 @@ Monitor your React applications from end-to-end by:
 
 ## Setup
 
-Make sure to [setup Datadog RUM][1] in your application. When creating a new RUM application within the Datadog App, make sure to select React. You can also edit an existing RUM application and change its type to React. The Datadog App will then show you the instructions to setup the Browser SDK [RUM-React plugin][2].
+Make sure to [setup Datadog RUM][1] in your application. When creating a new RUM application within the Datadog App, make sure to select React. You can also edit an existing RUM application and change its type to React. The Datadog App then shows you the instructions to setup the Browser SDK [RUM-React plugin][2].
 
 ## Error Tracking
 

--- a/rum_react/README.md
+++ b/rum_react/README.md
@@ -17,7 +17,7 @@ Monitor your React applications from end-to-end by:
 
 ## Setup
 
-Make sure to [setup Datadog RUM][1] in your application. When creating a new RUM application within the Datadog App, make sure to select React. You can also edit an existing RUM application and change its type to React. The Datadog App then shows you the instructions to setup the Browser SDK [RUM-React plugin][2].
+Start by setting up [Datadog RUM][1] in your React application. If you're creating a new RUM application in the Datadog App, select React as the application type. If you already have an existing RUM application, you can update its type to React instead. Once configured, the Datadog App will provide instructions for integrating the [RUM-React plugin][2] with the Browser SDK.
 
 ## Error Tracking
 


### PR DESCRIPTION
### What does this PR do?

Update the rum_react integration page to add the new [rum-react](https://www.npmjs.com/package/@datadog/browser-rum-react) plugin documentation. In the future, we'll remove the documentation from [the package readme](https://github.com/DataDog/browser-sdk/blob/main/packages/rum-react/README.md) and just add a link to the [integration doc page](https://docs.datadoghq.com/integrations/rum_react/).

[Rendered](https://github.com/BenoitZugmeyer/integrations-extras/blob/benoit/add-rum-react-doc/rum_react/README.md)

### Motivation

We are in the process of releasing the official rum-react integration plugin.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- N/A Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- N/A If this PR includes a log pipeline, please add a description describing the remappers and processors. 
