### PR TITLE
Add owner field to remaining Integrations Developer Platform manifest files

### DIFF
--- a/aimon/manifest.json
+++ b/aimon/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "aimon",
+  "owner": "integrations-developer-platform",
   "app_uuid": "019646ae-150c-78c1-aa29-fbdf76f0cab0",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/contrast_security_adr/manifest.json
+++ b/contrast_security_adr/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "contrast-security-adr",
+  "owner": "integrations-developer-platform",
   "app_uuid": "01967c4b-c618-7f2d-9af8-db3506afd1b5",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/gravitee/manifest.json
+++ b/gravitee/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "gravitee",
+  "owner": "integrations-developer-platform",
   "app_uuid": "0196aad1-ada8-7064-951a-d8d2f5931688",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,


### PR DESCRIPTION
Add \`owner\` field set to \`"integrations-developer-platform"\` to manifest.json files for remaining Integrations Developer Platform integrations.

This provides clear ownership tracking for aimon, gravitee, and contrast_security_adr integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

This PR includes 3 additional integrations for the Integrations Developer Platform team in integrations-extras.