### PR TITLE
Add release tag STS policy

### DIFF
--- a/.github/chainguard/self.release.tag-push.sts.yaml
+++ b/.github/chainguard/self.release.tag-push.sts.yaml
@@ -1,0 +1,23 @@
+# Policy for: .github/workflows/release-trigger.yml in DataDog/integrations-extras
+# The release job calls integrations-core's reusable release-dispatch workflow
+#
+# Security model:
+#   - Workflow runs only from the protected master branch
+#   - Access is scoped to the reusable release workflow on master
+#   - Supports push and workflow_dispatch events only
+#
+# Permissions granted:
+#   - contents: write  - Create and push integration release tags
+
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/integrations-extras:ref:refs/heads/master
+
+claim_pattern:
+  event_name: (push|workflow_dispatch)
+  job_workflow_ref: DataDog/integrations-core/\.github/workflows/release-dispatch\.yml@refs/heads/master
+  ref: refs/heads/master
+  repository: DataDog/integrations-extras
+
+permissions:
+  contents: write

--- a/.github/chainguard/self.release.tag-push.sts.yaml
+++ b/.github/chainguard/self.release.tag-push.sts.yaml
@@ -2,7 +2,7 @@
 # The release job calls integrations-core's reusable release-dispatch workflow
 #
 # Security model:
-#   - Workflow runs only from the protected master branch
+#   - Workflow runs only from master or prerelease branches
 #   - Access is scoped to the reusable release workflow on master
 #   - Supports push and workflow_dispatch events only
 #
@@ -11,12 +11,12 @@
 
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:DataDog/integrations-extras:ref:refs/heads/master
+subject_pattern: repo:DataDog/integrations-extras:ref:refs/heads/(master|(alpha|beta|rc)/.+)
 
 claim_pattern:
   event_name: (push|workflow_dispatch)
   job_workflow_ref: DataDog/integrations-core/\.github/workflows/release-dispatch\.yml@refs/heads/master
-  ref: refs/heads/master
+  ref: refs/heads/(master|(alpha|beta|rc)/.+)
   repository: DataDog/integrations-extras
 
 permissions:


### PR DESCRIPTION
### What does this PR do?

Adds the `self.release.tag-push` DD Octo STS trust policy used by integrations-core's reusable release workflow to create integration release tags in integrations-extras.

The policy grants only `contents: write` and restricts access to:

- integrations-extras workflows running from `master`, `alpha/*`, `beta/*`, or `rc/*`;
- `push` and `workflow_dispatch` events; and
- integrations-core's `release-dispatch.yml` reusable workflow on `master`.

### Motivation

DataDog/integrations-core#24535 replaces the reusable release workflow's default `GITHUB_TOKEN` tag credential with a repository-scoped DD Octo STS token. This policy must be present on the default branch before that PR is merged.

### Review checklist

- [x] PR has a meaningful title
- [x] Trust policy claims were validated locally
- [x] Git history is clean
- [x] This PR does not impact product documentation
- [x] This PR does not include a log pipeline

### Additional Notes

Merge this policy PR before DataDog/integrations-core#24535. DD Octo STS integration 1157446 is an organization-approved App for bypassing the public-repository tag protection ruleset.

