### PR TITLE
IDP-592 Add owner field to RUM - Mobile integrations

### DIFF
--- a/rum_android/manifest.json
+++ b/rum_android/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a70b6926-49a8-4f90-8190-315170e97e4f",
   "app_id": "rum-android",
+  "owner": "rum-mobile",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/rum_expo/manifest.json
+++ b/rum_expo/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "6894cf91-e7a2-4600-966b-20a0c99ff08d",
   "app_id": "rum-expo",
+  "owner": "rum-mobile",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/rum_flutter/manifest.json
+++ b/rum_flutter/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "a7344e0c-5fcf-43c0-af3b-734b484c1f29",
   "app_id": "rum-flutter",
+  "owner": "rum-mobile",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/rum_ios/manifest.json
+++ b/rum_ios/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "53933f32-091c-4b8d-83a5-bd53ac9eacdb",
   "app_id": "rum-ios",
+  "owner": "rum-mobile",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/rum_react_native/manifest.json
+++ b/rum_react_native/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "61207de8-cc1e-4915-a18a-7fb25093d85c",
   "app_id": "rum-react-native",
+  "owner": "rum-mobile",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/rum_roku/manifest.json
+++ b/rum_roku/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "0ab4b7a1-f017-4b3c-ab0f-eab5d476f132",
   "app_id": "rum-roku",
+  "owner": "rum-mobile",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `"rum-mobile"` to manifest.json files for RUM - Mobile integrations.

## Integrations Added (6 total):
- rum_android (rum-android)
- rum_expo (rum-expo)
- rum_flutter (rum-flutter)
- rum_ios (rum-ios)
- rum_react_native (rum-react-native)
- rum_roku (rum-roku)

This provides clear ownership tracking for RUM Mobile integrations as part of the initiative to add owner fields to all integration manifest.json files.

**Note:** These integrations are our best guesses for the RUM - Mobile team. If you don't own these integrations or if we're missing any integrations owned by this team, please let us know.

**For reviewer:** Please confirm:
1. Is `rum-mobile` the correct Datadog team slug in org 2 for tracking ownership?
2. For the display-tile feature flags in SDP, should we use `RUM - Mobile` as the workday team name to use as the `team` tag?

Thank you for your review\!

🤖 Generated with [Claude Code](https://claude.ai/code)