### PR TITLE
Update Cribl Stream troubleshooting guide link to new Cloud SIEM location

### DIFF
--- a/cribl_stream/README.md
+++ b/cribl_stream/README.md
@@ -52,7 +52,7 @@ The Cribl Stream integration does not include any service checks.
 
 ## Troubleshooting
 
-If you're using Cribl Stream to send data to Cloud SIEM and are having trouble with OOTB dashboards and detection rules, see [Troubleshoot the Cribl Stream integration with Cloud SIEM][9].
+If you're using Cribl Stream to send data to Cloud SIEM and are having trouble with OOTB dashboards and detection rules, see [Troubleshoot using Cribl Stream with Cloud SIEM][9].
 
 Need help? Contact [Cribl Support][8].
 
@@ -64,4 +64,4 @@ Need help? Contact [Cribl Support][8].
 [6]: http://docs.cribl.io/logstream/sources-cribl-internal/
 [7]: /organization-settings/api-keys
 [8]: https://cribl.io/support
-[9]: https://docs.datadoghq.com/security/guide/troubleshoot-integrations-cloud-siem/
+[9]: https://docs.datadoghq.com/security/cloud_siem/guide/troubleshoot-cribl-stream-cloud-siem/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the link to the Cribl Stream troubleshooting guide in the Cribl Stream README, following the page being moved in the documentation repo ([DataDog/documentation#36176](https://github.com/DataDog/documentation/pull/36176)).

Changes:
- Updated URL from `/security/guide/troubleshoot-integrations-cloud-siem/` to `/security/cloud_siem/guide/troubleshoot-cribl-stream-cloud-siem/`
- Updated link text to match the new page title: "Troubleshoot using Cribl Stream with Cloud SIEM"

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes