### PR TITLE
Add `logs-integrations-reviews` as codeowners for log assets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1173,4 +1173,4 @@
 
 # LEAVE THE FOLLOWING LOG OWNERSHIP LAST IN THE FILE
 # Make sure logs team is the full owner for all logs related files
-**/assets/logs/                          @DataDog/logs-integrations-reviewers @DataDog/logs-backend
+**/assets/logs/                          @DataDog/logs-integrations-reviewers @DataDog/logs-backend @DataDog/logs-integrations-reviews


### PR DESCRIPTION
### What does this PR do?
Codeowners entry for log assets