### PR TITLE
redis_sentinel: Add SSL/TLS, username/ACL, and Redis 7+ replica support

### DIFF
--- a/redis_sentinel/datadog_checks/redis_sentinel/data/conf.yaml.example
+++ b/redis_sentinel/datadog_checks/redis_sentinel/data/conf.yaml.example
@@ -7,22 +7,61 @@ instances:
     #
   - sentinel_host: localhost
 
-    ## @param sentinel_port - string - required
+    ## @param sentinel_port - integer - required
     ## Port to connect to when reaching `sentinel_host`.
     #
     sentinel_port: 26379
 
     ## @param sentinel_password - string - optional
-    ## Password for authenticating to the Sentinel host
+    ## Password for authenticating to the Sentinel host.
     #
-    # sentinel_password: <password>
+    # sentinel_password: <PASSWORD>
+
+    ## @param sentinel_username - string - optional
+    ## Username for authenticating to the Sentinel host. Redis 6+ only (ACL support).
+    #
+    # sentinel_username: <USERNAME>
 
     ## @param masters - list of strings - required
-    ## List of masters name to collect data from
+    ## List of masters name to collect data from.
     #
     masters:
       - <MASTER_NAME_1>
       - <MASTER_NAME_2>
+
+    ## @param socket_timeout - integer - optional - default: 5
+    ## Timeout in seconds for connecting to and reading from the Sentinel host.
+    #
+    # socket_timeout: 5
+
+    ## @param ssl - boolean - optional - default: false
+    ## Enable SSL/TLS encryption for the Sentinel connection.
+    #
+    # ssl: false
+
+    ## @param ssl_keyfile - string - optional
+    ## The path to the client-side private keyfile.
+    #
+    # ssl_keyfile: <CERT_KEY_PATH>
+
+    ## @param ssl_certfile - string - optional
+    ## The path to the client-side certificate file.
+    #
+    # ssl_certfile: <CERT_PEM_PATH>
+
+    ## @param ssl_ca_certs - string - optional
+    ## The path to the CA certs file.
+    #
+    # ssl_ca_certs: <CERT_PATH>
+
+    ## @param ssl_cert_reqs - integer - optional - default: 2
+    ## Specifies whether a certificate is required from the
+    ## other side of the connection, and whether it's validated if provided.
+    ##   * 0 for ssl.CERT_NONE (certificates ignored)
+    ##   * 1 for ssl.CERT_OPTIONAL (not required, but validated if provided)
+    ##   * 2 for ssl.CERT_REQUIRED (required and validated)
+    #
+    # ssl_cert_reqs: 2
 
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.

--- a/redis_sentinel/datadog_checks/redis_sentinel/redis_sentinel.py
+++ b/redis_sentinel/datadog_checks/redis_sentinel/redis_sentinel.py
@@ -56,7 +56,7 @@ class RedisSentinelCheck(AgentCheck):
             db=0,
             socket_timeout=socket_timeout,
             socket_connect_timeout=socket_timeout,
-            **ssl_kwargs
+            **ssl_kwargs,
         )
 
         for master_name in instance['masters']:

--- a/redis_sentinel/datadog_checks/redis_sentinel/redis_sentinel.py
+++ b/redis_sentinel/datadog_checks/redis_sentinel/redis_sentinel.py
@@ -24,6 +24,8 @@ class RedisSentinelCheck(AgentCheck):
             raise ConfigurationError('Configuration error. "sentinel_port" must be an int.')
 
         passwd = instance.get('sentinel_password', None)
+        username = instance.get('sentinel_username', None)
+        socket_timeout = instance.get('socket_timeout', 5)
 
         ssl_kwargs = {}
         if instance.get('ssl', False):
@@ -38,15 +40,24 @@ class RedisSentinelCheck(AgentCheck):
             if ssl_ca_certs:
                 ssl_kwargs['ssl_ca_certs'] = ssl_ca_certs
             ssl_cert_reqs = instance.get('ssl_cert_reqs')
-            if ssl_cert_reqs:
+            if ssl_cert_reqs is not None:
                 ssl_kwargs['ssl_cert_reqs'] = ssl_cert_reqs
 
-        return host, port, passwd, ssl_kwargs
+        return host, port, passwd, username, socket_timeout, ssl_kwargs
 
     def check(self, instance):
-        host, port, password, ssl_kwargs = self._load_config(instance)
+        host, port, password, username, socket_timeout, ssl_kwargs = self._load_config(instance)
 
-        redis_conn = redis.StrictRedis(host=host, port=port, password=password, db=0, **ssl_kwargs)
+        redis_conn = redis.StrictRedis(
+            host=host,
+            port=port,
+            password=password,
+            username=username,
+            db=0,
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_timeout,
+            **ssl_kwargs
+        )
 
         for master_name in instance['masters']:
             base_tags = ['redis_name:%s' % master_name] + instance.get('tags', [])
@@ -59,6 +70,15 @@ class RedisSentinelCheck(AgentCheck):
         master_tags = self._process_master_stats(redis_conn, master_name, base_tags)
         self._process_slaves_stats(redis_conn, master_name, base_tags, master_tags)
         self._process_sentinels_stats(redis_conn, master_name, base_tags, master_tags)
