### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 .github/CODEOWNERS*                                        @DataDog/agent-integrations
 .github/workflows/*                                        @DataDog/agent-integrations
+code-coverage.datadog.yml                                  @DataDog/agent-integrations
 
 # Documentation
 **/README.md                             @DataDog/documentation

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,6 +17,43 @@ jobs:
        # needed for compute-matrix in test-target.yml
        contents: read
 
+  upload-coverage:
+    needs:
+    - test
+    if: >
+      !github.event.repository.private &&
+      (success() || failure())
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Download all coverage artifacts
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        pattern: coverage-*
+        path: coverage-reports
+        merge-multiple: false
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+      with:
+        use_oidc: true
+        directory: coverage-reports
+        fail_ci_if_error: false
+
+    - name: Upload coverage to Datadog
+      if: always()
+      continue-on-error: true
+      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
+      with:
+        api_key: ${{ secrets.DD_API_KEY }}
+        files: coverage-reports
+        format: cobertura
+
   publish-test-results:
     needs:
     - test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -46,12 +46,18 @@ jobs:
         directory: coverage-reports
         fail_ci_if_error: false
 
+    - name: Get Datadog credentials
+      id: dd-sts
+      continue-on-error: true
+      uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+      with:
+        policy: integrations-extras
     - name: Upload coverage to Datadog
-      if: always()
+      if: steps.dd-sts.outputs.api_key != ''
       continue-on-error: true
       uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
       with:
-        api_key: ${{ secrets.DD_API_KEY }}
+        api_key: ${{ steps.dd-sts.outputs.api_key }}
         files: coverage-reports
         format: cobertura
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch:  # temporary — remove after verification
 
 jobs:
   test:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-  workflow_dispatch:  # temporary — remove after verification
 
 jobs:
   test:

--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -1,0 +1,2 @@
+schema-version: v1
+carryforward: true


### PR DESCRIPTION
Adds Datadog Code Coverage upload alongside the existing Codecov setup — nothing is removed or changed.

Part of the migration from Codecov to [Datadog Code Coverage](https://docs.datadoghq.com/code_analysis/code_coverage/).