### PR TITLE
[LOGSC-2385] Add bypass annotations for new linter checks

### DIFF
--- a/akamai_datastream_2/assets/logs/akamai.datastream.yaml
+++ b/akamai_datastream_2/assets/logs/akamai.datastream.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: akamai.datastream
 metric_id: akamai-datastream-2
 backend_only: false

--- a/aqua/assets/logs/aqua.yaml
+++ b/aqua/assets/logs/aqua.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: aqua
 metric_id: aqua
 backend_only: false

--- a/doppler/assets/logs/doppler.yaml
+++ b/doppler/assets/logs/doppler.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: doppler
 metric_id: doppler
 backend_only: false

--- a/jamf_protect/assets/logs/jamfprotect.yaml
+++ b/jamf_protect/assets/logs/jamfprotect.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: jamfprotect
 metric_id: jamf-protect
 backend_only: false

--- a/jfrog_platform_self_hosted/assets/logs/jfrog_platform.yaml
+++ b/jfrog_platform_self_hosted/assets/logs/jfrog_platform.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: jfrog_platform
 metric_id: jfrog-platform
 backend_only: false

--- a/lacework/assets/logs/lacework.yaml
+++ b/lacework/assets/logs/lacework.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: lacework
 metric_id: lacework
 backend_only: false

--- a/lambdatest/assets/logs/lambdatest.yaml
+++ b/lambdatest/assets/logs/lambdatest.yaml
@@ -1,3 +1,5 @@
+# bypass-global-facets-path-checks
+# bypass-global-missing-date-remapper-checks
 id: lambdatest
 backend_only: false
 facets:

--- a/loadrunner_professional/assets/logs/loadrunner_professional.yaml
+++ b/loadrunner_professional/assets/logs/loadrunner_professional.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: loadrunner_professional
 metric_id: loadrunner-professional
 backend_only: false

--- a/modal/assets/logs/modal.yaml
+++ b/modal/assets/logs/modal.yaml
@@ -1,3 +1,4 @@
+# bypass-global-facets-path-checks
 id: modal
 backend_only: false
 facets:

--- a/perimeterx/assets/logs/perimeterx.yaml
+++ b/perimeterx/assets/logs/perimeterx.yaml
@@ -1,3 +1,5 @@
+# bypass-global-facets-path-checks
+# bypass-global-missing-date-remapper-checks
 id: perimeterx
 metric_id: perimeterx
 backend_only: false

--- a/reflectiz/assets/logs/reflectiz.yaml
+++ b/reflectiz/assets/logs/reflectiz.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: reflectiz
 # See app_id in your integration's manifest.json file to learn more:
 # https://docs.datadoghq.com/developers/integrations/check_references/#manifest-file

--- a/sqreen/assets/logs/sqreen.yaml
+++ b/sqreen/assets/logs/sqreen.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: sqreen
 metric_id: sqreen
 backend_only: false

--- a/tailscale/assets/logs/tailscale.yaml
+++ b/tailscale/assets/logs/tailscale.yaml
@@ -1,3 +1,5 @@
+# bypass-global-facets-path-checks
+# bypass-global-missing-date-remapper-checks
 id: tailscale
 metric_id: tailscale
 backend_only: false

--- a/twingate/assets/logs/twingate.yaml
+++ b/twingate/assets/logs/twingate.yaml
@@ -1,3 +1,4 @@
+# bypass-global-missing-date-remapper-checks
 id: twingate
 backend_only: false
 facets:

--- a/typingdna_activelock/assets/logs/typingdna.yaml
+++ b/typingdna_activelock/assets/logs/typingdna.yaml
@@ -1,3 +1,5 @@
+# bypass-global-facets-path-checks
+# bypass-global-missing-date-remapper-checks
 id: typingdna
 metric_id: typingdna-activelock
 backend_only: false

--- a/vercel/assets/logs/vercel.yaml
+++ b/vercel/assets/logs/vercel.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-rules-checks
 id: vercel
 backend_only: false
 facets:


### PR DESCRIPTION
We’re enabling new linter rules and some integrations are expected to remain non‑compliant.
Add permanent bypass annotations so CI stays green and not fail for new PRs.