### PR TITLE
[DOCS-14494] Use region-param shortcode for webhook URL

### DIFF
--- a/zabbix/README.md
+++ b/zabbix/README.md
@@ -60,7 +60,7 @@ try {
 	var params = JSON.parse(value);
 	var req = new HttpRequest();
 	req.addHeader('Content-Type: application/json');
-	var webhook_url = 'https://app.datadoghq.com/intake/webhook/zabbix?api_key=' + params.api_key;
+	var webhook_url = 'https://{{< region-param key="dd_full_site" >}}/intake/webhook/zabbix?api_key=' + params.api_key;
 	var webhook_data = value;
 	var resp = req.post(webhook_url, webhook_data);
 	if (req.getStatus() != 202) {


### PR DESCRIPTION
### What does this PR do?

Replaces the hardcoded `https://app.datadoghq.com/intake/webhook/zabbix` host in the Zabbix integration README's webhook script with the `{{< region-param key="dd_full_site" >}}` shortcode, so the webhook URL resolves to the reader's Datadog site instead of always showing US1.

### Motivation

Customers not on the US1 site otherwise have to know that the host needs to change. This matches the pattern already used in the `github` and `azure_devops` READMEs and the Amazon SNS update (DataDog/integrations-internal-core#3306).

Fixes DOCS-14494

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Documentation-only change (integration README). No code or changelog impact.
