### PR TITLE
Change display_on_public_website to false

### DIFF
--- a/webb_ai/manifest.json
+++ b/webb_ai/manifest.json
@@ -3,7 +3,7 @@
   "app_uuid": "ca4c3360-0e0f-4257-a392-8d6e461a3806",
   "app_id": "webb-ai",
   "owner": "integrations-developer-platform",
-  "display_on_public_website": true,
+  "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?

Hides tile from public docs. 

### Motivation

Integration has been hidden in app as the product no longer exists.
