### PR TITLE
Add owner field to Integrations Developer Platform manifest files (Group 2)

### DIFF
--- a/cybersixgill_actionable_alerts/manifest.json
+++ b/cybersixgill_actionable_alerts/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b27feb80-b06f-4200-981a-e91a031d62e6",
   "app_id": "cybersixgill-actionable-alerts",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/cyral/manifest.json
+++ b/cyral/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "da6e2ea6-1611-4d37-9cc6-efce73bc4f31",
   "app_id": "cyral",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/dagster/manifest.json
+++ b/dagster/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "dagster-plus",
+  "owner": "integrations-developer-platform",
   "app_uuid": "019635d0-d25c-7e1b-86de-83baaac55b5e",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/docontrol/manifest.json
+++ b/docontrol/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "7622c46e-bade-44ce-99e1-a3529bf4fc04",
   "app_id": "docontrol",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/doctordroid/manifest.json
+++ b/doctordroid/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "5e75658c-065e-460f-b9f8-42bf100e361d",
   "app_id": "doctordroid",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/doppler/manifest.json
+++ b/doppler/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e22c8861-f652-42a9-9582-6470504b421f",
   "app_id": "doppler",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/downdetector/manifest.json
+++ b/downdetector/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "downdetector",
+  "owner": "integrations-developer-platform",
   "app_uuid": "0193da66-1a4a-7d09-b520-469edb80cf24",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/drata/manifest.json
