### PR TITLE
Add back pinned actions to test-all

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -63,7 +63,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j7a4721a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Aqua
       target: aqua
@@ -81,7 +81,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j68e2604:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: AWS Pricing
       target: aws_pricing
@@ -99,7 +99,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd342fce:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: BIND 9
       target: bind9
@@ -117,7 +117,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j9eb5f31:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: celerdata
       target: celerdata
@@ -135,7 +135,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jcb3c31b:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: cfssl
       target: cfssl
@@ -153,7 +153,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j6a8ad70:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: CloudNatix
       target: cloudnatix
@@ -171,7 +171,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja2364fe:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Cloudsmith
       target: cloudsmith
@@ -189,7 +189,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja669dc6:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: cybersixgill_actionable_alerts
       target: cybersixgill_actionable_alerts
@@ -207,7 +207,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j3263e78:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Cyral
       target: cyral
@@ -225,7 +225,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jfe56917:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: emqx
       target: emqx
@@ -243,7 +243,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j8c2c004:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Eventstore
       target: eventstore
@@ -261,7 +261,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jbb3d7c9:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: exim
       target: exim
@@ -279,7 +279,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j0180cad:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: fiddler
       target: fiddler
@@ -297,7 +297,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jec10af8:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Filebeat
       target: filebeat
@@ -315,7 +315,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j77495f2:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: filemage
       target: filemage
@@ -333,7 +333,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd678fea:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Fluent Bit
       target: fluentbit
@@ -351,7 +351,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jb8cf774:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: flume
       target: flume
@@ -369,7 +369,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jb4053fb:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Gatekeeper
       target: gatekeeper
@@ -387,7 +387,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j94cb576:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Gitea
       target: gitea
@@ -405,7 +405,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdb917e1:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Gnatsd
       target: gnatsd
@@ -423,7 +423,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j5bcfa2e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Gnatsd Streaming
       target: gnatsd_streaming
@@ -441,7 +441,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdb696b5:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: go_pprof_scraper
       target: go_pprof_scraper
@@ -459,7 +459,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jb27a2a4:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: gRPC Check
       target: grpc_check
@@ -477,7 +477,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j2eba458:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: hikaricp
       target: hikaricp
@@ -495,7 +495,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j43aee0d:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Kepler
       target: kepler
@@ -513,7 +513,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja3e78b9:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Kernelcare
       target: kernelcare
@@ -531,7 +531,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j68bd571:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Lighthouse
       target: lighthouse
@@ -549,7 +549,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j41ca94d:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Logstash
       target: logstash
@@ -567,7 +567,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j1d16977:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Mergify
       target: mergify
@@ -585,7 +585,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j981d202:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Neo4j
       target: neo4j
@@ -603,7 +603,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf1d4aee:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Neutrona
       target: neutrona
@@ -621,7 +621,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j337128a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Nextcloud
       target: nextcloud
@@ -639,7 +639,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j581723e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Netnology SD-WAN
       target: nn_sdwan
@@ -657,7 +657,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j61be2af:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: NS1
       target: ns1
@@ -675,7 +675,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   je41f6a9:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: nvml
       target: nvml
@@ -693,7 +693,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j1018635:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Ocient
       target: ocient
@@ -711,7 +711,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   je2bd36a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: OctoPrint
       target: octoprint
@@ -729,7 +729,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdcde1e7:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: open_policy_agent
       target: open_policy_agent
@@ -747,7 +747,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdcd599a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: PHP APCu
       target: php_apcu
@@ -765,7 +765,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf9ca17e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: PHP OPcache
       target: php_opcache
@@ -783,7 +783,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j7220ce3:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: pihole
       target: pihole
@@ -801,7 +801,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j6a4c3a4:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Ping
       target: ping
@@ -819,7 +819,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdb59cb8:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Portworx
       target: portworx
@@ -837,7 +837,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j831ad4c:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Puma
       target: puma
@@ -855,7 +855,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j689e0be:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: PureFA
       target: purefa
@@ -873,7 +873,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja269254:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: PureFB
       target: purefb
@@ -891,7 +891,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja7891bb:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Qdrant
       target: qdrant
@@ -909,7 +909,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd4cdbe0:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Radarr
       target: radarr
@@ -927,7 +927,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j473bdb7:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Reboot Required
       target: reboot_required
@@ -945,7 +945,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jacbd216:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Redis Cloud
       target: redis_cloud
@@ -963,7 +963,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j9989d64:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Redis Enterprise V2
       target: redis_enterprise
@@ -981,7 +981,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd9748f1:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Redis Enterprise Prometheus
       target: redis_enterprise_prometheus
@@ -999,7 +999,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja8f7203:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Redis Sentinel
       target: redis_sentinel
@@ -1017,7 +1017,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja156788:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Redis Enterprise
       target: redisenterprise
@@ -1035,7 +1035,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jce0dc1a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Redpanda
       target: redpanda
@@ -1053,7 +1053,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j09df637:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Resilience4j
       target: resilience4j
@@ -1071,7 +1071,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jc5ec7c0:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Resin
       target: resin
@@ -1089,7 +1089,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j4accb07:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Riak MDC Replication
       target: riak_repl
@@ -1107,7 +1107,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jfcdbb05:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Robust Intelligence AI Firewall
       target: robust_intelligence_ai_firewall
@@ -1125,7 +1125,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf772a8e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Scalr
       target: scalr
@@ -1143,7 +1143,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja91188c:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Scaphandre
       target: scaphandre
@@ -1161,7 +1161,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf44ab67:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Sendmail
       target: sendmail
@@ -1179,7 +1179,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j190d837:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: snmpwalk
       target: snmpwalk
@@ -1197,7 +1197,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jcdba2ca:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Sonarr
       target: sonarr
@@ -1215,7 +1215,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j011590d:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Sortdb
       target: sortdb
@@ -1233,7 +1233,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jfc3e971:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: speedtest
       target: speedtest
@@ -1251,7 +1251,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   je0445d5:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Stardog
       target: stardog
@@ -1269,7 +1269,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j5870f9b:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Storm
       target: storm
@@ -1287,7 +1287,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j9744de5:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Syncthing
       target: syncthing
@@ -1305,7 +1305,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j0c2f158:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: TiDB
       target: tidb
@@ -1323,7 +1323,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd73ec80:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Trino
       target: trino
@@ -1341,7 +1341,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j6c9fa4e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Unbound
       target: unbound
@@ -1359,7 +1359,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja76fbf3:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Unifi Console
       target: unifi_console
@@ -1377,7 +1377,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jfe85d2e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Upbound UXP
       target: upbound_uxp
@@ -1395,7 +1395,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j4041974:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: UPSC
       target: upsc
@@ -1413,7 +1413,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j8fcdf27:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Vespa
       target: vespa
@@ -1431,7 +1431,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   je48051a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: warpstream
       target: warpstream
@@ -1449,7 +1449,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf287d93:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: wayfinder
       target: wayfinder
@@ -1467,7 +1467,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja67c5ea:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Zabbix
       target: zabbix
@@ -1485,7 +1485,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j7f4936a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@master
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
     with:
       job-name: Zenoh router
       target: zenoh_router


### PR DESCRIPTION
### What does this PR do?

This PR brings back the pinned actions for test-all.

### Motivation
They were first added in  #2824 but removed because in extras we validate CI with the latest released version of `ddev`. We cannot modify this workflow that is automatically generated without a version of `ddev` that supports the update. They were removed in #2846.

Once the version of `ddev` that supports validating this is released, we can merge this PR.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
