### PR TITLE
Add type: integer to OCSF facets in auth0

### DIFF
--- a/auth0/assets/logs/auth0.yaml
+++ b/auth0/assets/logs/auth0.yaml
@@ -112,6 +112,7 @@ facets:
     name: Activity ID
     path: ocsf.activity_id
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Activity Name
@@ -122,6 +123,7 @@ facets:
     name: Category ID
     path: ocsf.category_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Category
@@ -132,6 +134,7 @@ facets:
     name: Class ID
     path: ocsf.class_uid
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Class
@@ -177,6 +180,7 @@ facets:
     name: Status ID
     path: ocsf.status_id
     source: log
+    type: integer
 pipeline:
   type: pipeline
   name: Auth0


### PR DESCRIPTION
### What does this PR do?

Adds `type: integer` to OCSF facet definitions for `ocsf.activity_id`, `ocsf.category_uid`, `ocsf.class_uid`, and `ocsf.status_id` in the auth0 log pipeline yaml.

### Motivation

The `validate-logs` CI check fails when these facets are missing `type: integer`, as other integrations define them with that type. Fixes [SEC-31840](https://datadoghq.atlassian.net/browse/SEC-31840).

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors.

### Additional Notes

Same fix as DataDog/integrations-core#23777.

[SEC-31840]: https://datadoghq.atlassian.net/browse/SEC-31840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