### PR TITLE
[IDP-592] Add owner field to Container Integrations Integrations

### DIFF
--- a/aqua/manifest.json
+++ b/aqua/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d3819b09-3e08-492f-b0f8-b0d3f53fbdf5",
   "app_id": "aqua",
+  "owner": "container-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `container-integrations` to manifest.json files for Container Integrations Integrations (1 integration):
aqua

**Note:** These integrations are our best guesses for the Container Integrations team. If you don't own these integrations, or if you also own other integrations that should be included, please let us know.

This provides clear ownership tracking for these container integrations as part of the initiative to add owner fields to all integration manifest.json files.

**For reviewer:** Please confirm:
1. Is `container-integrations` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, what workday team should we use as the `team` tag? We believe it should be "Container Integrations" - could you confirm this is the correct workday team name?

Thank you for your review\!