### PR TITLE
[SVLS-8671] Add Vercel to serverless product dataflows

### DIFF
--- a/vercel/assets/dataflows.yaml
+++ b/vercel/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: vercel-metrics
+    always_on: false
+    granular: true
+    data_type: metrics
+    direction: inbound
+  - id: vercel-logs
+    always_on: false
+    granular: true
+    data_type: logs
+    direction: inbound

--- a/vercel/assets/dataflows.yaml
+++ b/vercel/assets/dataflows.yaml
@@ -9,3 +9,8 @@ provides:
     granular: true
     data_type: logs
     direction: inbound
+  - id: vercel-traces
+    always_on: false
+    granular: true
+    data_type: traces
+    direction: inbound


### PR DESCRIPTION
## Summary

- Adds `vercel/assets/dataflows.yaml` with `provides` entries for `vercel-metrics` and `vercel-logs`
- This is one half of a two-repo change to associate Vercel with `productId=serverless`, so that `GET /api/ui/integrations?filter[productId]=serverless` returns Vercel natively

## Why

The serverless setup page currently uses a synthetic injection to show the Vercel tile because the API doesn't return Vercel for `productId=serverless`. Once this PR and the companion [integrations-internal-core PR](https://github.com/DataDog/integrations-internal-core/pull/3300) both land, the synthetic injection in web-ui can be removed.