### PR TITLE
updating streaming URL

### DIFF
--- a/gnatsd_streaming/datadog_checks/gnatsd_streaming/gnatsd_streaming.py
+++ b/gnatsd_streaming/datadog_checks/gnatsd_streaming/gnatsd_streaming.py
@@ -14,7 +14,7 @@ class GnatsdStreamingConfig:
         self.instance = instance
         self.host = instance.get('host', '')
         self.port = int(instance.get('port', 8222))
-        self.url = self.host + ':' + str(self.port) + '/streaming'
+        self.url = self.host + ':' + str(self.port) + '/jsz'
         self.server_name = instance.get('server_name', '')
         self.pagination_limit = instance.get('pagination_limit', 1024)
         self.tags = instance.get('tags', [])


### PR DESCRIPTION
### What does this PR do?

This changes the `/streaming` url to `/jsz` as NATS has deprecated the `/streaming` endpoint. 