### PR TITLE
[IDP-592] Add owner field to oceanbase-cloud integration

### DIFF
--- a/oceanbasecloud/manifest.json
+++ b/oceanbasecloud/manifest.json
@@ -2,6 +2,7 @@
     "manifest_version": "2.0.0",
     "app_uuid": "a42252f6-63f8-4da8-bce9-c765f30e7771",
     "app_id": "oceanbase-cloud",
+    "owner": "integrations-developer-platform",
     "display_on_public_website": true,
     "tile": {
         "overview": "README.md#Overview",


### PR DESCRIPTION
## Summary
Add `owner` field set to `"integrations-developer-platform"` to manifest.json file for the oceanbase-cloud integration.

## Integration Added:
- oceanbase-cloud

This integration belongs to the Integrations Developer Platform team.

## Test plan
- [x] Verify manifest.json file has valid JSON syntax
- [x] Confirm owner field is correctly added after app_id
- [ ] Team review to confirm ownership is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)