### PR TITLE
[ECOINT-263] Update README.md

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -48,7 +48,7 @@ For the detailed instructions, follow the [k6 documentation][2].
     Once the Datadog Agent service is running, run the k6 test and send the metrics to the Agent with:
 
     ```shell
-    K6_STATSD_ENABLE_TAGS=true k6 run --out xk6-output-statsd script.js
+    K6_STATSD_ENABLE_TAGS=true k6 run --out output-statsd script.js
     ```
 
 4. Visualize the k6 metrics in Datadog.


### PR DESCRIPTION
Requesting the following change be made from step 3 to use the updated statsd syntax in accordance with Grafana/k6's official documentation: https://grafana.com/docs/k6/latest/results-output/real-time/statsd/

### What does this PR do?

Updates the Datadog documentation to be in line with current Grafana/k6 documentation

### Motivation

Outdated statsd syntax in the Datadog documentation.

### Review checklist

- [X] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [X] Feature or bugfix has tests
- [X] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
