### PR TITLE
Update Vercel OOTB Dashboard to use entirely new set of widgets

### DIFF
--- a/vercel/assets/dashboards/vercel_overview.json
+++ b/vercel/assets/dashboards/vercel_overview.json
@@ -1372,22 +1372,6 @@
         "layout_type": "ordered",
         "widgets": [
           {
-            "id": 3453297883976480,
-            "definition": {
-              "type": "note",
-              "content": "⚠️ Note: you can remove the URL related to queries in APM. We are using it in APM to avoid leaking data from other Vercel production deployments.",
-              "background_color": "white",
-              "font_size": "16",
-              "text_align": "center",
-              "vertical_align": "center",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
-            },
-            "layout": { "x": 0, "y": 0, "width": 12, "height": 1 }
-          },
-          {
             "id": 8763256642528684,
             "definition": {
               "title": "API Status Code Responses",


### PR DESCRIPTION
[Ticket](https://datadoghq.atlassian.net/browse/SVLS-7385)
### What does this PR do?

This PR updates the OOTB Vercel dashboard widgets, completely changing all of them based on specifications given by Vercel.

### Motivation

The Vercel team has requested a complete overhaul of the widgets in their OOTB dashboard: [slack thread](https://dd.slack.com/archives/C019MJKQHLH/p1753283944125979).

Test the changes on staging: [prod](https://app.datadoghq.com/dash/integration/30567/vercel), [staging](http://dd.datad0g.com/dash/integration/30714/vercel) **Can't at the moment, because no staging vercel apps exist**

### TESTING ALTERNATIVE:

I've exported and made my own copy of the [dashboard](https://ddserverless.datadoghq.com/dashboard/nsw-fa6-fp4?fromUser=false&refresh_mode=sliding&from_ts=1756414214581&to_ts=1756417814581&live=true) on an organization (DDServerless) that has test data for Vercel.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
