### PR TITLE
IDP-800: Add owner field to Integrations Developer Platform manifest files

### DIFF
--- a/sigsci/manifest.json
+++ b/sigsci/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "edc9a664-24f1-45ee-88ad-04e5da064f51",
   "app_id": "sigsci",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/split-rum/manifest.json
+++ b/split-rum/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "750d9e38-2856-44fe-98d0-9fbbc617d876",
   "app_id": "split-rum",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/statsig_rum/manifest.json
+++ b/statsig_rum/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "86a69c7d-8042-4f93-96b1-f139b2058644",
   "app_id": "statsig-rum",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",

--- a/warpstream/manifest.json
+++ b/warpstream/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "warpstream",
+  "owner": "integrations-developer-platform",
   "app_uuid": "01954cf7-1c47-75a3-818b-bf5ebeacb349",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/webb_ai/manifest.json
+++ b/webb_ai/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "ca4c3360-0e0f-4257-a392-8d6e461a3806",
   "app_id": "webb-ai",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
Add `owner` field set to `"integrations-developer-platform"` to manifest.json files for Integrations Developer Platform team.

This provides clear ownership tracking for IDP-managed integrations as part of IDP-800 to add owner fields to integration manifest.json files.

**Integrations updated (5 files changed):**
- sigsci, split-rum, statsig_rum, warpstream, webb_ai

Since `integrations-developer-platform` is an existing owner team, no team confirmation needed.

🤖 Generated with [Claude Code](https://claude.ai/code)