### PR TITLE
IDP-592: Add owner field to Agent Integrations manifest files (Community integrations)

### DIFF
--- a/apache-apisix/manifest.json
+++ b/apache-apisix/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b842d639-caf6-4b3a-8115-52458b9a0753",
   "app_id": "apache-apisix",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/apache-apisix/manifest.json
+++ b/apache-apisix/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b842d639-caf6-4b3a-8115-52458b9a0753",
   "app_id": "apache-apisix",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/bind9/manifest.json
+++ b/bind9/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b37533b0-6f0e-4259-9971-083f08086fac",
   "app_id": "bind9",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/bind9/manifest.json
+++ b/bind9/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b37533b0-6f0e-4259-9971-083f08086fac",
   "app_id": "bind9",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cfssl/manifest.json
+++ b/cfssl/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "dfcfda46-a2e3-44e4-8f80-1603e0317b2d",
   "app_id": "cfssl",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cfssl/manifest.json
+++ b/cfssl/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "dfcfda46-a2e3-44e4-8f80-1603e0317b2d",
   "app_id": "cfssl",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b0c2527f-671e-4a98-aa74-807d7f1826e3",
   "app_id": "eventstore",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/eventstore/manifest.json
+++ b/eventstore/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b0c2527f-671e-4a98-aa74-807d7f1826e3",
   "app_id": "eventstore",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/exim/manifest.json
+++ b/exim/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c84e4868-f96b-49b6-8243-2031dde179af",
   "app_id": "exim",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/exim/manifest.json
+++ b/exim/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c84e4868-f96b-49b6-8243-2031dde179af",
   "app_id": "exim",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "50405147-1148-405a-9d81-ea48be4f613b",
   "app_id": "filebeat",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/filebeat/manifest.json
+++ b/filebeat/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "50405147-1148-405a-9d81-ea48be4f613b",
   "app_id": "filebeat",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/filemage/manifest.json
+++ b/filemage/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e8ffcc16-9430-4d73-8e01-4e135a872384",
   "app_id": "filemage",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/filemage/manifest.json
+++ b/filemage/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e8ffcc16-9430-4d73-8e01-4e135a872384",
   "app_id": "filemage",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/fluentbit/manifest.json
+++ b/fluentbit/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "eee076f9-145f-4333-ad76-7bb40e41afef",
   "app_id": "fluentbit",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/fluentbit/manifest.json
+++ b/fluentbit/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "eee076f9-145f-4333-ad76-7bb40e41afef",
   "app_id": "fluentbit",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/flume/manifest.json
+++ b/flume/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9e349061-5665-482d-9a5a-f3a07999bfae",
   "app_id": "flume",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/flume/manifest.json
+++ b/flume/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9e349061-5665-482d-9a5a-f3a07999bfae",
   "app_id": "flume",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/gatekeeper/manifest.json
+++ b/gatekeeper/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9c48b05d-ee74-4557-818e-14456c6f427b",
   "app_id": "gatekeeper",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/gatekeeper/manifest.json
+++ b/gatekeeper/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9c48b05d-ee74-4557-818e-14456c6f427b",
   "app_id": "gatekeeper",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/gnatsd/manifest.json
+++ b/gnatsd/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "91ef7414-0d7b-4ccd-b1a0-d23ef8b6780f",
   "app_id": "gnatsd",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/gnatsd/manifest.json
+++ b/gnatsd/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "91ef7414-0d7b-4ccd-b1a0-d23ef8b6780f",
   "app_id": "gnatsd",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/gnatsd_streaming/manifest.json
+++ b/gnatsd_streaming/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "264e486e-d704-4851-987a-d33c11036521",
   "app_id": "gnatsd-streaming",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/gnatsd_streaming/manifest.json
+++ b/gnatsd_streaming/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "264e486e-d704-4851-987a-d33c11036521",
   "app_id": "gnatsd-streaming",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/go_pprof_scraper/manifest.json
+++ b/go_pprof_scraper/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2b13f6b1-d3ba-4254-93c0-2ceaf783cd85",
   "app_id": "go-pprof-scraper",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/go_pprof_scraper/manifest.json
+++ b/go_pprof_scraper/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2b13f6b1-d3ba-4254-93c0-2ceaf783cd85",
   "app_id": "go-pprof-scraper",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/grpc_check/manifest.json
+++ b/grpc_check/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f0317cd5-e4b9-4147-998e-25c69fad94ed",
   "app_id": "grpc-check",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/grpc_check/manifest.json
+++ b/grpc_check/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f0317cd5-e4b9-4147-998e-25c69fad94ed",
   "app_id": "grpc-check",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/hbase_master/manifest.json
