### PR TITLE
[IDP-592] Add owner field to Agent Integrations integrations

### DIFF
--- a/bottomline_recordandreplay/manifest.json
+++ b/bottomline_recordandreplay/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "d87fbcfa-71db-4d62-8264-5d88ba2338ce",
   "app_id": "bottomline-recordandreplay",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/concourse_ci/manifest.json
+++ b/concourse_ci/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "eb83d03f-e1d6-4718-8e54-922f4d2528b1",
   "app_id": "concourse-ci",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/convox/manifest.json
+++ b/convox/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4476973b-6e79-4861-a321-7e24e581873b",
   "app_id": "convox",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/gitea/manifest.json
+++ b/gitea/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f4cd02de-cfb8-4de9-a809-7a772ba738ca",
   "app_id": "gitea",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/lacework/manifest.json
+++ b/lacework/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "e23af0ca-003e-4b3d-b6c5-24894b710750",
   "app_id": "lacework",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/logzio/manifest.json
+++ b/logzio/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a637cc4e-f31f-4b35-9fff-76a8e7557d66",
   "app_id": "logz-io",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/nomad/manifest.json
+++ b/nomad/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "245bf496-4185-4407-a0fd-d6ef6fc125bb",
   "app_id": "nomad",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/rbltracker/manifest.json
+++ b/rbltracker/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "4b512bd9-ca9d-4d6a-b4f2-5fec54ce75bc",
   "app_id": "rbltracker",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/redis_sentinel/manifest.json
+++ b/redis_sentinel/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "207e2b2c-5fad-40a4-a4fc-09f119e142d3",
   "app_id": "redis-sentinel",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/snmpwalk/manifest.json
+++ b/snmpwalk/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "bc37c561-7ac5-4799-a56b-d85347bc9ff1",
   "app_id": "snmpwalk",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/sqreen/manifest.json
+++ b/sqreen/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "3b9c7a33-a133-47b9-ac1d-3a918d378ecd",
   "app_id": "sqreen",
+  "owner": "agent-integrations",
   "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",

--- a/vns3/manifest.json
+++ b/vns3/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f6ffc9ae-a65d-41e4-8abd-c7194fc39a9a",
   "app_id": "vns3",
+  "owner": "agent-integrations",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
## Summary
Add `owner` field set to `"agent-integrations"` to manifest.json files for Agent Integrations integrations.

## Integrations Added (12 total):
- bottomline_recordandreplay
- concourse_ci
- convox
- gitea
- lacework
- logzio
- nomad
- rbltracker
- redis_sentinel
- snmpwalk
- sqreen
- vns3

## Test plan
- [x] Verify manifest.json files have valid JSON syntax
- [x] Confirm owner field is correctly added after app_id
- [ ] Team review to confirm ownership is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)