### PR TITLE
Fix ddev commands in README

### DIFF
--- a/gatekeeper/README.md
+++ b/gatekeeper/README.md
@@ -1,4 +1,4 @@
-# Agent Check: gatekeeper 
+# Agent Check: gatekeeper
 
 ## Overview
 
@@ -35,7 +35,7 @@ To install the gatekeeper check on your Kubernetes cluster:
 3. Update your `ddev` config with the `integrations-extras/` path:
 
    ```shell
-   ddev config set extras ./integrations-extras
+   ddev config set repos.extras ./integrations-extras
    ```
 
 4. To build the `gatekeeper` package, run:

--- a/open_policy_agent/README.md
+++ b/open_policy_agent/README.md
@@ -1,4 +1,4 @@
-# Agent Check: open_policy_agent 
+# Agent Check: open_policy_agent
 
 ## Overview
 
@@ -22,7 +22,7 @@ To install the open_policy_agent check on your Kubernetes cluster:
 3. Update your `ddev` config with the `integrations-extras/` path:
 
    ```shell
-   ddev config set extras ./integrations-extras
+   ddev config set repos.extras ./integrations-extras
    ```
 
 4. To build the `open_policy_agent` package, run:


### PR DESCRIPTION
### What does this PR do?
Fix typo in `ddev` command in README.

### Motivation

Cleaning up any appearance of a broken command after we have seen this from customers in support tickets.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes
None