+++ b/drata/manifest.json
@@ -1,6 +1,7 @@
 {
   "manifest_version": "2.0.0",
   "app_id": "drata-integration",
+  "owner": "integrations-developer-platform",
   "app_uuid": "c06736af-282f-4b3c-a9e6-2b049dbc0e2a",
   "display_on_public_website": true,
   "tile": {

--- a/dylibso-webassembly/manifest.json
+++ b/dylibso-webassembly/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "30eb706f-9143-461e-99af-89015e8493d5",
   "app_id": "webassembly-observe-sdk",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/embrace_mobile/manifest.json
+++ b/embrace_mobile/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "86988058-9b89-45a8-b92f-5473a96e4a36",
   "app_id": "embrace-mobile",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/emnify/manifest.json
+++ b/emnify/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "000307b4-8304-424a-8378-daf9a41b4d93",
   "app_id": "emnify",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/emqx/manifest.json
+++ b/emqx/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fa40ec7e-e8f6-4c4b-a675-31716b23a9df",
   "app_id": "emqx",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/eppo/manifest.json
+++ b/eppo/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1d7b7957-82d6-4e9d-8ba1-b697f01fc850",
   "app_id": "eppo",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/eversql/manifest.json
+++ b/eversql/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "bc900600-d0cf-4ddf-83b7-cdaba44d1525",
   "app_id": "eversql",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/fairwinds_insights_ui/manifest.json
+++ b/fairwinds_insights_ui/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d95c6f4f-7f99-4a29-9198-6921809efad6",
   "app_id": "fairwinds-insights-ui",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/fauna/manifest.json
+++ b/fauna/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2be7cc0c-a21f-43ad-b2b7-3f41a98ad299",
   "app_id": "fauna",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/federatorai/manifest.json
+++ b/federatorai/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c9192d7c-101d-44b2-8ddf-c5fcbe5c5306",
   "app_id": "federatorai",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/fiddler/manifest.json
+++ b/fiddler/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ee617671-508e-4bb3-ba25-8815b11a16aa",
   "app_id": "fiddler",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/finout/manifest.json
+++ b/finout/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fc1d0074-ccd3-4513-a5c3-3d8ee99b1e49",
   "app_id": "finout",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/firefly/manifest.json
+++ b/firefly/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "58481132-c79e-4659-8064-7cdaabbbc999",
   "app_id": "firefly",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/flagsmith-rum/manifest.json
+++ b/flagsmith-rum/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a88f10b6-aef7-41df-979e-d70b720c6752",
   "app_id": "flagsmith-rum",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/flagsmith/manifest.json
+++ b/flagsmith/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "0ad66873-2958-4ca5-ae25-ee893b4c6e31",
   "app_id": "flagsmith",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/gatling_enterprise/manifest.json
+++ b/gatling_enterprise/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "gatling-enterprise",
+  "owner": "integrations-developer-platform",
   "app_uuid": "019662ce-ced4-7e23-9738-bd4c09f38b64",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/gigamon/manifest.json
+++ b/gigamon/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "041cf2fe-f391-4d8b-930c-b700c648c683",
   "app_id": "gigamon",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/gremlin/manifest.json
+++ b/gremlin/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "451a4863-1767-4c11-8831-d196ae4643d0",
   "app_id": "gremlin",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/harness_cloud_cost_management/manifest.json
+++ b/harness_cloud_cost_management/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3eb2e9ef-2c9c-45b6-8f1c-8a900910f948",
   "app_id": "harness-cloud-cost-management",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/harness_harness_notifications/manifest.json
+++ b/harness_harness_notifications/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "harness-harness-notifications",
+  "owner": "integrations-developer-platform",
   "app_uuid": "0194c0d4-f822-7117-be7a-1ed1ccf587e7",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/hasura_cloud/manifest.json
+++ b/hasura_cloud/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d7eb9597-f00b-48dc-9100-7afda5fe4bce",
   "app_id": "hasura-cloud",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/hawkeye_by_neubird/manifest.json
+++ b/hawkeye_by_neubird/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "hawkeye-by-neubird",
+  "owner": "integrations-developer-platform",
   "app_uuid": "0195aa67-c4bc-714b-a2e7-0230fb1055e7",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/ilert/manifest.json
+++ b/ilert/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "12731389-915a-4fb7-baec-3319f87dfc7f",
   "app_id": "ilert",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/inngest/manifest.json
+++ b/inngest/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "inngest",
+  "owner": "integrations-developer-platform",
   "app_uuid": "01960169-7c57-7080-bc2b-05f5bf2828ac",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/insightfinder/manifest.json
+++ b/insightfinder/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "144b8c72-b842-4257-9815-93aa63ad2da1",
   "app_id": "insightfinder",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/instabug/manifest.json
+++ b/instabug/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "37d9bc39-888f-4bec-b8c5-3c137cf88f84", 
   "app_id": "instabug",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/invary/manifest.json
+++ b/invary/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "13509f2d-d922-4d8b-b3c2-7a8c2dd7fc54",
   "app_id": "invary",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/isdown/manifest.json
+++ b/isdown/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "22560cfe-27cc-492f-a978-64dfcdc3b3c0",
   "app_id": "isdown",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/jfrog_platform_cloud/manifest.json
+++ b/jfrog_platform_cloud/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "798102cb-6c52-4a16-bc1b-48c2e6b54e71",
   "app_id": "jfrog-platform-cloud",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/jfrog_platform_self_hosted/manifest.json
+++ b/jfrog_platform_self_hosted/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b2748652-b976-461c-91dd-5abd4467f361",
   "app_id": "jfrog-platform",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/k6/manifest.json
+++ b/k6/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "41cc233f-4db9-447b-925a-44363b202130",
   "app_id": "k6",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kameleoon/manifest.json
+++ b/kameleoon/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d47149c7-b559-43f5-a4c8-2dc2480fcd4d",
   "app_id": "kameleoon",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/keep/manifest.json
+++ b/keep/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "40ac95c0-35bd-49c8-a5f0-b21037bc87b4",
   "app_id": "keep",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/kernelcare/manifest.json
+++ b/kernelcare/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "7bfd2b8a-d461-4890-aeba-f1e9eab617c7",
   "app_id": "kernelcare",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add \`owner\` field set to \`"integrations-developer-platform"\` to manifest.json files for Integrations Developer Platform (Group 2).

This provides clear ownership tracking for Ecosystems integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

This is Group 2 of 4 PRs for Integrations Developer Platform integrations (41 integrations). Related PRs: #2796 (Group 1) and Groups 3, 4 (coming next)