### PR TITLE
fix(auth0): populate ocsf.dst_endpoint to satisfy Authentication at_least_one constraint

### DIFF
--- a/auth0/assets/logs/auth0.yaml
+++ b/auth0/assets/logs/auth0.yaml
@@ -896,12 +896,23 @@ pipeline:
           preserveSource: true
           overrideOnConflict: false
         - type: attribute-remapper
-          name: Map `data.hostname` to `ocsf.dst_endpoint.hostname`
+          name: Map `data.hostname`, `data.client_name` to `ocsf.dst_endpoint.hostname`
           enabled: true
           sources:
             - data.hostname
+            - data.client_name
           sourceType: attribute
           target: ocsf.dst_endpoint.hostname
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: false
+        - type: attribute-remapper
+          name: Map `data.client_id` to `ocsf.dst_endpoint.uid`
+          enabled: true
+          sources:
+            - data.client_id
+          sourceType: attribute
+          target: ocsf.dst_endpoint.uid
           targetType: attribute
           preserveSource: true
           overrideOnConflict: false


### PR DESCRIPTION
## Summary

- The OCSF Authentication class (3002) has an `at_least_one` constraint requiring either `device` or `dst_endpoint` to be present
- For `sertft` (Refresh Token exchange) and other token-exchange events, `data.hostname` is absent but `data.client_name` (e.g. `"Blacklane"`) and `data.client_id` are always present
- The existing `dst_endpoint.hostname` remapper only listed `data.hostname` as a source, so `dst_endpoint` was never populated for these events
- This caused ~**23,000 `constraint_failed` validation errors per day** in the OCSF validation job

**Changes:**
- Add `data.client_name` as a fallback source on the `ocsf.dst_endpoint.hostname` remapper
- Add a new remapper for `data.client_id` → `ocsf.dst_endpoint.uid`

Both fields are present on all auth events that go through the Authentication [3002] sub-pipeline.

## Test plan

- [ ] Verify `sertft` events in staging have `ocsf.dst_endpoint.hostname` populated after pipeline runs
- [ ] Confirm `constraint_failed` validation error count drops for source `auth0` in `event-jobs-security-monitoring`
- [ ] Check that `data.hostname` still takes precedence when present (it is listed first in sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)