### PR TITLE
[TXP-77] Add webhook_config asset for Zscaler integration

### DIFF
--- a/zscaler/README.md
+++ b/zscaler/README.md
@@ -16,8 +16,8 @@ A Zscaler Cloud NSS subscription is required.
 
 ### Create a Datadog Webhook URL
 
-1.  From the **Configure** tab of the Zscaler integration, use the API Key Picker to select an existing API key, or create a new one.
-2. Click **Add API key**, then **Click Here to Copy Intake URL**.
+1. {{< integration-api-key-picker >}}
+2. Click **Click Here to Copy Intake URL**.
 
 ### Configure a webhook in Zscaler
 

--- a/zscaler/assets/webhook_config.json
+++ b/zscaler/assets/webhook_config.json
@@ -1,0 +1,4 @@
+{
+  "type": "url",
+  "source": "zscaler"
+}


### PR DESCRIPTION
## Summary

- Adds `webhook_config.json` with `{ "type": "url", "source": "zscaler" }` to `zscaler/assets/`
- This asset drives the auto-generated webhook configuration tab in the integrations UI
- Replaces the custom `ZScalerConfigurationTab` component being removed in the companion web-ui PR

## Related

- Companion `integrations-internal-core` PR: DataDog/integrations-internal-core#3148 (same pattern for 8 other integrations)
- Part of TXP-77: replacing custom `ConfigurationTab` overrides with auto-generated tabs

## Test plan

- [ ] Verify the Zscaler integration configuration tab renders correctly after deploy
- [ ] Confirm the generated webhook URL includes `ddsource=zscaler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)