### PR TITLE
[SCMGMT-794] test: trigger external-org team CODEOWNERS rule

### DIFF
--- a/cloudquery/README.md
+++ b/cloudquery/README.md
@@ -217,3 +217,4 @@ For support, contact [CloudQuery][4].
 [12]: /apm/traces
 [13]: /metric/summary
 [14]: /logs
+<!-- Test PR for SCMGMT-794: verify external-org team filter -->


### PR DESCRIPTION
## Summary
Test PR to verify the external-org GitHub team filter introduced in dd-source PR [#427376](https://github.com/DataDog/dd-source/pull/427376) ([SCMGMT-794](https://datadoghq.atlassian.net/browse/SCMGMT-794)).

Touches `cloudquery/README.md` so the `@cloudquery/cloudquery-framework` CODEOWNERS rule (an external GitHub org team) is exercised by `enforce_full_approvals`.

**Do not merge** — close once the external-team filter behavior is verified.

## Test plan
- [ ] Confirm `enforce_full_approvals` skips the external `@cloudquery/cloudquery-framework` team
- [ ] Close this PR without merging

[SCMGMT-794]: https://datadoghq.atlassian.net/browse/SCMGMT-794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