### PR TITLE
Update notion oauth properties

### DIFF
--- a/notion/assets/oauth_clients.json
+++ b/notion/assets/oauth_clients.json
@@ -3,7 +3,8 @@
     "onboarding_url": "https://integrations-api.notion.com/datadog/install",
     "client_role": "integration",
     "redirect_uris": [
-      "https://www.notion.so/datadogauthcallback"
+      "https://www.notion.so/datadogauthcallback",
+      "https://app.notion.com/datadogauthcallback"
     ],
     "description": "Official Notion integration for Datadog",
     "name": "Notion",


### PR DESCRIPTION
### What does this PR do?

Notion recently updated its main app url from notion.so to app.notion.com. Integrations with datadog now oauth redirect to the new TLD.

### Motivation

Customers have complained the current OAuth flow is broken between Notion and DataDog

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [x] Feature or bugfix has tests
- [x] Git history is clean
- [x] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [x] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
