### PR TITLE
ci: disable forced dry-run in release-trigger workflow

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -26,8 +26,7 @@ on:
         description: "Print what would be released without pushing tags or starting builds"
         required: false
         type: boolean
-        # TODO: flip back to false once agent-integration-wheels-release is updated to handle the new payload
-        default: true
+        default: false
       ddev-version:
         description: "ddev version, pinned by default."
         required: false
@@ -64,7 +63,7 @@ jobs:
       source-repo: integrations-extras
       packages: ${{ inputs.packages || '' }}
       source-repo-ref: ${{ inputs.source-repo-ref || github.sha }}
-      dry-run: ${{ inputs.dry-run || true }}  # TODO: flip back to false
+      dry-run: ${{ inputs.dry-run }}
       ddev-version: ${{ inputs.ddev-version || '' }}
       is-stable-release: ${{ needs.context.outputs.is-stable-release }}
     permissions:


### PR DESCRIPTION
## What

Stop forcing dry-run mode in the `release-trigger.yml` wrapper:
- `workflow_dispatch` input `dry-run` default `true` -> `false`
- reusable call `dry-run: ${{ inputs.dry-run || true }}` -> `dry-run: ${{ inputs.dry-run }}`

## Why

`false || true == true` in GitHub Actions, so the explicit `dry-run: false` path was unreachable. Combined with the input default of `true`, **every** run was a dry run and the "Dispatch wheel builds" matrix job in integrations-core's reusable `release-dispatch.yml` was always skipped.

The TODO gated flipping this on `agent-integration-wheels-release` handling the new release-dispatch payload. Verified that its production branch now consumes the exact payload shape (`packages`, `source_repo`, `source_repo_ref`) emitted by integrations-core's `release-dispatch.yml@master`, validates it (`validate-inbound-dispatch`), and defaults `dry_run` to `false` when absent. **Precondition met.**

## Note

Companion to the identical change in `DataDog/marketplace` (#1646).