### PR TITLE
[DOCS-12377] Remove Open Policy Agent integration

### DIFF
--- a/open_policy_agent/manifest.json
+++ b/open_policy_agent/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "98c54837-27eb-48ca-9780-29bb593eecb8",
   "app_id": "open-policy-agent",
-  "display_on_public_website": true,
+  "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?

This integration has been deprecated in favor of the [Gatekeeper](https://docs.datadoghq.com/integrations/gatekeeper/) integration for Open Policy Agent metrics. This PR marks the integration as no longer public so it will not show up in the docs, and I will follow up with the engineering team to remove the code for the integration afterward.

See also https://github.com/DataDog/documentation/pull/32539.

### Motivation

The Docs team received a request to remove the integration.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If this PR includes a log pipeline, please add a description describing the remappers and processors. 