### PR TITLE
Add owner field to Integrations Developer Platform manifest files (Group 1)

### DIFF
--- a/1e/manifest.json
+++ b/1e/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d86565ae-ca60-45c2-a0b9-944ec1e05a15",
   "app_id": "one-e",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/ably/manifest.json
+++ b/ably/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4596cd59-d3f2-4921-8133-3a448ccaea61",
   "app_id": "ably",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/adaptive_shield/manifest.json
+++ b/adaptive_shield/manifest.json
@@ -1,6 +1,7 @@
 {
   "manifest_version": "2.0.0",
   "app_id": "adaptive-shield",
+  "owner": "integrations-developer-platform",
   "app_uuid": "0c72bf61-1de6-4408-8a24-86f8e3413e07",
   "display_on_public_website": true,
   "tile": {

--- a/agora_analytics/manifest.json
+++ b/agora_analytics/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a752523e-9c3d-458c-a91a-af0c9fae5adc",
   "app_id": "agora-analytics",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/akamas/manifest.json
+++ b/akamas/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "akamas",
+  "owner": "integrations-developer-platform",
   "app_uuid": "019643fd-e352-70b1-a27c-3919f06ded71",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/akeyless_gateway/manifest.json
+++ b/akeyless_gateway/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a71a3b29-5921-4bc9-8a7e-38de5a940ad8",
   "app_id": "akeyless-gateway",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/alertnow/manifest.json
+++ b/alertnow/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "cdb258cc-5e74-4fa2-be21-1489375bb370",
   "app_id": "alertnow",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/algorithmia/manifest.json
+++ b/algorithmia/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "09ef6f74-1555-4082-a69e-b5cf21ec4512",
   "app_id": "algorithmia",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/altostra/manifest.json
+++ b/altostra/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c22d6f84-3404-4638-99bc-7cb19ab4508a",
   "app_id": "altostra",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/ambassador/manifest.json
+++ b/ambassador/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "eb591405-8cda-486a-8cf5-a06af769a3d7",
   "app_id": "ambassador",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/amixr/manifest.json
+++ b/amixr/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "051b4bbe-d7cc-46bf-9a66-169ab7d5a4aa",
   "app_id": "amixr",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/anecdote/manifest.json
+++ b/anecdote/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "35d64545-cee9-4eb6-98be-65cb9fdd944a",
   "app_id": "anecdote",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
    "tile": {
     "overview": "README.md#Overview",

--- a/apollo/manifest.json
+++ b/apollo/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b39f1239-b97f-4b3b-ab5a-7a888915eedd",
   "app_id": "apollo",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/appkeeper/manifest.json
+++ b/appkeeper/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fc54f5f2-0ce1-4d4e-b1e0-191eece029d3",
   "app_id": "appkeeper",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/appomni/manifest.json
+++ b/appomni/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "appomni",
+  "owner": "integrations-developer-platform",
   "app_uuid": "0194613a-1308-70c2-9889-c662c8e812d8",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/apptrail/manifest.json
+++ b/apptrail/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "302b6db7-d1d6-445c-ae20-00743775cb6b",
   "app_id": "apptrail",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/artie/manifest.json
+++ b/artie/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3ccc5034-0902-4e00-8a69-04d007d31310",
   "app_id": "artie",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/auth0/manifest.json
+++ b/auth0/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "0c91d12e-f01e-47d9-8a07-4dba1cde4b67",
   "app_id": "auth0",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/authzed_cloud/manifest.json
+++ b/authzed_cloud/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "authzed-cloud",
+  "owner": "integrations-developer-platform",
   "app_uuid": "01957258-b7bc-701c-b7f5-1ae15bba0209",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/backstage/manifest.json
+++ b/backstage/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2b89148d-0938-46fc-a9dc-fd8a45e583a9",
   "app_id": "backstage",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/blink/manifest.json
+++ b/blink/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f2bd43a7-bbc5-4f69-89b7-437afbbff9fd",
   "app_id": "blink",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/bluematador/manifest.json
+++ b/bluematador/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b1cfb279-ab1a-4f63-a04f-9c6508d06588",
   "app_id": "blue-matador",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/bonsai/manifest.json
+++ b/bonsai/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ec3141f4-b722-4eaa-be49-47c6eec76da9",
   "app_id": "bonsai",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/botprise/manifest.json
+++ b/botprise/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "91806afb-9bd7-4ab2-91e4-7c7f2d05780f",
   "app_id": "botprise",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/buoyant_cloud/manifest.json
+++ b/buoyant_cloud/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "dee4b74f-34b7-457e-98b1-7bb8306f2c18",
   "app_id": "buoyant-cloud",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/causely/manifest.json
+++ b/causely/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "0ac3b5eb-46d2-4091-a001-e95dc5782609",
   "app_id": "causely",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/celerdata/manifest.json
+++ b/celerdata/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "790d8932-0833-43ac-b9d8-d6d0a4f11517",
   "app_id": "celerdata",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/census/manifest.json
+++ b/census/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "7f4f3919-5b0a-4b4b-93e5-7f0c035f3887",
   "app_id": "census",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/chainguard/manifest.json
+++ b/chainguard/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "chainguard",
+  "owner": "integrations-developer-platform",
   "app_uuid": "0195624f-3d2a-7db6-ad4d-c1c1ce8a643b",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/cloudaeye/manifest.json
+++ b/cloudaeye/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4a0bb068-63fa-4cc2-a557-0452e8dca689",
   "app_id": "cloudaeye",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cloudnatix/manifest.json
+++ b/cloudnatix/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "caebfbe2-48ba-443f-b2c6-bd80122b2605",
   "app_id": "cloudnatix",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cloudquery-cloud/manifest.json
+++ b/cloudquery-cloud/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "727e53a9-0bbe-4277-8ed0-9e9425fe34de",
   "app_id": "cloudquery-cloud",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cloudquery/manifest.json
+++ b/cloudquery/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9a7d20ab-d200-4c5a-ae7c-b3e4fa18407d",
   "app_id": "cloudquery",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cloudsmith/manifest.json
+++ b/cloudsmith/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "92b5a159-e5e9-4e38-a4d4-b987cd03b7a1",
   "app_id": "cloudsmith",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cloudzero/manifest.json
+++ b/cloudzero/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6f1a61c2-e875-42f7-b8ba-94b191786846",
   "app_id": "cloudzero",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/configcat/manifest.json
+++ b/configcat/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "22b2d616-b246-457e-8883-a79bee8c467d",
   "app_id": "configcat",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/contrastsecurity/manifest.json
+++ b/contrastsecurity/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8509e113-cf2e-42f1-b8d4-1261720498a5",
   "app_id": "contrastsecurity",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cortex/manifest.json
+++ b/cortex/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "15baccdd-d89c-4591-ab45-e6378d8c174f",
   "app_id": "cortex",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cribl_stream/manifest.json
+++ b/cribl_stream/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2ef15aea-af91-4769-940c-2b124e4d04a6",
   "app_id": "cribl-stream",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add \`owner\` field set to \`"integrations-developer-platform"\` to manifest.json files for Integrations Developer Platform (Group 1).

This provides clear ownership tracking for Ecosystems integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

This is Group 1 of 4 PRs for Integrations Developer Platform integrations (39 integrations). Related PRs: Groups 2, 3, and 4 (coming next)