### PR TITLE
add additional field to mapping of host

### DIFF
--- a/jamf_protect/assets/logs/jamfprotect.yaml
+++ b/jamf_protect/assets/logs/jamfprotect.yaml
@@ -121,7 +121,7 @@ pipeline:
         - event.device.userDeviceName
         - input.host.hostname
       target: host
-      preserveSource: false
+      preserveSource: true
       overrideOnConflict: false
       sourceType: attribute
       targetType: attribute

--- a/jamf_protect/assets/logs/jamfprotect_tests.yaml
+++ b/jamf_protect/assets/logs/jamfprotect_tests.yaml
@@ -261,6 +261,7 @@ tests:
         host: "Mac mini von Norbert"
         input:
           host:
+            hostname: "Mac mini von Norbert"
             os: "Version 13.2.1 (Build 22D68)"
             protectVersion: "5.0.2.4"
             provisioningUDID: "00008103-000A45E400C0291E"
@@ -656,6 +657,7 @@ tests:
         host: "MBP16-MWARD-ALPHA"
         input:
           host:
+            hostname: "MBP16-MWARD-ALPHA"
             os: "Version 14.0 (Build 23A344)"
             protectVersion: "5.1.0.4"
             provisioningUDID: "081DE2CA-9228-56D0-AD00-BF11AFA67710"
@@ -1380,6 +1382,7 @@ tests:
             deviceName: "Apple iPhone 11 (11.2.5)"
             externalId: "5087dc0e-876c-4b0e-95ea-5b543476e0c4"
             os: "IOS 11.2.5"
+            userDeviceName: "Apple iPhone 11"
           eventType:
             id: 213
           eventUrl: "https://radar.wandera.com/security/events/detail/013b15c9-8f62-4bf1-948a-d82367af2a10.SIDE_LOADED_APP_IN_INVENTORY?createdUtcMs=1580406461767"


### PR DESCRIPTION
### What does this PR do?

Adding an additional field(input.host.hostname) to the mapping of the host field in the pipeline.

### Motivation

A request from a customer tracked in this ticket https://datadoghq.atlassian.net/browse/SCI2-5144?atlOrigin=eyJpIjoiYmFkMjMxOWFjNmIzNGE0M2JhMmU5ZmQwNjk3ZWZmODMiLCJwIjoiaiJ9

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
