### PR TITLE
Disable validations for assets

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,6 @@ jobs:
       # Validations
       ci: true
       config: true
-      dashboards: true
       imports: true
       integration-style: true
       jmx-metrics: true
@@ -28,7 +27,5 @@ jobs:
       models: true
       package: true
       readmes: true
-      saved-views: true
-      service-checks: true
       codeowners: true
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?

### Motivation

APW's `validate-assets` takes care of this now and `integrations-core` doesn't run them either.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors.

### Additional Notes

Anything else we should know when reviewing?
