### PR TITLE
Pin run-validations workflow to integrations-core master commit

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   run:
-    uses: DataDog/integrations-core/.github/workflows/run-validations.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
+    uses: DataDog/integrations-core/.github/workflows/run-validations.yml@4e58c485d24656a1dbc9aae3502cbf861a6fc152 # master
     with:
       repo: extras
 


### PR DESCRIPTION
### What does this PR do?

Pins the `run-validations.yml` reusable workflow reference to the latest commit on `integrations-core` master (`4e58c485d24656a1dbc9aae3502cbf861a6fc152`).

### Motivation

[integrations-core#23249](https://github.com/DataDog/integrations-core/pull/23249) replaces the per-validation boolean inputs in `run-validations.yml` with a single `ddev validate all` command. Pinning to the current master commit ensures this repo continues using the old workflow interface until `ddev` is released with the new command.

### Review checklist

- [x] PR has a meaningful title or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean