### PR TITLE
[DOCS-12018] Clarify how to find integration version

### DIFF
--- a/ping/README.md
+++ b/ping/README.md
@@ -21,7 +21,7 @@ For Agent v7.21+ / v6.21+, follow the instructions below to install the ping che
 
 1. Run the one of the following commands to install the Agent integration:
 
-  <div class="alert alert-info">To find the integration version, run <code>datadog-agent integration show datadog-ping</code>.</div>
+   <div class="alert alert-info">To find the integration version, refer to the integration's changelog on GitHub or the Release Notes tab in the integration tile.</div>
 
    ```shell
    # Linux


### PR DESCRIPTION
### What does this PR do?

We received feedback that a user wanted to know how to find the integration version to use in a listed command. This update adds a tip block with how to find the version.

### Motivation

Hotjar feedback.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

This solution feels like a bit of a one-off: ideally there would be a page I could link to, or maybe a reusable snippet, about finding the integration version. However, I decided to err on the side of simplicity for now, and just added it directly here. We can revisit if we see more feedback like this.