+
+    def _get_sentinel_replicas(self, redis_conn, master_name):
+        """Get replica stats using sentinel_replicas() (Redis 7+) with fallback to sentinel_slaves()."""
+        if hasattr(redis_conn, 'sentinel_replicas'):
+            try:
+                return redis_conn.sentinel_replicas(master_name)
+            except Exception:
+                pass
+        return redis_conn.sentinel_slaves(master_name)
 
     def _process_sentinels_stats(self, redis_conn, master_name, base_tags, master_tags):
         """
@@ -140,7 +160,7 @@ class RedisSentinelCheck(AgentCheck):
             'slave-repl-offset': 12345678,
         }]
         """
-        slaves_stats = redis_conn.sentinel_slaves(master_name)
+        slaves_stats = self._get_sentinel_replicas(redis_conn, master_name)
         slaves_odown = 0
         slaves_sdown = 0
 

--- a/redis_sentinel/datadog_checks/redis_sentinel/redis_sentinel.py
+++ b/redis_sentinel/datadog_checks/redis_sentinel/redis_sentinel.py
@@ -25,12 +25,28 @@ class RedisSentinelCheck(AgentCheck):
 
         passwd = instance.get('sentinel_password', None)
 
-        return host, port, passwd
+        ssl_kwargs = {}
+        if instance.get('ssl', False):
+            ssl_kwargs['ssl'] = True
+            ssl_certfile = instance.get('ssl_certfile')
+            if ssl_certfile:
+                ssl_kwargs['ssl_certfile'] = ssl_certfile
+            ssl_keyfile = instance.get('ssl_keyfile')
+            if ssl_keyfile:
+                ssl_kwargs['ssl_keyfile'] = ssl_keyfile
+            ssl_ca_certs = instance.get('ssl_ca_certs')
+            if ssl_ca_certs:
+                ssl_kwargs['ssl_ca_certs'] = ssl_ca_certs
+            ssl_cert_reqs = instance.get('ssl_cert_reqs')
+            if ssl_cert_reqs:
+                ssl_kwargs['ssl_cert_reqs'] = ssl_cert_reqs
+
+        return host, port, passwd, ssl_kwargs
 
     def check(self, instance):
-        host, port, password = self._load_config(instance)
+        host, port, password, ssl_kwargs = self._load_config(instance)
 
-        redis_conn = redis.StrictRedis(host=host, port=port, password=password, db=0)
+        redis_conn = redis.StrictRedis(host=host, port=port, password=password, db=0, **ssl_kwargs)
 
         for master_name in instance['masters']:
             base_tags = ['redis_name:%s' % master_name] + instance.get('tags', [])

--- a/redis_sentinel/pyproject.toml
+++ b/redis_sentinel/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
-    "redis==2.10.5",
+    "redis>=4.5.0",
 ]
 
 [project.urls]

--- a/redis_sentinel/tests/conftest.py
+++ b/redis_sentinel/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 from datadog_checks.dev.docker import docker_run, get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))

--- a/redis_sentinel/tests/test_redis_sentinel.py
+++ b/redis_sentinel/tests/test_redis_sentinel.py
@@ -46,18 +46,90 @@ def test_load_config():
         c._load_config({'sentinel_host': 'localhost', 'sentinel_port': 'port'})
 
     # Expect to pass when port is an integer, with no password defined.
-    host, port, password = c._load_config({'sentinel_host': 'localhost', 'sentinel_port': 123, 'masters': 'mymaster'})
+    host, port, password, username, socket_timeout, ssl_kwargs = c._load_config(
+        {'sentinel_host': 'localhost', 'sentinel_port': 123, 'masters': 'mymaster'}
+    )
     assert host == 'localhost'
     assert port == 123
     assert password is None
+    assert username is None
+    assert socket_timeout == 5
+    assert ssl_kwargs == {}
 
     # Expect to pass when port is an integer, with password defined.
