### PR TITLE
Add Windows support to the speedtest integration

### DIFF
--- a/speedtest/datadog_checks/speedtest/speedtest.py
+++ b/speedtest/datadog_checks/speedtest/speedtest.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import os
 from typing import Any, Dict  # noqa: F401
 
 from datadog_checks.base import AgentCheck, ConfigurationError
@@ -44,7 +45,10 @@ class SpeedtestCheck(AgentCheck):
 
     def _build_command(self, host, ip, interface, server_id):
         # Build command
-        cmd = "speedtest -f json -p no -A -P 8 "
+        if os.name == 'nt':  # Windows
+            cmd = r'"C:\Program Files\Speedtest\speedtest.exe" -f json -p no -A -P 8 '
+        else:  # Unix-based systems
+            cmd = "speedtest -f json -p no -A -P 8 "
         if host:
             cmd += " --host={}".format(host)
         if ip:

--- a/speedtest/datadog_checks/speedtest/speedtest.py
+++ b/speedtest/datadog_checks/speedtest/speedtest.py
@@ -1,6 +1,6 @@
 import json
-import subprocess
 import os
+import subprocess
 from typing import Any, Dict  # noqa: F401
 
 from datadog_checks.base import AgentCheck, ConfigurationError


### PR DESCRIPTION
### What does this PR do?
This PR allows the speedtest integration to call the Windows equivalent of `speedtest -f json -p no -A -P 8 `. 

### Motivation
A Datadog customer ran into runtime errors when running the integration on Windows:
```
Traceback (most recent call last):
        File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\speedtest\speedtest.py", line 31, in check
          payload = self._call_command(cmd)
                    ^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\site-packages\datadog_checks\speedtest\speedtest.py", line 61, in _call_command
          result = subprocess.check_output(cmd, shell=True)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\subprocess.py", line 468, in check_output
          return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Program Files\Datadog\Datadog Agent\embedded3\Lib\subprocess.py", line 573, in run
          raise CalledProcessError(retcode, process.args,
      subprocess.CalledProcessError: Command 'speedtest -f json -p no -A -P 8 ' returned non-zero exit status 1.
```

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [na] If this PR includes a log pipeline, please add a description describing the remappers and processors. 