### PR TITLE
Enable event creation in Zabbix manifest

### DIFF
--- a/zabbix/manifest.json
+++ b/zabbix/manifest.json
@@ -34,7 +34,7 @@
         "spec": "assets/configuration/spec.yaml"
       },
       "events": {
-        "creates_events": false
+        "creates_events": true
       },
       "metrics": {
         "prefix": "zabbix.",


### PR DESCRIPTION
### What does this PR do?

Enables `creates_events ` flag for Zabbix integration

### Motivation

Zabbix is being onboarding in the new event management pipeline, which needs this field to be enable 

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
