### PR TITLE
Add owner field to Integrations Developer Platform manifest files (Group 4)

### DIFF
--- a/rundeck/manifest.json
+++ b/rundeck/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "beb808d2-cc12-4bc5-8ff7-b63552b35e0a",
   "app_id": "rundeck",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/scalr/manifest.json
+++ b/scalr/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d74ce5c8-4e5a-485a-be79-ff55f8205c9d",
   "app_id": "scalr",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/scaphandre/manifest.json
+++ b/scaphandre/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "0aa80baa-7ba6-4264-97ae-5475a6f796dc",
   "app_id": "scaphandre",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/seagence/manifest.json
+++ b/seagence/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "94f4e504-c98c-466f-b934-5e5ee0331944",
   "app_id": "seagence",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sedai/manifest.json
+++ b/sedai/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fa7de455-fef8-4cb2-af30-9baa50e351f2",
   "app_id": "sedai",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/signl4/manifest.json
+++ b/signl4/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "07952edd-2dc5-4c11-a697-5cba325f64ee",
   "app_id": "signl4",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/singlestoredb_cloud/manifest.json
+++ b/singlestoredb_cloud/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c7638089-0864-4ddc-bd32-b731c58fe567",
   "app_id": "singlestoredb-cloud",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sleuth/manifest.json
+++ b/sleuth/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "7923b3ef-2436-4315-bf2e-7631a6975886",
   "app_id": "sleuth",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sofy_sofy/manifest.json
+++ b/sofy_sofy/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "eea6fdbc-2f8d-4483-bbd3-767818b1c25a",
   "app_id": "sofy",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sosivio/manifest.json
+++ b/sosivio/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d98f7912-e5a3-48bc-b63e-612d835bf6b4",
   "app_id": "sosivio",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/speedscale/manifest.json
+++ b/speedscale/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "35e3ad0c-9189-4453-b3c3-2b4aefa7c176",
   "app_id": "speedscale",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/split/manifest.json
+++ b/split/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "690989fe-dca5-4394-b38a-86f9770dd470",
   "app_id": "split",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/squadcast/manifest.json
+++ b/squadcast/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "cfa65726-33af-42bf-8be3-7abb43147a47",
   "app_id": "squadcast",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/stackpulse/manifest.json
+++ b/stackpulse/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c42edc68-cb25-43f9-9bd2-657a2b7dea82",
   "app_id": "stackpulse",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/stardog/manifest.json
+++ b/stardog/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a4d874ba-7173-4c43-8cc8-09f966186be8",
   "app_id": "stardog",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/statsig/manifest.json
+++ b/statsig/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "57fb9235-151d-4ed9-b15e-a3e6f918dcca",
   "app_id": "statsig",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/steadybit/manifest.json
+++ b/steadybit/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "b1194c36-afd0-47dc-9c0a-11f3ab82f387",
   "app_id": "steadybit",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/stormforge/manifest.json
+++ b/stormforge/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6f1ddcc9-e704-4f94-941b-8a914fcd89a0",
   "app_id": "stormforge",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/superwise/manifest.json
+++ b/superwise/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "814d45d4-bf11-46c9-98a2-5fab9c997c94",
   "app_id": "superwise",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sym/manifest.json
+++ b/sym/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d81d1dd3-d5e8-4373-98a6-f95b797b3f9d",
   "app_id": "sym",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/taskcall/manifest.json
+++ b/taskcall/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "dd54da03-0a8c-4796-aaa6-61eeb04e611b",
   "app_id": "taskcall",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tidb/manifest.json
+++ b/tidb/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "79e5c6d7-c494-4df7-98bc-c639e211c0b8",
   "app_id": "tidb",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tidb_cloud/manifest.json
+++ b/tidb_cloud/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9ed710d3-49d4-41fa-a304-0b27f289bdb7",
   "app_id": "tidb-cloud",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/torq/manifest.json
+++ b/torq/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "56e675d8-a461-46ec-93e9-9e8618d21354",
   "app_id": "torq",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/twingate/manifest.json
+++ b/twingate/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c88bd253-18da-4224-af14-7854ce8ae6ed",
   "app_id": "twingate",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/tyk/manifest.json
+++ b/tyk/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "caca4c4f-104b-4d28-a051-f09bc58a0a32",
   "app_id": "tyk",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/typingdna_activelock/manifest.json
+++ b/typingdna_activelock/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e4eb4314-400c-4c30-8842-60d74e7f455a",
   "app_id": "typingdna-activelock",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/unitq/manifest.json
+++ b/unitq/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "7781542f-b4a2-40e2-86cd-9987980a0ead",
   "app_id": "unitq",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/upbound_uxp/manifest.json
+++ b/upbound_uxp/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f1427ca4-4b88-484a-a7c5-9cc66542b0d9",
   "app_id": "upbound-uxp",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/upstash/manifest.json
+++ b/upstash/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "fe1f17e3-11a4-4e44-b819-8781ebcc86f8",
   "app_id": "upstash",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/uptycs/manifest.json
+++ b/uptycs/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d27ee4b6-649d-42bd-b7ac-fb40537d7031",
   "app_id": "uptycs",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/vantage/manifest.json
+++ b/vantage/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "2784a986-2673-4189-a3b8-320755f6c2b4",
   "app_id": "vantage",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/vespa/manifest.json
+++ b/vespa/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "9e31df30-189f-468f-88c7-9c73caf4cdca",
   "app_id": "vespa",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/wayfinder/manifest.json
+++ b/wayfinder/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a68bad83-ba55-4350-a913-2f98bb667bad",
   "app_id": "wayfinder",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/yugabytedb_managed/manifest.json
+++ b/yugabytedb_managed/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "c5cf1ad4-fa3f-4835-9f3b-f467288b382a",
   "app_id": "yugabytedb-managed",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zebrium/manifest.json
+++ b/zebrium/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a1fa9510-af05-4950-ad67-4eed3f14d4bf",
   "app_id": "zebrium",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zenduty/manifest.json
+++ b/zenduty/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "0f2dea25-5757-477c-ad92-d459133d8b05",
   "app_id": "zenduty",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/zilliz_cloud_zilliz_cloud/manifest.json
+++ b/zilliz_cloud_zilliz_cloud/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "zilliz-cloud-zilliz-cloud",
+  "owner": "integrations-developer-platform",
   "app_uuid": "01930078-8f78-7bf8-a96f-2104f77b1c90",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,


### PR DESCRIPTION
Add \`owner\` field set to \`"integrations-developer-platform"\` to manifest.json files for Integrations Developer Platform (Group 4).

This provides clear ownership tracking for Ecosystems integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

This is Group 4 of 4 PRs for Integrations Developer Platform integrations (38 integrations). Related PRs: #2796 (Group 1), #2797 (Group 2), #2798 (Group 3)