### PR TITLE
Add owner field to Serverless manifest files

### DIFF
--- a/vercel/manifest.json
+++ b/vercel/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3ee4a2db-aea9-4663-93a9-d5758f71ba9d",
   "app_id": "vercel",
+  "owner": "serverless",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `"serverless"` to manifest.json files for Serverless.

This provides clear ownership tracking for serverless integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

**For reviewer:** Please confirm:
1. Is `serverless` the correct datadog team slug in org 2?
2. Is `Serverless` the correct workday team name to use as the team tag in SDP?

Thank you for your review\!

🤖 Generated with [Claude Code](https://claude.ai/code)