### PR TITLE
[APPS] Swap LaunchDarkly Integration Dashboard's UI Extension with OOTB App

### DIFF
--- a/launchdarkly/assets/dashboards/launchdarkly.json
+++ b/launchdarkly/assets/dashboards/launchdarkly.json
@@ -1,39 +1,122 @@
 {
   "title": "LaunchDarkly",
-  "description": "The LaunchDarkly integration for Datadog brings flag event markers to your monitoring dashboards, so you can see the effects of your LaunchDarkly feature deployments on your customer's services or systems. For instance, if a deployed feature causes a service to slow down, you can see the cause within Datadog. Additionally you can use the LaunchDarkly flags dashboard widget to seamlessly monitor and perform a feature go-live from a single window.",
+  "description": "The LaunchDarkly integration for Datadog brings flag event markers to your monitoring dashboards, so you can see the effects of your LaunchDarkly feature deployments on your customer's services or systems. For instance, if a deployed feature causes a service to slow down, you can see the cause within Datadog. Additionally you can use the LaunchDarkly flags dashboard widget to seamlessly monitor and perform a feature go-live from a single window. (cloned)",
   "widgets": [
     {
-      "id": 6051850329724523,
+      "id": 8021451179097924,
       "definition": {
-        "type": "image",
-        "url": "https://static.launchdarkly.com/integrations/datadog/dashboard/header_light.png",
-        "url_dark_theme": "https://static.launchdarkly.com/integrations/datadog/dashboard/header.png",
-        "sizing": "cover",
-        "has_background": false,
-        "has_border": false,
-        "vertical_align": "center",
-        "horizontal_align": "center"
+        "title": "Overview",
+        "background_color": "gray",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 6051850329724523,
+            "definition": {
+              "type": "image",
+              "url": "https://static.datadoghq.com/static/images/logos/launchdarkly_large.svg",
+              "url_dark_theme": "https://static.datadoghq.com/static/images/logos/launchdarkly_reversed_large.svg",
+              "sizing": "cover",
+              "margin": "md",
+              "has_background": true,
+              "has_border": true,
+              "vertical_align": "center",
+              "horizontal_align": "center"
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 3
+            }
+          },
+          {
+            "id": 3979461125263392,
+            "definition": {
+              "type": "note",
+              "content": "### Track Change Events \nThe LaunchDarkly events integration for Datadog brings flag event markers to your monitoring dashboards, so you can see the effects of your LaunchDarkly feature deployments on your customer's services or systems.\n\n### Toggle Feature flags\nLaunchDarkly's feature flag tracking integration enriches your RUM data with your feature flags to provide visibility into performance monitoring and behavioral changes. \n\n### Relay proxy metrics \nIf you are using the LaunchDarkly Relay Proxy, you can configure it to export metrics, such as active and cumulative connections, to Datadog.\n\n[Learn more about the LaunchDarkly Integration](https://launchdarkly.com/docs/integrations/datadog)",
+              "background_color": "white",
+              "font_size": "14",
+              "text_align": "left",
+              "vertical_align": "top",
+              "show_tick": false,
+              "tick_pos": "50%",
+              "tick_edge": "left",
+              "has_padding": true
+            },
+            "layout": {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 3
+            }
+          }
+        ]
       },
       "layout": {
         "x": 0,
         "y": 0,
         "width": 12,
+        "height": 4
+      }
+    },
+    {
+      "id": 5250128683109816,
+      "definition": {
+        "type": "note",
+        "content": "## Create, view, or toggle on or off LaunchDarkly feature flags\n\nControl feature flags directly within this dashboard. Narrow down your search by project or environment.",
+        "background_color": "blue",
+        "font_size": "14",
+        "text_align": "left",
+        "vertical_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom",
+        "has_padding": true
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 6,
+        "height": 2,
+        "is_column_break": true
+      }
+    },
+    {
+      "id": 1261236294436942,
+      "definition": {
+        "type": "note",
+        "content": "## Track Feature Flag Change Events\n\nEvents are displayed in a list or as markers on your charts. These events help you correlate and understand how changes to your features in LaunchDarkly impact your app and infrastructure metrics.\n\nUtilize [template variables](https://docs.datadoghq.com/dashboards/template_variables) to dynamically override the **Launchdarkly environment** setting as you change dashboard views.",
+        "background_color": "blue",
+        "font_size": "14",
+        "text_align": "left",
+        "vertical_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom",
+        "has_padding": true
+      },
+      "layout": {
+        "x": 6,
+        "y": 0,
+        "width": 6,
         "height": 2
       }
     },
     {
-      "id": 3385727926662895,
+      "id": 5922188908441656,
       "definition": {
         "type": "embedded_app",
-        "title": "LaunchDarkly",
-        "title_size": "16",
+        "title": "Manage Feature Flags",
+        "title_size": "13",
         "title_align": "left",
         "template_id": "embedded_launchdarkly_feature_flag_manager"
       },
       "layout": {
         "x": 0,
         "y": 2,
-        "width": 5,
+        "width": 6,
         "height": 7
       }
     },
