### PR TITLE
Add owner field to integrations-developer-platform (redis_enterprise_prometheus, contrast_security_adr)

### DIFF
--- a/contrast_security_adr/manifest.json
+++ b/contrast_security_adr/manifest.json
@@ -1,5 +1,6 @@
 {
   "app_id": "contrast-security-adr",
+  "owner": "integrations-developer-platform",
   "app_uuid": "01967c4b-c618-7f2d-9af8-db3506afd1b5",
   "manifest_version": "2.0.0",
   "display_on_public_website": true,

--- a/redis_enterprise_prometheus/manifest.json
+++ b/redis_enterprise_prometheus/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "f065ce60-b831-4e7d-8521-1cde67a6c12a",
   "app_id": "redis-enterprise-prometheus",
+  "owner": "integrations-developer-platform",
   "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",


### PR DESCRIPTION
## Summary
Add owner field to 2 integrations-extras integrations for integrations-developer-platform team:
- redis_enterprise_prometheus
- contrast_security_adr

This completes owner field coverage for all integrations-extras integrations as part of the IDP-800 initiative.

🤖 Generated with [Claude Code](https://claude.ai/code)