-    host, port, password = c._load_config(
+    host, port, password, username, socket_timeout, ssl_kwargs = c._load_config(
         {'sentinel_host': 'localhost', 'sentinel_port': 123, 'masters': 'mymaster', 'sentinel_password': 'password1'}
     )
     assert host == 'localhost'
     assert port == 123
     assert password == 'password1'
+    assert username is None
+    assert ssl_kwargs == {}
+
+
+@pytest.mark.unit
+def test_load_config_username():
+    c = RedisSentinelCheck('redis_sentinel', {}, {})
+
+    host, port, password, username, socket_timeout, ssl_kwargs = c._load_config(
+        {
+            'sentinel_host': 'localhost',
+            'sentinel_port': 123,
+            'masters': 'mymaster',
+            'sentinel_password': 'password1',
+            'sentinel_username': 'myuser',
+        }
+    )
+    assert username == 'myuser'
+    assert password == 'password1'
+
+
+@pytest.mark.unit
+def test_load_config_ssl():
+    c = RedisSentinelCheck('redis_sentinel', {}, {})
+
+    # SSL disabled by default
+    _, _, _, _, _, ssl_kwargs = c._load_config(
+        {'sentinel_host': 'localhost', 'sentinel_port': 123, 'masters': 'mymaster'}
+    )
+    assert ssl_kwargs == {}
+
+    # SSL enabled with all options
+    _, _, _, _, _, ssl_kwargs = c._load_config(
+        {
+            'sentinel_host': 'localhost',
+            'sentinel_port': 123,
+            'masters': 'mymaster',
+            'ssl': True,
+            'ssl_certfile': '/path/to/cert.pem',
+            'ssl_keyfile': '/path/to/key.pem',
+            'ssl_ca_certs': '/path/to/ca.pem',
+            'ssl_cert_reqs': 2,
+        }
+    )
+    assert ssl_kwargs == {
+        'ssl': True,
+        'ssl_certfile': '/path/to/cert.pem',
+        'ssl_keyfile': '/path/to/key.pem',
+        'ssl_ca_certs': '/path/to/ca.pem',
+        'ssl_cert_reqs': 2,
+    }
+
+    # SSL enabled with minimal options
+    _, _, _, _, _, ssl_kwargs = c._load_config(
+        {'sentinel_host': 'localhost', 'sentinel_port': 123, 'masters': 'mymaster', 'ssl': True}
+    )
+    assert ssl_kwargs == {'ssl': True}
+
+
+@pytest.mark.unit
+def test_load_config_socket_timeout():
+    c = RedisSentinelCheck('redis_sentinel', {}, {})
+
+    _, _, _, _, socket_timeout, _ = c._load_config(
+        {'sentinel_host': 'localhost', 'sentinel_port': 123, 'masters': 'mymaster', 'socket_timeout': 10}
+    )
+    assert socket_timeout == 10
 
 
 @pytest.mark.integration
@@ -92,7 +164,7 @@ def test_down_slaves(aggregator, instance):
     for _ in range(7):
         sentinel_slaves.append({'is_odown': False, 'is_sdown': True})
 
-    with mock.patch('redis.StrictRedis.sentinel_slaves', return_value=sentinel_slaves):
+    with mock.patch.object(check, '_get_sentinel_replicas', return_value=sentinel_slaves):
         check.check(instance)
 
         aggregator.assert_metric('redis.sentinel.odown_slaves', 5)

--- a/redis_sentinel/tests/test_redis_sentinel.py
+++ b/redis_sentinel/tests/test_redis_sentinel.py
@@ -1,6 +1,5 @@
 import mock
 import pytest
-
 from datadog_checks.base import ConfigurationError
 from datadog_checks.redis_sentinel import RedisSentinelCheck
 


### PR DESCRIPTION
## Summary

Modernizes the Redis Sentinel check to support TLS-enabled deployments, Redis 6+ ACLs, and Redis 7+ command changes.

Fixes #2938, #2395, #1586

## Changes

### 1. SSL/TLS support (#2938)
The check previously created `redis.StrictRedis` connections without any SSL parameters, making it impossible to connect to TLS-enabled Sentinel instances (e.g. AWS ElastiCache, Azure Cache for Redis).

Added support for: `ssl`, `ssl_certfile`, `ssl_keyfile`, `ssl_ca_certs`, `ssl_cert_reqs` — matching the core `redisdb` integration.

### 2. Username / ACL support (#2395)
Redis 6+ introduced ACLs requiring a `username` parameter. Without it, `AUTH` fails with: `AUTH <password> called without any password configured for the default user`.

Added `sentinel_username` instance config option, passed through to `StrictRedis(username=...)`.

### 3. Redis 7+ REPLICAS command (#1586)
Redis 7 removed the `SENTINEL SLAVES` subcommand in favor of `SENTINEL REPLICAS`. The check now uses `sentinel_replicas()` (redis-py 4.2+) with a fallback to `sentinel_slaves()` for older Redis versions.

### 4. Socket timeout
Added `socket_timeout` config option (default: 5s) to prevent the check from hanging indefinitely on unreachable sentinels.

## Files changed

| File | Change |
|------|--------|
| `redis_sentinel.py` | SSL, username, timeout params in `_load_config()`; `_get_sentinel_replicas()` helper |
| `conf.yaml.example` | Documented all new config options |
| `test_redis_sentinel.py` | Tests for SSL, username, timeout config; updated mock for replicas |
| `pyproject.toml` | Bumped `redis` dep from `2.10.5` to `>=4.5.0` |

## Example config (Helm)
```yaml
datadog:
  confd:
    redis_sentinel.yaml: |-
      instances:
        - sentinel_host: sentinel.example.com
          sentinel_port: 26379
          sentinel_username: default
          sentinel_password: secret
          ssl: true
          ssl_ca_certs: /etc/ssl/certs/ca.pem
          ssl_certfile: /etc/ssl/certs/client.pem
          ssl_keyfile: /etc/ssl/certs/client-key.pem
          socket_timeout: 10
          masters:
            - mymaster
```

## Backward compatibility
- All new options are optional with sensible defaults
- Without `ssl: true`, behavior is identical to before
- `_get_sentinel_replicas()` falls back to `sentinel_slaves()` if `sentinel_replicas()` is unavailable