@@ -43,58 +126,24 @@
         "title": "LaunchDarkly feature flag events",
         "title_size": "16",
         "title_align": "left",
-        "type": "event_stream",
-        "query": "sources:launchdarkly tags:environment_key:$ld-environment",
-        "tags_execution": "and",
-        "event_size": "l"
+        "requests": [
+          {
+            "query": {
+              "query_string": "sources:launchdarkly tags:environment_key:$ld-environment",
+              "data_source": "event_stream",
+              "event_size": "l"
+            },
+            "columns": [],
+            "response_format": "event_list"
+          }
+        ],
+        "type": "list_stream"
       },
       "layout": {
-        "x": 5,
+        "x": 6,
         "y": 2,
-        "width": 7,
+        "width": 6,
         "height": 7
-      }
-    },
-    {
-      "id": 5250128683109816,
-      "definition": {
-        "type": "note",
-        "content": "Customize the LaunchDarkly flags widget to show a subset feature flags that are relevant to your team, project, or service.\n\nOptionally, you can utilize a Datadog [template variable](https://docs.datadoghq.com/dashboards/template_variables) to dynamically override the **Launchdarkly environment** setting as you change dashboard views.",
-        "background_color": "gray",
-        "font_size": "14",
-        "text_align": "left",
-        "vertical_align": "center",
-        "show_tick": true,
-        "tick_pos": "50%",
-        "tick_edge": "top",
-        "has_padding": true
-      },
-      "layout": {
-        "x": 0,
-        "y": 9,
-        "width": 5,
-        "height": 3
-      }
-    },
-    {
-      "id": 1261236294436942,
-      "definition": {
-        "type": "note",
-        "content": "Enable LaunchDarkly's [Datadog events integration](https://docs.launchdarkly.com/integrations/datadog/events) to send feature flag change events to Datadog. Events are displayed in a list or as markers on your charts. These events help you correlate and understand how changes to your features in LaunchDarkly impact your app and infrastructure metrics.",
-        "background_color": "gray",
-        "font_size": "14",
-        "text_align": "left",
-        "vertical_align": "center",
-        "show_tick": true,
-        "tick_pos": "50%",
-        "tick_edge": "top",
-        "has_padding": true
-      },
-      "layout": {
-        "x": 5,
-        "y": 9,
-        "width": 7,
-        "height": 3
       }
     },
     {
@@ -108,7 +157,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 12,
+        "y": 9,
         "width": 12,
         "height": 1
       }
@@ -117,15 +166,14 @@
   "template_variables": [
     {
       "name": "ld-environment",
-      "default": "*",
       "available_values": [
         "production",
         "test"
-      ]
+      ],
+      "default": "*"
     }
   ],
   "layout_type": "ordered",
-  "is_read_only": false,
   "notify_list": [],
   "reflow_type": "fixed"
 }

