### PR TITLE
Fix README.md and update URL for screenshot image links. (ECOINT-128)

### DIFF
--- a/cribl_stream/README.md
+++ b/cribl_stream/README.md
@@ -21,23 +21,23 @@ Navigate to [_API Keys_][7] under Organization Settings and create an API Key fo
 
 #### Cribl
 1. In Cribl, navigate to _Quick Connects_ and click the _+Add Source_ button. 
-![step1](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/images/cribl_dd_1.png)
+![step1](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/cribl_dd_1.png)
 2. Scroll down to _System Internal_ , hover over _Cribl Internal_ and choose _Select Existing_. Enable both _CriblLogs_ and _CriblMetrics_.  
  - **Note**: Both sources must have **Quick Connect** enabled instead of **Routes**.
-![step3](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/images/cribl_dd_3.png)
+![step3](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/cribl_dd_3.png)
 
 3. Click the _+Add Destination_ button.
 4. Scroll to the _Datadog_ tile and click _+Add New_.
 5. Give a name to the input (for example, Cribl_Datadog).
-![step4](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/images/cribl_dd_4.png)
+![step4](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/cribl_dd_4.png)
 
 6. Next, enter your _Datadog API Key_ and select your Datadog site.
 7. Add any Datadog tags, a Message Field, Source, or Host information. For more information, see the [Cribl Datadog Destination documentation][3].
 8. Click _Save_.
 10. Select _Passthru_ to connect Cribl Metrics to your Datadog destination.
-![step5](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/images/cribl_dd_6.png)
+![step5](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/cribl_dd_6.png)
 
-![complete](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/images/cribl_dd_5.png)
+![complete](https://raw.githubusercontent.com/DataDog/integrations-extras/master/cribl_stream/images/cribl_dd_5.png)
 
 ## Uninstallation
 Use the [delete dashboard][4] option within the Cribl Stream dashboard settings to delete the Cribl Stream dashboard. Remove the Datadog destination from the Cribl Stream deployment to stop sending data.


### PR DESCRIPTION
Repaired broken links to images for Cribl Stream and Datadog screenshots.

### What does this PR do?

Updating the links to the screenshots; removing the additional images reference in the URL.

### Motivation

Repair the missing images to help people see how to use this integration.

### Review checklist

- [X ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [X ] Feature or bugfix has tests
- [X ] Git history is clean
- [X ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

