### PR TITLE
Update Vantage OAuth scopes for observability read access

### DIFF
--- a/vantage/CHANGELOG.md
+++ b/vantage/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Changed***:
 
-* updates OAuth scopes for logs, monitors, APM, dashboards, and MCP read access.
+* adds OAuth scopes for logs, monitors, APM, dashboards, and MCP read access.
 
 ## 1.0.1 / 2025-05-30
 

--- a/vantage/CHANGELOG.md
+++ b/vantage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - Vantage
 
+## 1.0.2 / 2026-05-26
+
+***Changed***:
+
+* updates OAuth scopes for logs, monitors, APM, dashboards, and MCP read access.
+
 ## 1.0.1 / 2025-05-30
 
 ***Added***:

--- a/vantage/CHANGELOG.md
+++ b/vantage/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Changed***:
 
-* adds OAuth scopes for logs, monitors, APM, dashboards, and MCP read access.
+* adds OAuth scopes for logs, monitors, APM, dashboards, MCP, incidents, events, and LLM observability read access.
 
 ## 1.0.1 / 2025-05-30
 

--- a/vantage/assets/oauth_clients.json
+++ b/vantage/assets/oauth_clients.json
@@ -13,7 +13,10 @@
       "monitors_read",
       "apm_read",
       "dashboards_read",
-      "mcp_read"
+      "mcp_read",
+      "incident_read",
+      "events_read",
+      "llm_observability_read"
     ],
     "name": "Vantage",
     "client_role": "integration",

--- a/vantage/assets/oauth_clients.json
+++ b/vantage/assets/oauth_clients.json
@@ -1,10 +1,15 @@
 {
   "integration": {
     "scopes": [
-      "usage_read",
-      "timeseries_query",
-      "metrics_read",
-      "billing_read"
+      "logs_read_config",
+      "logs_read_archives",
+      "logs_read_data",
+      "logs_read_index_data",
+      "logs_read_workspaces",
+      "monitors_read",
+      "apm_read",
+      "dashboards_read",
+      "mcp_read"
     ],
     "name": "Vantage",
     "client_role": "integration",

--- a/vantage/assets/oauth_clients.json
+++ b/vantage/assets/oauth_clients.json
@@ -1,6 +1,10 @@
 {
   "integration": {
     "scopes": [
+      "usage_read",
+      "metrics_read",
+      "timeseries_query",
+      "billing_read",
       "logs_read_config",
       "logs_read_archives",
       "logs_read_data",


### PR DESCRIPTION
### What does this PR do?

Adds OAuth scopes for logs, monitors, APM, dashboards, MCP, incidents, events, and LLM observability read access to the Vantage integration while retaining existing billing and metrics scopes.

### Motivation

Vantage requires expanded Datadog OAuth scopes to read logs, monitoring, APM, dashboard, MCP, incident, event, and LLM observability data in addition to existing cost and usage data.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If this PR includes a log pipeline, please add a description describing the remappers and processors.

### Additional Notes

Adds the following scopes while retaining `usage_read`, `metrics_read`, `timeseries_query`, and `billing_read`:

- `logs_read_config`
- `logs_read_archives`
- `logs_read_data`
- `logs_read_index_data`
- `logs_read_workspaces`
- `monitors_read`
- `apm_read`
- `dashboards_read`
- `mcp_read`
- `incident_read`
- `events_read`
- `llm_observability_read`