### PR TITLE
fix Vercel service-remapper logs pipeline

### DIFF
--- a/vercel/assets/logs/vercel.yaml
+++ b/vercel/assets/logs/vercel.yaml
@@ -82,10 +82,10 @@ pipeline:
       sources:
         - http.status_category
     - type: service-remapper
-      name: Define `proxy.host` as the official service of the log
+      name: Define `projectName` as the official service of the log
       enabled: true
       sources:
-        - proxy.host
+        - projectName
     - type: attribute-remapper
       name: Map `host` to `url_host`
       enabled: true

--- a/vercel/assets/logs/vercel_tests.yaml
+++ b/vercel/assets/logs/vercel_tests.yaml
@@ -21,6 +21,7 @@ tests:
       "source" : "lambda",
       "message" : "START RequestId: 85ea8a46-d63e-4fe3-ad03-ade7c16cd36b Version: $LATEST END RequestId: 85ea8a46-d63e-4fe3-ad03-ade7c16cd36b REPORT RequestId: 85ea8a46-d63e-4fe3-ad03-ade7c16cd36b Duration: 0.58 ms Billed Duration: 1 ms Memory Size: 1024 MB Max Memory Used: 31 MB",
       "projectId" : "prj_WTsCRsCir3qyRE9iijJyTc7PqywW",
+      "projectName": "verceltb.vercel.app",
       "timestamp" : "2021-08-24T15:43:17.812Z",
       "tags" : [ "source:vercel" ],
       "traceId" : "85ea8a46-d63e-4fe3-ad03-ade7c16cd36b",
@@ -43,6 +44,7 @@ tests:
         client:
           geoip: {}
       projectId: "prj_WTsCRsCir3qyRE9iijJyTc7PqywW"
+      projectName: "verceltb.vercel.app"
       proxy:
         clientIp: "64.145.79.247"
         host: "verceltb.vercel.app"


### PR DESCRIPTION
[Ticket](https://datadoghq.atlassian.net/browse/LOI-549), [Ticket 2](https://datadoghq.atlassian.net/browse/FRSLES-764)
### What does this PR do?

Updates the Vercel OOTB pipeline to correctly remap `projectName` as the service of the log, rather than `proxy.host`.

### Motivation

This was requested by the Vercel team directly! [Slack thread](https://dd.slack.com/archives/C019MJKQHLH/p1751268158866709).

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
