### PR TITLE
Revert "Remove permissions needed to run codecov (#2757)"

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,6 +12,8 @@ jobs:
       repo: extras
     secrets: inherit
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,5 +19,7 @@ jobs:
       python-version: "3.12"
     secrets: inherit
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -47,5 +47,7 @@ jobs:
       agent-image-windows-py2: "${{ inputs.agent-image-windows-py2 }}"
     secrets: inherit
     permissions:
+       # needed for codecov in test-target.yml, allows the action to get a JWT signed by Github
+       id-token: write
        # needed for compute-matrix in test-target.yml
        contents: read


### PR DESCRIPTION
### What does this PR do?
This reverts commit a9523572113b2db31504e2e801588f400cc43e25.

### Motivation
Bring Codecov back

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors.

### Additional Notes

Anything else we should know when reviewing?
