### PR TITLE
[DOCS-14086] Remove site support notice from LaunchDarkly integration docs

### DIFF
--- a/launchdarkly/README.md
+++ b/launchdarkly/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 <!-- partial
-{{% site-region region="gov" %}}
+{{% site-region region="gov,gov2" %}}
 **The LaunchDarkly integration is not supported for the Datadog {{< region-param key="dd_site_name" >}} site**.
 {{% /site-region %}}
 partial -->

--- a/launchdarkly/README.md
+++ b/launchdarkly/README.md
@@ -2,12 +2,6 @@
 
 ## Overview
 
-<!-- partial
-{{% site-region region="gov,gov2" %}}
-**The LaunchDarkly integration is not supported for the Datadog {{< region-param key="dd_site_name" >}} site**.
-{{% /site-region %}}
-partial -->
-
 LaunchDarkly provides the following integrations with Datadog:
 
 ### Events integration


### PR DESCRIPTION
Removing the LaunchDarkly site support banner. Adding it in the docs repo instead [#36672](https://github.com/DataDog/documentation/pull/36672)