### PR TITLE
[LOGSC-2395] add bypasse for new linter rule on grok parsers

### DIFF
--- a/zscaler/assets/logs/zscaler.yaml
+++ b/zscaler/assets/logs/zscaler.yaml
@@ -1,3 +1,4 @@
+# bypass-global-grok-parser-count-per-pipeline-checks
 id: zscaler
 metric_id: z-scaler
 backend_only: false


### PR DESCRIPTION
This integration doesn’t comply with the new linter rule limiting the maximum number of parsers per pipeline, so it needs to bypass the check.