### PR TITLE
[LOGSP-29] Add bypass annotations for linter checks

### DIFF
--- a/aimon/assets/logs/aimon_tests.yaml
+++ b/aimon/assets/logs/aimon_tests.yaml
@@ -1,4 +1,4 @@
-# bypass-global-
+# bypass-global-date-remapper-parse-failure-checks
 id: aimon
 tests:
  -

--- a/aimon/assets/logs/aimon_tests.yaml
+++ b/aimon/assets/logs/aimon_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-
 id: aimon
 tests:
  -

--- a/aqua/assets/logs/aqua_tests.yaml
+++ b/aqua/assets/logs/aqua_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-date-remapper-parse-failure-checks
 # bypass-global-timestamp-format-in-sample-checks
 id: "aqua"
 tests:

--- a/dagster/assets/logs/dagster-plus_tests.yaml
+++ b/dagster/assets/logs/dagster-plus_tests.yaml
@@ -1,4 +1,5 @@
 # bypass-global-timestamp-format-in-sample-checks
+# bypass-global-date-remapper-parse-failure-checks
 id: "dagster-plus"
 tests:
  -

--- a/jfrog_platform_self_hosted/assets/logs/jfrog_platform_tests.yaml
+++ b/jfrog_platform_self_hosted/assets/logs/jfrog_platform_tests.yaml
@@ -1,4 +1,5 @@
 # bypass-global-timestamp-format-in-sample-checks
+# bypass-global-date-remapper-parse-failure-checks
 id: "jfrog_platform"
 tests:
  -

--- a/watchtower_ziris/assets/logs/ziris_tests.yaml
+++ b/watchtower_ziris/assets/logs/ziris_tests.yaml
@@ -1,4 +1,4 @@
-# bypass-global-
+# bypass-global-date-remapper-parse-failure-checks
 id: ziris
 tests:
  -

--- a/watchtower_ziris/assets/logs/ziris_tests.yaml
+++ b/watchtower_ziris/assets/logs/ziris_tests.yaml
@@ -1,3 +1,4 @@
+# bypass-global-
 id: ziris
 tests:
  -


### PR DESCRIPTION
A linter rule is being added or changed and some integrations are expected to remain non-compliant.
Add permanent bypass annotations so CI stays green and does not fail for new PRs.