--- a/launchdarkly/assets/dashboards/launchdarkly.json
+++ b/launchdarkly/assets/dashboards/launchdarkly.json
@@ -35,7 +35,7 @@
             "id": 3979461125263392,
             "definition": {
               "type": "note",
-              "content": "### Track Change Events \nThe LaunchDarkly events integration for Datadog brings flag event markers to your monitoring dashboards, so you can see the effects of your LaunchDarkly feature deployments on your customer's services or systems.\n\n### Toggle Feature flags\nLaunchDarkly's feature flag tracking integration enriches your RUM data with your feature flags to provide visibility into performance monitoring and behavioral changes. \n\n### Relay proxy metrics \nIf you are using the LaunchDarkly Relay Proxy, you can configure it to export metrics, such as active and cumulative connections, to Datadog.\n\n[Learn more about the LaunchDarkly Integration](https://launchdarkly.com/docs/integrations/datadog)",
+              "content": "### Track Change Events \nThe LaunchDarkly events integration for Datadog brings flag event markers to your monitoring dashboards, so you can see the effects of your LaunchDarkly feature deployments on your customers' services or systems.\n\n### Toggle Feature flags\nLaunchDarkly's feature flag tracking integration enriches your RUM data with your feature flags to provide visibility into performance monitoring and behavioral changes. \n\n### Relay proxy metrics \nIf you are using the LaunchDarkly Relay Proxy, you can configure it to export metrics, such as active and cumulative connections, to Datadog.\n\n[Learn more about the LaunchDarkly Integration](https://launchdarkly.com/docs/integrations/datadog)",
               "background_color": "white",
               "font_size": "14",
               "text_align": "left",

--- a/launchdarkly/assets/dashboards/launchdarkly.json
+++ b/launchdarkly/assets/dashboards/launchdarkly.json
@@ -65,7 +65,7 @@
       "id": 5250128683109816,
       "definition": {
         "type": "note",
-        "content": "## Create, view, or toggle on or off LaunchDarkly feature flags\n\nControl feature flags directly within this dashboard. Narrow down your search by project or environment.",
+        "content": "## Create, View, or Toggle LaunchDarkly Feature Flags\n\nControl feature flags directly within this dashboard. Narrow your search by project or environment.",
         "background_color": "blue",
         "font_size": "14",
         "text_align": "left",

--- a/launchdarkly/assets/dashboards/launchdarkly.json
+++ b/launchdarkly/assets/dashboards/launchdarkly.json
@@ -126,10 +126,11 @@
         "title": "LaunchDarkly feature flag events",
         "title_size": "16",
         "title_align": "left",
+        "time": {},
         "requests": [
           {
             "query": {
-              "query_string": "sources:launchdarkly tags:environment_key:$ld-environment",
+              "query_string": "sources:launchdarkly env:$ld-environment.value",
               "data_source": "event_stream",
               "event_size": "l"
             },

--- a/launchdarkly/assets/dashboards/launchdarkly.json
+++ b/launchdarkly/assets/dashboards/launchdarkly.json
@@ -1,6 +1,6 @@
 {
   "title": "LaunchDarkly",
-  "description": "The LaunchDarkly integration for Datadog brings flag event markers to your monitoring dashboards, so you can see the effects of your LaunchDarkly feature deployments on your customer's services or systems. For instance, if a deployed feature causes a service to slow down, you can see the cause within Datadog. Additionally you can use the LaunchDarkly flags dashboard widget to seamlessly monitor and perform a feature go-live from a single window. (cloned)",
+  "description": "The LaunchDarkly integration for Datadog brings flag event markers to your monitoring dashboards, so you can see the effects of your LaunchDarkly feature deployments on your customer's services or systems. For instance, if a deployed feature causes a service to slow down, you can see the cause within Datadog. Additionally you can use the LaunchDarkly flags dashboard widget to seamlessly monitor and perform a feature go-live from a single window.",
   "widgets": [
     {
       "id": 8021451179097924,

--- a/launchdarkly/assets/dashboards/launchdarkly.json
+++ b/launchdarkly/assets/dashboards/launchdarkly.json
@@ -87,7 +87,7 @@
       "id": 1261236294436942,
       "definition": {
         "type": "note",
-        "content": "## Track Feature Flag Change Events\n\nEvents are displayed in a list or as markers on your charts. These events help you correlate and understand how changes to your features in LaunchDarkly impact your app and infrastructure metrics.\n\nUtilize [template variables](https://docs.datadoghq.com/dashboards/template_variables) to dynamically override the **Launchdarkly environment** setting as you change dashboard views.",
+        "content": "## Track Feature Flag Change Events\n\nEvents are displayed in a list or as markers on your charts. These events help you correlate and understand how changes to your LaunchDarkly features impact your application and infrastructure metrics.\n\nUse [template variables](https://docs.datadoghq.com/dashboards/template_variables) to dynamically override the **Launchdarkly environment** setting as you change dashboard views.",
         "background_color": "blue",
         "font_size": "14",
         "text_align": "left",

--- a/launchdarkly/assets/dashboards/launchdarkly.json
+++ b/launchdarkly/assets/dashboards/launchdarkly.json
@@ -14,23 +14,28 @@
         "vertical_align": "center",
         "horizontal_align": "center"
       },
-      "layout": { "x": 0, "y": 0, "width": 12, "height": 2 }
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 12,
+        "height": 2
+      }
     },
     {
       "id": 3385727926662895,
       "definition": {
+        "type": "embedded_app",
         "title": "LaunchDarkly",
         "title_size": "16",
         "title_align": "left",
-        "type": "custom",
-        "app_id": "7144d0c5-42f2-4cc5-b562-5f77debc0c52",
-        "custom_widget_key": "launchdarkly",
-        "options": {
-          "dashboardURL": "https://app.launchdarkly.com/default/production/features",
-          "envTemplateVar": "ld-environment"
-        }
+        "template_id": "embedded_launchdarkly_feature_flag_manager"
       },
-      "layout": { "x": 0, "y": 2, "width": 5, "height": 7 }
+      "layout": {
+        "x": 0,
+        "y": 2,
+        "width": 5,
+        "height": 7
+      }
     },
     {
       "id": 3140411049621601,
@@ -43,7 +48,12 @@
         "tags_execution": "and",
         "event_size": "l"
       },
-      "layout": { "x": 5, "y": 2, "width": 7, "height": 7 }
+      "layout": {
+        "x": 5,
+        "y": 2,
+        "width": 7,
+        "height": 7
+      }
     },
     {
       "id": 5250128683109816,
@@ -59,7 +69,12 @@
         "tick_edge": "top",
         "has_padding": true
       },
-      "layout": { "x": 0, "y": 9, "width": 5, "height": 3 }
+      "layout": {
+        "x": 0,
+        "y": 9,
+        "width": 5,
+        "height": 3
+      }
     },
     {
       "id": 1261236294436942,
@@ -75,7 +90,12 @@
         "tick_edge": "top",
         "has_padding": true
       },
-      "layout": { "x": 5, "y": 9, "width": 7, "height": 3 }
+      "layout": {
+        "x": 5,
+        "y": 9,
+        "width": 7,
+        "height": 3
+      }
     },
     {
       "id": 4318688676203407,
@@ -86,14 +106,22 @@
         "sizing": "cover",
         "horizontal_align": "right"
       },
-      "layout": { "x": 0, "y": 12, "width": 12, "height": 1 }
+      "layout": {
+        "x": 0,
+        "y": 12,
+        "width": 12,
+        "height": 1
+      }
     }
   ],
   "template_variables": [
     {
       "name": "ld-environment",
       "default": "*",
-      "available_values": ["production", "test"]
+      "available_values": [
+        "production",
+        "test"
+      ]
     }
   ],
   "layout_type": "ordered",


### PR DESCRIPTION
### What does this PR do?

Replaces LaunchDarkly [Integration Dashboard](https://dd.datad0g.com/dash/integration/launchdarkly) UI Extensions with Embedded Apps

### Motivation

Fix issue with LaunchDarkly integration dashboards displaying UI Extension deprecation copy

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
