### PR TITLE
Add documentation for the TanStack Router integration

### DIFF
--- a/rum_react/CHANGELOG.md
+++ b/rum_react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - React
 
+## 3.0.0
+
+**_Added_**:
+
+* Add documentation for the TanStack Router integration
+
 ## 2.0.0
 
 * Add documentation for the RUM React integration plugin

--- a/rum_react/README.md
+++ b/rum_react/README.md
@@ -134,6 +134,31 @@ const router = createBrowserRouter([
 ReactDOM.createRoot(document.getElementById('root')).render(<RouterProvider router={router} />)
 ```
 
+## TanStack Router integration
+
+[TanStack Router][14] is a typesafe router for React. To track route changes with the Datadog RUM Browser SDK, first initialize the `reactPlugin` with the `router: true` option, then replace `createRouter` from `@tanstack/react-router` with its equivalent from `@datadog/browser-rum-react/tanstack-router`. Example:
+
+```javascript
+import { RouterProvider } from '@tanstack/react-router'
+import { datadogRum } from '@datadog/browser-rum'
+import { reactPlugin } from '@datadog/browser-rum-react'
+// Use "createRouter" from @datadog/browser-rum-react/tanstack-router instead of @tanstack/react-router:
+import { createRouter } from '@datadog/browser-rum-react/tanstack-router'
+
+datadogRum.init({
+  ...
+  plugins: [reactPlugin({ router: true })],
+})
+
+const router = createRouter({ routeTree })
+
+ReactDOM.createRoot(document.getElementById('root')).render(<RouterProvider router={router} />)
+```
+
+A new RUM view is created on every path change. The view name uses the route's `fullPath` template, so navigating to `/posts/42` is reported as `/posts/$postId`. Catch-all (splat) segments are replaced with the matched path, so `/files/$` with `_splat = "path/to/file"` becomes `/files/path/to/file`. Query string changes do not create a new view.
+
+This integration requires `@tanstack/react-router` v1.64.0 or later.
+
 ## Go further with Datadog React integration
 
 ### Traces
@@ -171,3 +196,4 @@ Additional helpful documentation, links, and articles:
 [11]: https://docs.datadoghq.com/real_user_monitoring/generate_metrics
 [12]: https://docs.datadoghq.com/help/
 [13]: https://www.datadoghq.com/blog/datadog-rum-react-components/
+[14]: https://tanstack.com/router/latest

--- a/rum_react/README.md
+++ b/rum_react/README.md
@@ -157,8 +157,6 @@ ReactDOM.createRoot(document.getElementById('root')).render(<RouterProvider rout
 
 A new RUM view is created on every path change. The view name uses the route's `fullPath` template, so navigating to `/posts/42` is reported as `/posts/$postId`. Catch-all (splat) segments are replaced with the matched path, so `/files/$` with `_splat = "path/to/file"` becomes `/files/path/to/file`. Query string changes do not create a new view.
 
-This integration requires `@tanstack/react-router` v1.64.0 or later.
-
 ## Go further with Datadog React integration
 
 ### Traces

--- a/rum_react/README.md
+++ b/rum_react/README.md
@@ -155,7 +155,7 @@ const router = createRouter({ routeTree })
 ReactDOM.createRoot(document.getElementById('root')).render(<RouterProvider router={router} />)
 ```
 
-A new RUM view is created on every path change. The view name uses the route's `fullPath` template, so navigating to `/posts/42` is reported as `/posts/$postId`. Catch-all (splat) segments are replaced with the matched path, so `/files/$` with `_splat = "path/to/file"` becomes `/files/path/to/file`. Query string changes do not create a new view.
+RUM creates a new view on every path change. The view name uses the route's `fullPath` template, so navigating to `/posts/42` is reported as `/posts/$postId`. Catch-all (splat) segments are replaced with the matched path, so `/files/$` with `_splat = "path/to/file"` becomes `/files/path/to/file`. Query string changes do not create a new view.
 
 ## Go further with Datadog React integration
 


### PR DESCRIPTION
### What does this PR do?

Adds a TanStack Router section to `rum_react/README.md`, documenting how to track route changes with `@datadog/browser-rum-react/tanstack-router`.

### Motivation

The integration shipped in `@datadog/browser-rum-react@6.33.0` ([browser-sdk #4414](https://github.com/DataDog/browser-sdk/pull/4414)) without customer-facing docs. It's a sub-entry of `rum-react` like `react-router-v6` and `react-router-v7`, so it lives inside the existing `rum_react` tile rather than a new integration. View tracking only — errors are already covered by the parent React integration.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the \`no-changelog\` label attached
- [x] Git history is clean
- [x] Docs team will be notified

### Additional Notes

`rum_nuxt/` is still missing in this repo even though `@datadog/browser-rum-nuxt` is now public — worth a follow-up.