### PR TITLE
Add tool.ddev.repo to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,7 @@ ban-relative-imports = "all"
 #Tests can use assertions and relative imports
 "**/tests/**/*" = ["S101", "TID252"]
 "tests/models/config_models/deprecations.py" = ["E501"]
+
+[tool.ddev]
+repo = extras
+


### PR DESCRIPTION
### What does this PR do?
Add the repo config to `tool.ddev` in `pyproject.toml`.

### Motivation

Automatically recognize the repo through ddev for local overrides. See [Add support for local overrides from .ddev.toml file](https://github.com/DataDog/integrations-core/pull/19877)

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
