### PR TITLE
[SEC-31850][k9] OCSF facets: add type: integer to auth0

### DIFF
--- a/auth0/assets/logs/auth0.yaml
+++ b/auth0/assets/logs/auth0.yaml
@@ -112,6 +112,7 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Activity Name
@@ -122,6 +123,7 @@ facets:
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -132,6 +134,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -177,6 +180,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
 pipeline:
   type: pipeline
   name: Auth0


### PR DESCRIPTION
## Changes
Related to [SEC-31850](https://datadoghq.atlassian.net/browse/SEC-31850).

Add the missing `type: integer` field to OCSF integer facets (`ocsf.activity_id`, `ocsf.category_uid`, `ocsf.class_uid`, `ocsf.status_id`, `ocsf.severity_id`) in integrations that didn't declare it, for consistency with https://github.com/DataDog/integrations-internal-core/pull/3268. Without this, `validate-logs` rejects PRs because these facet paths are defined inconsistently across integrations