+++ b/hbase_master/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e53ed650-6454-4f69-abfc-2cedd35ec2c3",
   "app_id": "hbase-master",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/hbase_master/manifest.json
+++ b/hbase_master/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e53ed650-6454-4f69-abfc-2cedd35ec2c3",
   "app_id": "hbase-master",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/hbase_regionserver/manifest.json
+++ b/hbase_regionserver/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8835d739-bd99-49c1-bf71-8d20e9715e10",
   "app_id": "hbase-regionserver",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/hbase_regionserver/manifest.json
+++ b/hbase_regionserver/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8835d739-bd99-49c1-bf71-8d20e9715e10",
   "app_id": "hbase-regionserver",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/hikaricp/manifest.json
+++ b/hikaricp/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fa40ec7e-e8f6-4c4b-a675-31716b23a9fa",
   "app_id": "hikaricp",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/hikaricp/manifest.json
+++ b/hikaricp/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fa40ec7e-e8f6-4c4b-a675-31716b23a9fa",
   "app_id": "hikaricp",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/lighthouse/manifest.json
+++ b/lighthouse/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e61bdb03-995f-4f46-8b14-afd59e35453b",
   "app_id": "lighthouse",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/lighthouse/manifest.json
+++ b/lighthouse/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e61bdb03-995f-4f46-8b14-afd59e35453b",
   "app_id": "lighthouse",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "efcb18d9-2789-4481-bd4b-ff5a4c058dc3",
   "app_id": "logstash",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/logstash/manifest.json
+++ b/logstash/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "efcb18d9-2789-4481-bd4b-ff5a4c058dc3",
   "app_id": "logstash",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/nextcloud/manifest.json
+++ b/nextcloud/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a48ccc77-3e72-4e3b-b439-3ebe7e2688b7",
   "app_id": "nextcloud",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/nextcloud/manifest.json
+++ b/nextcloud/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a48ccc77-3e72-4e3b-b439-3ebe7e2688b7",
   "app_id": "nextcloud",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/nvml/manifest.json
+++ b/nvml/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2c7a8b1e-9343-4b4a-bada-5091e37c4806",
   "app_id": "nvml",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/nvml/manifest.json
+++ b/nvml/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2c7a8b1e-9343-4b4a-bada-5091e37c4806",
   "app_id": "nvml",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/octoprint/manifest.json
+++ b/octoprint/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f076efc3-c1c7-4e0a-b0dc-92870d655211",
   "app_id": "octoprint",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/octoprint/manifest.json
+++ b/octoprint/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f076efc3-c1c7-4e0a-b0dc-92870d655211",
   "app_id": "octoprint",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/php_apcu/manifest.json
+++ b/php_apcu/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ec09379e-851f-4ecc-be78-de5297087994",
   "app_id": "php-apcu",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/php_apcu/manifest.json
+++ b/php_apcu/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ec09379e-851f-4ecc-be78-de5297087994",
   "app_id": "php-apcu",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/php_opcache/manifest.json
+++ b/php_opcache/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "392e54ac-60d4-4225-ab5a-d75245e0ea06",
   "app_id": "php-opcache",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/php_opcache/manifest.json
+++ b/php_opcache/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "392e54ac-60d4-4225-ab5a-d75245e0ea06",
   "app_id": "php-opcache",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/pihole/manifest.json
+++ b/pihole/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "008d006b-6390-4b93-9302-dc37d9625b18",
   "app_id": "pihole",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/pihole/manifest.json
+++ b/pihole/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "008d006b-6390-4b93-9302-dc37d9625b18",
   "app_id": "pihole",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/ping/manifest.json
+++ b/ping/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "841c9313-628f-4861-ad0b-2d12c37ee571",
   "app_id": "ping",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/ping/manifest.json
+++ b/ping/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "841c9313-628f-4861-ad0b-2d12c37ee571",
   "app_id": "ping",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/puma/manifest.json
+++ b/puma/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c517e801-0fa5-4f5e-8175-a7d5d48a8131",
   "app_id": "puma",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/puma/manifest.json
+++ b/puma/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c517e801-0fa5-4f5e-8175-a7d5d48a8131",
   "app_id": "puma",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/radarr/manifest.json
+++ b/radarr/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e235eeb6-6996-467b-b07a-18742754de5a",
   "app_id": "radarr",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/radarr/manifest.json
+++ b/radarr/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e235eeb6-6996-467b-b07a-18742754de5a",
   "app_id": "radarr",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/reboot_required/manifest.json
+++ b/reboot_required/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "673a1136-68ad-46f4-ba6f-4203df10db6a",
   "app_id": "reboot-required",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/reboot_required/manifest.json
