### PR TITLE
Add owner field to Integrations Developer Platform manifest files (Group 3)

### DIFF
--- a/komodor/manifest.json
+++ b/komodor/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "995fe904-e761-4f2f-8dbf-148baf3f080a",
   "app_id": "komodor",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/lambdatest/manifest.json
+++ b/lambdatest/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8d4556af-b5e8-4608-a4ca-4632111931c1",
   "app_id": "lambdatest",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/launchdarkly/manifest.json
+++ b/launchdarkly/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "7144d0c5-42f2-4cc5-b562-5f77debc0c52",
   "app_id": "launchdarkly",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/loadrunner_professional/manifest.json
+++ b/loadrunner_professional/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e6b5ab52-139d-4dde-a4ad-94fedeac7f29",
   "app_id": "loadrunner-professional",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/mendix/manifest.json
+++ b/mendix/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4119b134-c828-4e14-95b5-585bb13d314a",
   "app_id": "mendix",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/mergify/manifest.json
+++ b/mergify/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "17230c84-50c7-4025-8fc8-69a9bc0bd502",
   "app_id": "mergify",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/mergify_oauth/manifest.json
+++ b/mergify_oauth/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3b53fe32-b47e-4a29-881f-b90397a11589",
   "app_id": "mergify-oauth",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/modal/manifest.json
+++ b/modal/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "faa29018-d015-4134-956e-40912d774640",
   "app_id": "modal",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/moovingon_ai/manifest.json
+++ b/moovingon_ai/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1a02140e-4927-49c9-8442-dff81a18c703",
   "app_id": "moovingon-ai",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/n2ws/manifest.json
+++ b/n2ws/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6c0176c4-b878-43e0-a5a8-d280b0fa123e",
   "app_id": "n2ws",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/neo4j/manifest.json
+++ b/neo4j/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f2657bb8-ded4-48f3-8095-f703cc203149",
   "app_id": "neo4j",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/neoload/manifest.json
+++ b/neoload/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3d16e6da-7ac2-47b4-95c0-0d221686f05a",
   "app_id": "neoload",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/neutrona/manifest.json
+++ b/neutrona/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f44f84d4-1436-4ab1-8023-b952850b64c8",
   "app_id": "neutrona",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/ngrok/manifest.json
+++ b/ngrok/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3b096ceb-d7a5-4bb5-bf0a-3a07d308d56a",
   "app_id": "ngrok",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/nn_sdwan/manifest.json
+++ b/nn_sdwan/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8ff5c833-1498-4e63-9ef2-8deecf444d09",
   "app_id": "nn-sdwan",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/nobl9/manifest.json
+++ b/nobl9/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "678f6805-2038-4705-80b3-de7cc143baef",
   "app_id": "nobl9",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/notion/manifest.json
+++ b/notion/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "0a709534-658c-4d8f-99a3-566dd7cd809b",
   "app_id": "notion",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/ns1/manifest.json
+++ b/ns1/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8bc08030-a931-42a0-b9c0-9ca87f3e0e12",
   "app_id": "ns1",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/ocient/manifest.json
+++ b/ocient/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c2769280-0bee-4e1a-a6ea-0c3e66fe1500",
   "app_id": "ocient",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/onepane/manifest.json
+++ b/onepane/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "68e9daf8-3439-49a0-8609-cdb91d72a036",
   "app_id": "onepane",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/packetfabric/manifest.json
+++ b/packetfabric/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "da10a120-217b-40f3-8b7f-7dc2fdea3b94",
   "app_id": "packetfabric",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/pagerduty_ui/manifest.json
+++ b/pagerduty_ui/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fbbb4a11-4a8f-4911-bdf7-bd867d9bdfb2",
   "app_id": "pagerduty-ui",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/perfectscale/manifest.json
+++ b/perfectscale/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1f6c7afa-b008-4fa6-a82d-8259c9c423e3",
   "app_id": "perfectscale",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/perimeterx/manifest.json
+++ b/perimeterx/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "47527216-ad8e-454b-8291-494f05c2d5c9",
   "app_id": "perimeterx",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/pliant/manifest.json
+++ b/pliant/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "28fb0874-e3be-4171-819d-142f1c9dd3cc",
   "app_id": "pliant",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/portworx/manifest.json
+++ b/portworx/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e682ab93-39cd-403b-a16f-8082961bc081",
   "app_id": "portworx",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/postman/manifest.json
+++ b/postman/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9ba70e31-8e84-4d6b-84a1-95d6ba713df9",
   "app_id": "postman",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/pulumi/manifest.json
+++ b/pulumi/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "7604c52b-dc07-4854-a5e4-799ab62798d8",
   "app_id": "pulumi",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/purefa/manifest.json
+++ b/purefa/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a2d8f393-62cd-4ece-bfab-e30797698b12",
   "app_id": "purefa",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/purefb/manifest.json
+++ b/purefb/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "50ae3c61-a87d-44ee-9917-df981184ff8a",
   "app_id": "purefb",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/qdrant/manifest.json
+++ b/qdrant/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "bee8e975-219c-4673-83c0-9fa68b973298",
   "app_id": "qdrant",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/redis_cloud/manifest.json
+++ b/redis_cloud/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "0b59b80e-db72-44a6-8c2b-67475d10ad71",
   "app_id": "redis-cloud",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/redis_enterprise/manifest.json
+++ b/redis_enterprise/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b569beaa-dbf6-4c40-a640-fab0ea2b9cab",
   "app_id": "redis-enterprise",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/redisenterprise/manifest.json
+++ b/redisenterprise/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a353f8c5-240c-48f9-b2a1-c86d2da0c07e",
   "app_id": "redisenterprise",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/redpanda/manifest.json
+++ b/redpanda/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4c7855c5-6c2c-46c5-bfc3-1a7df1ac6b77",
   "app_id": "redpanda",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/reflectiz/manifest.json
+++ b/reflectiz/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "display_on_public_website": true,
   "app_id": "reflectiz",
+  "owner": "integrations-developer-platform",
   "app_uuid": "79767e7d-f5db-4528-aeea-1cd68649ccd8",
   "tile": {
     "overview": "README.md#Overview",

--- a/retool/manifest.json
+++ b/retool/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "13239057-ebc6-4cb6-a789-35f064bbcd0f",
   "app_id": "retool",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/rigor/manifest.json
+++ b/rigor/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f9ab0c97-235c-4f88-8b92-89eb563e18ba",
   "app_id": "rigor",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/robust_intelligence_ai_firewall/manifest.json
+++ b/robust_intelligence_ai_firewall/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "1d208134-9005-4a79-bbc1-445950d1a5c7",
   "app_id": "robust-intelligence-ai-firewall",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/rookout/manifest.json
+++ b/rookout/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a82a4f89-0690-48cf-bad0-9603fb652f44",
   "app_id": "rookout",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add \`owner\` field set to \`"integrations-developer-platform"\` to manifest.json files for Integrations Developer Platform (Group 3).

This provides clear ownership tracking for Ecosystems integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

This is Group 3 of 4 PRs for Integrations Developer Platform integrations (40 integrations). Related PRs: #2796 (Group 1), #2797 (Group 2) and Group 4 (coming next)