### PR TITLE
Add back the repo configuration for ddev in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,6 @@ ban-relative-imports = "parents"
 "**/tests/**/*" = ["S101", "TID252"]
 "datadog_checks/*/config_models/deprecations.py" = ["E501"]
 "tests/models/config_models/deprecations.py" = ["E501"]
+
+[tool.ddev]
+repo = "extras"


### PR DESCRIPTION
### What does this PR do?

The `ddev.tool.repo` configuration option tells `ddev` what repo we are running in. This allows the `ddev config override` to automatically detect it and create a `.ddev.toml` override config that allows running `ddev` in extras in the correct repo without having to modify the config or having to pass `-e`.

### Motivation

It was added when the `config override` command was added but it has since been removed by mistake.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
