### PR TITLE
[SEC-31850][k9] OCSF facets: add type: integer

### DIFF
--- a/zscaler/assets/logs/zscaler.yaml
+++ b/zscaler/assets/logs/zscaler.yaml
@@ -326,6 +326,7 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Activity Name
@@ -336,6 +337,7 @@ facets:
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -346,6 +348,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -371,6 +374,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Severity
@@ -381,6 +385,7 @@ facets:
     name: Severity ID
     path: ocsf.severity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Request URL String


### PR DESCRIPTION
## Changes
Related to [SEC-31850](https://datadoghq.atlassian.net/browse/SEC-31850).

Add the missing `type: integer` field to OCSF integer facets (`ocsf.activity_id`, `ocsf.category_uid`, `ocsf.class_uid`, `ocsf.status_id`, `ocsf.severity_id`) in integrations that didn't declare it, for consistency with https://github.com/DataDog/integrations-internal-core/pull/3268. Without this, `validate-logs` rejects PRs because these facet paths are defined inconsistently across integrations


[SEC-31850]: https://datadoghq.atlassian.net/browse/SEC-31850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