### PR TITLE
[LOGSC-2211] Set up new github team to review logs integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1153,4 +1153,4 @@
 
 # LEAVE THE FOLLOWING LOG OWNERSHIP LAST IN THE FILE
 # Make sure logs team is the full owner for all logs related files
-**/assets/logs/                          @DataDog/logs-backend @DataDog/logs-core
+**/assets/logs/                          @DataDog/logs-integrations-reviewers @DataDog/logs-backend @DataDog/logs-core


### PR DESCRIPTION
Some engineers from not the logs-backend team will now help to review integrations. So we create this new reviewer team for all people with the ownership to review logs integrations files.