### PR TITLE
upbound_uxp: filter one pod per replicaSet (ECOINT-108)

### DIFF
--- a/upbound_uxp/datadog_checks/upbound_uxp/data/conf.yaml.example
+++ b/upbound_uxp/datadog_checks/upbound_uxp/data/conf.yaml.example
@@ -53,3 +53,11 @@ instances:
     #   - <INCLUDE_REGEX>
     #   exclude:
     #   - <EXCLUDE_REGEX>
+    
+    ## @param filter_one_pod_per_replica - boolean - optional - default: false
+    ## If enabled, only one pod per replica (e.g., ReplicaSet) will be selected for metric collection.
+    ## This helps avoid duplicates when multiple pods are running on the same node.
+    ## 
+    ## Default is `false`, meaning all pods will be considered.
+    #
+    # filter_one_pod_per_replica: false


### PR DESCRIPTION
### what does this PR do?
This PR introduces a feature flag (filter_one_pod_per_replica) to allow filtering of only one pod per ReplicaSet for metric collection in Kubernetes environments. This change helps avoid duplicate metrics when multiple pods from the same ReplicaSet are running on the same node. The default behavior is to collect metrics from all pods.

### motivation
The motivation for this change is to enhance metric collection efficiency in environments where high availability is configured with multiple pods per ReplicaSet, avoiding the collection of duplicate data from pods running on the same node.



### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

- The new feature flag filter_one_pod_per_replica is added to the configuration file, defaulting to false. When enabled, only one pod per ReplicaSet will be selected for metrics collection.
- This change helps ensure that metric collection is more efficient in environments with multiple pods running on the same node, reducing the chances of duplicate metrics being collected.
