### PR TITLE
Add `busy_threads` metric to Puma integration

### DIFF
--- a/puma/datadog_checks/puma/puma.py
+++ b/puma/datadog_checks/puma/puma.py
@@ -7,6 +7,7 @@ from datadog_checks.base import AgentCheck, ConfigurationError
 METRICS = [
     ('backlog', 'backlog', AgentCheck.gauge),
     ('booted_workers', 'booted_workers', AgentCheck.gauge),
+    ('busy_threads', 'busy_threads', AgentCheck.gauge),
     ('max_threads', 'max_threads', AgentCheck.gauge),
     ('pool_capacity', 'pool_capacity', AgentCheck.gauge),
     ('requests_count', 'requests_count', AgentCheck.gauge),
@@ -32,6 +33,7 @@ class PumaCheck(AgentCheck):
         metrics = {
             'backlog': 0,
             'booted_workers': 0,
+            'busy_threads': 0,
             'max_threads': 0,
             'pool_capacity': 0,
             'requests_count': 0,
@@ -46,6 +48,7 @@ class PumaCheck(AgentCheck):
             for worker in response['worker_status']:
                 last_status = worker.get('last_status')
                 metrics['backlog'] += int(last_status.get('backlog', 0))
+                metrics['busy_threads'] += int(last_status.get('busy_threads', 0))
                 metrics['max_threads'] += int(last_status.get('max_threads', 0))
                 metrics['pool_capacity'] += int(last_status.get('pool_capacity', 0))
                 metrics['requests_count'] += int(last_status.get('requests_count', 0))
@@ -53,6 +56,7 @@ class PumaCheck(AgentCheck):
 
         else:  # Puma is not clustered
             metrics['backlog'] = int(response.get('backlog', 0))
+            metrics['busy_threads'] = int(response.get('busy_threads', 0))
             metrics['max_threads'] = int(response.get('max_threads', 0))
             metrics['pool_capacity'] = int(response.get('pool_capacity', 0))
             metrics['requests_count'] = int(response.get('requests_count', 0))

--- a/puma/metadata.csv
+++ b/puma/metadata.csv
@@ -1,7 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 puma.backlog,gauge,,unit,,Pending request backlog,0,puma,request backlog,
 puma.booted_workers,gauge,,unit,,Number of booted puma workers,0,puma,booted workers,
-puma.busy_threads,gauge,,unit,,Number of threads that are running minus requests waiting for work plus requests waiting on a thread.,0,puma,booted workers,
+puma.busy_threads,gauge,,unit,,Number of threads that are running, including requests waiting on a thread, but excluding requests waiting for work.,0,puma,booted workers,
 puma.max_threads,gauge,,unit,,Maximum threads,0,puma,max threads,
 puma.pool_capacity,gauge,,unit,,Pool capacity,0,puma,pool capacity,
 puma.requests_count,gauge,,unit,,Request count,0,puma,request count,

--- a/puma/metadata.csv
+++ b/puma/metadata.csv
@@ -1,7 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 puma.backlog,gauge,,unit,,Pending request backlog,0,puma,request backlog,
 puma.booted_workers,gauge,,unit,,Number of booted puma workers,0,puma,booted workers,
-puma.busy_threads,gauge,,unit,,Number of threads that are running, including requests waiting on a thread, but excluding requests waiting for work.,0,puma,booted workers,
+puma.busy_threads,gauge,,unit,,"Number of threads that are running, including requests waiting on a thread, but excluding requests waiting for work.",0,puma,booted workers,
 puma.max_threads,gauge,,unit,,Maximum threads,0,puma,max threads,
 puma.pool_capacity,gauge,,unit,,Pool capacity,0,puma,pool capacity,
 puma.requests_count,gauge,,unit,,Request count,0,puma,request count,

--- a/puma/metadata.csv
+++ b/puma/metadata.csv
@@ -1,6 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 puma.backlog,gauge,,unit,,Pending request backlog,0,puma,request backlog,
 puma.booted_workers,gauge,,unit,,Number of booted puma workers,0,puma,booted workers,
+puma.busy_threads,gauge,,unit,,Number of threads that are running minus requests waiting for work plus requests waiting on a thread.,0,puma,booted workers,
 puma.max_threads,gauge,,unit,,Maximum threads,0,puma,max threads,
 puma.pool_capacity,gauge,,unit,,Pool capacity,0,puma,pool capacity,
 puma.requests_count,gauge,,unit,,Request count,0,puma,request count,

--- a/puma/tests/test_puma.py
+++ b/puma/tests/test_puma.py
@@ -29,6 +29,7 @@ def test_metrics_for_puma_in_cluster_mode(aggregator, instance):
                 {
                     'last_status': {
                         'backlog': 0,
+                        'busy_threads': 6,
                         'max_threads': 20,
                         'pool_capacity': 15,
                         'running': 20,
@@ -38,6 +39,7 @@ def test_metrics_for_puma_in_cluster_mode(aggregator, instance):
                 {
                     'last_status': {
                         'backlog': 1,
+                        'busy_threads': 4,
                         'max_threads': 20,
                         'pool_capacity': 15,
                         'running': 20,
@@ -58,6 +60,7 @@ def test_metrics_for_puma_in_cluster_mode(aggregator, instance):
     aggregator.assert_metric('puma.workers', value=2.0, tags=[])
     aggregator.assert_metric('puma.backlog', value=1.0, tags=[])
     aggregator.assert_metric('puma.booted_workers', value=2.0, tags=[])
+    aggregator.assert_metric('puma.busy_threads', value=10.0, tags=[])
     aggregator.assert_metric('puma.pool_capacity', value=30.0, tags=[])
     aggregator.assert_metric('puma.running', value=40.0, tags=[])
     aggregator.assert_metric('puma.requests_count', value=270.0, tags=[])
@@ -71,7 +74,9 @@ def test_metrics_for_puma_in_single_mode(aggregator, instance):
         'content-type': 'application/json',
     }
 
-    content = json.dumps({"backlog": 1, "running": 2, "pool_capacity": 15, "max_threads": 20, "requests_count": 120})
+    content = json.dumps(
+        {"backlog": 1, "busy_threads": 6, "running": 2, "pool_capacity": 15, "max_threads": 20, "requests_count": 120}
+    )
 
     response = Mock(headers=headers, content=content)
 
@@ -81,6 +86,7 @@ def test_metrics_for_puma_in_single_mode(aggregator, instance):
 
     aggregator.assert_metric('puma.max_threads', value=20.0, tags=[])
     aggregator.assert_metric('puma.backlog', value=1.0, tags=[])
+    aggregator.assert_metric('puma.busy_threads', value=6.0, tags=[])
     aggregator.assert_metric('puma.pool_capacity', value=15.0, tags=[])
     aggregator.assert_metric('puma.running', value=2.0, tags=[])
     aggregator.assert_metric('puma.requests_count', value=120.0, tags=[])
@@ -107,6 +113,7 @@ def test_check(aggregator, instance, test_server):
     aggregator.assert_metric('puma.workers', value=2.0, tags=[])
     aggregator.assert_metric('puma.backlog', value=0.0, tags=[])
     aggregator.assert_metric('puma.booted_workers', value=2.0, tags=[])
+    aggregator.assert_metric('puma.busy_threads', value=0.0, tags=[])
     aggregator.assert_metric('puma.pool_capacity', value=10.0, tags=[])
     aggregator.assert_metric('puma.running', value=10.0, tags=[])
     aggregator.assert_metric('puma.requests_count', value=1.0, tags=[])


### PR DESCRIPTION
This new stat was [added about 6 months ago](https://github.com/puma/puma/pull/3517) to track "the overall current state of work to be done and the capacity to do it". It seems like it could be useful to track, potentially for autoscaling or other applications.

### What does this PR do?

This adds the new(ish) `busy_threads` stat as a metric.

### Motivation

I want to track it and experiment with using it for autoscaling

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