+++ b/reboot_required/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "673a1136-68ad-46f4-ba6f-4203df10db6a",
   "app_id": "reboot-required",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/resin/manifest.json
+++ b/resin/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ff99886d-87b7-407a-aa90-7bea5ca27564",
   "app_id": "resin",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/resin/manifest.json
+++ b/resin/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ff99886d-87b7-407a-aa90-7bea5ca27564",
   "app_id": "resin",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sendmail/manifest.json
+++ b/sendmail/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8169d145-8d1f-4bb8-a4de-a0aa9aa84c0b",
   "app_id": "sendmail",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sendmail/manifest.json
+++ b/sendmail/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8169d145-8d1f-4bb8-a4de-a0aa9aa84c0b",
   "app_id": "sendmail",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sonarr/manifest.json
+++ b/sonarr/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a0ce5329-1aca-454e-bcc2-b21457574acc",
   "app_id": "sonarr",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/sonarr/manifest.json
+++ b/sonarr/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a0ce5329-1aca-454e-bcc2-b21457574acc",
   "app_id": "sonarr",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/sortdb/manifest.json
+++ b/sortdb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "02cd7f3d-5394-4d08-8364-35c9d1af1377",
   "app_id": "sortdb",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sortdb/manifest.json
+++ b/sortdb/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "02cd7f3d-5394-4d08-8364-35c9d1af1377",
   "app_id": "sortdb",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/speedtest/manifest.json
+++ b/speedtest/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "550862f8-f1d1-4924-b802-185b865e09a4",
   "app_id": "speedtest",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/speedtest/manifest.json
+++ b/speedtest/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "550862f8-f1d1-4924-b802-185b865e09a4",
   "app_id": "speedtest",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a3c93ee5-077d-467d-87d7-a2325bdcf782",
   "app_id": "storm",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/storm/manifest.json
+++ b/storm/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a3c93ee5-077d-467d-87d7-a2325bdcf782",
   "app_id": "storm",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/syncthing/manifest.json
+++ b/syncthing/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a61c3428-6898-45be-8a20-89f4c039a56d",
   "app_id": "syncthing",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/syncthing/manifest.json
+++ b/syncthing/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a61c3428-6898-45be-8a20-89f4c039a56d",
   "app_id": "syncthing",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/trino/manifest.json
+++ b/trino/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "5d6fa7f8-e827-408c-9cf1-8f2bd64b45d3",
   "app_id": "trino",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/trino/manifest.json
+++ b/trino/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "5d6fa7f8-e827-408c-9cf1-8f2bd64b45d3",
   "app_id": "trino",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/unbound/manifest.json
+++ b/unbound/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "33cd72ba-822b-4a74-92eb-f1240ea71975",
   "app_id": "unbound",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/unbound/manifest.json
+++ b/unbound/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "33cd72ba-822b-4a74-92eb-f1240ea71975",
   "app_id": "unbound",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/unifi_console/manifest.json
+++ b/unifi_console/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "224a050d-7ed3-4e7a-ada6-410f61393fc0",
   "app_id": "unifi-console",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/unifi_console/manifest.json
+++ b/unifi_console/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "224a050d-7ed3-4e7a-ada6-410f61393fc0",
   "app_id": "unifi-console",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/upsc/manifest.json
+++ b/upsc/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4681a41f-efdc-4d22-b573-06e101b9cf24",
   "app_id": "upsc",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/upsc/manifest.json
+++ b/upsc/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4681a41f-efdc-4d22-b573-06e101b9cf24",
   "app_id": "upsc",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zabbix/manifest.json
+++ b/zabbix/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9b7022c4-95c7-4872-83b6-7eaba2cc9d88",
   "app_id": "zabbix",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zabbix/manifest.json
+++ b/zabbix/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9b7022c4-95c7-4872-83b6-7eaba2cc9d88",
   "app_id": "zabbix",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zenoh_router/manifest.json
+++ b/zenoh_router/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8ef30e8d-955c-4456-b176-a01f2560bda1",
   "app_id": "zenoh-router",
+  "owner": "community-open-source-engineering",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zenoh_router/manifest.json
+++ b/zenoh_router/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8ef30e8d-955c-4456-b176-a01f2560bda1",
   "app_id": "zenoh-router",
-  "owner": "community-open-source-engineering",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add \`owner\` field set to \`"agent-integrations"\` to manifest.json files for Agent Integrations team.

This provides clear ownership tracking for community integrations (apache-apisix → zenoh_router) as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

This PR includes 42 community integrations owned by the Agent Integrations team.