### PR TITLE
Fix permissions for github workflows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,9 +14,11 @@ jobs:
       # Options
       standard: true
     secrets: inherit
-    # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
     permissions:
-      id-token: write
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
+       # needed for compute-matrix in test-target.yml
+       contents: read
 
   publish-test-results:
     needs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   test:
-    uses: DataDog/integrations-core/.github/workflows/pr-test.yml@sarah/test-permissions-workflow
+    uses: DataDog/integrations-core/.github/workflows/pr-test.yml@master
     with:
       repo: extras
       python-version: "3.12"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
       repo: extras
       python-version: "3.12"
     secrets: inherit
-    # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
     permissions:
-      id-token: write
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
+       # needed for compute-matrix in test-target.yml
+       contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   test:
-    uses: DataDog/integrations-core/.github/workflows/pr-test.yml@master
+    uses: DataDog/integrations-core/.github/workflows/pr-test.yml@sarah/test-permissions-workflow
     with:
       repo: extras
       python-version: "3.12"

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -49,6 +49,8 @@ jobs:
       agent-image-windows: "${{ inputs.agent-image-windows }}"
       agent-image-windows-py2: "${{ inputs.agent-image-windows-py2 }}"
     secrets: inherit
-    # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
     permissions:
-      id-token: write
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
+       # needed for compute-matrix in test-target.yml
+       contents: read

--- a/aqua/datadog_checks/aqua/aqua.py
+++ b/aqua/datadog_checks/aqua/aqua.py
@@ -35,7 +35,7 @@ STATUS_METRICS = [
 
 class AquaCheck(AgentCheck):
     """
-    Collect metrics from Aqua.
+    Collect metric from Aqua.
     """
 
     SERVICE_CHECK_NAME = 'aqua.can_connect'

--- a/aqua/datadog_checks/aqua/aqua.py
+++ b/aqua/datadog_checks/aqua/aqua.py
@@ -35,7 +35,7 @@ STATUS_METRICS = [
 
 class AquaCheck(AgentCheck):
     """
-    Collect metric from Aqua.
+    Collect metrics from Aqua.
     """
 
     SERVICE_CHECK_NAME = 'aqua.can_connect'


### PR DESCRIPTION
### What does this PR do?

required for https://github.com/DataDog/integrations-core/pull/20239, now that contents:read are required for workflows
### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
