### PR TITLE
Add owner field to Chat Integrations manifest files

### DIFF
--- a/discord/manifest.json
+++ b/discord/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ccbbe4fc-2408-4373-8157-ae392c28cc8c",
   "app_id": "discord",
+  "owner": "chat-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `"chat-integrations"` to manifest.json files for Chat Integrations.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations, please let us know.

This provides clear ownership tracking for chat integrations as part of the initiative to add owner fields to all integration manifest.json files.

**For reviewer:** Please confirm:
1. Is `"chat-integrations"` the correct team slug?
2. Is `Chat Integrations` the correct workday team name to use as the team tag in SDP?

Thank you for your review\!

🤖 Generated with [Claude Code](https://claude.ai/code)