### PR TITLE
[Vercel Logs Pipeline] Update OOTB pipeline to use correct Date remapping

### DIFF
--- a/vercel/assets/logs/vercel.yaml
+++ b/vercel/assets/logs/vercel.yaml
@@ -103,10 +103,10 @@ pipeline:
       target: network.client.geoip
       ip_processing_behavior: do-nothing
     - type: date-remapper
-      name: Define `proxy.timestamp` as the official date of the log
+      name: Define `timestamp` as the official date of the log
       enabled: true
       sources:
-        - proxy.timestamp
+        - timestamp
     - type: trace-id-remapper
       name: Define `traceId` as the official trace ID of the log
       enabled: true

--- a/vercel/assets/logs/vercel_tests.yaml
+++ b/vercel/assets/logs/vercel_tests.yaml
@@ -65,7 +65,7 @@ tests:
     status: "ok"
     tags:
      - "source:LOGS_SOURCE"
-    timestamp: 1629819797810
+    timestamp: "2021-08-24T15:43:17.812Z"
     trace_id: "85ea8a46-d63e-4fe3-ad03-ade7c16cd36b"
     span_id: "1012381427123789198737891237891"
 


### PR DESCRIPTION
### What does this PR do?

Updates the Vercel OOTB pipeline to correctly remap `timestamp` as the Date timestamp of the log, rather than `proxy.timestamp`.

### Motivation

This was requested by the Vercel team directly! [Slack thread](https://dd.slack.com/archives/C019MJKQHLH/p1751268158866709).

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
