### PR TITLE
ci(release): gate release-trigger on the release environment

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -48,11 +48,18 @@ jobs:
             echo "is-stable-release=false" >> "$GITHUB_OUTPUT"
           fi
 
+  approve:
+    name: Await release approval
+    needs: context
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - run: echo "Release approved"
+
   dispatch:
     name: Release
-    needs: context
+    needs: [context, approve]
     uses: DataDog/integrations-core/.github/workflows/release-dispatch.yml@master
-    environment: release
     with:
       source-repo: integrations-extras
       packages: ${{ inputs.packages || '' }}

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -52,6 +52,7 @@ jobs:
     name: Release
     needs: context
     uses: DataDog/integrations-core/.github/workflows/release-dispatch.yml@master
+    environment: release
     with:
       source-repo: integrations-extras
       packages: ${{ inputs.packages || '' }}


### PR DESCRIPTION
## Summary

- Add `environment: release` to the `dispatch` job in `release-trigger.yml` so GitHub's deployment protection runs before the reusable `release-dispatch.yml` workflow starts — the `prepare` step (which creates tags) now requires manual approval
- Remove the inner `environment: release` from `release-dispatch.yml`'s `dispatch` job; a single gate at the trigger level is sufficient

## Problem

The `prepare` job in `release-dispatch.yml` creates git tags before reaching the `environment: release` gate on the inner `dispatch` job, so tags could be created without a manual approval step.

## Test plan
- [ ] Trigger a push to master that touches a CHANGELOG to confirm the deployment approval gate fires before any tags are created