### PR TITLE
pin workflows to more recent commit

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -65,5 +65,5 @@ jobs:
       pull-requests: write
       contents: write
 
-    uses: DataDog/integrations-core/.github/workflows/test-results-master.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
+    uses: DataDog/integrations-core/.github/workflows/test-results-master.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933 # master
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   test:
-    uses: DataDog/integrations-core/.github/workflows/pr-test.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
+    uses: DataDog/integrations-core/.github/workflows/pr-test.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933 # master
     with:
       repo: extras
       python-version: "3.13"

--- a/.github/workflows/publish-test-results-pr.yml
+++ b/.github/workflows/publish-test-results-pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    uses: DataDog/integrations-core/.github/workflows/test-results-pr.yml@574d63ba88365ffbab915280ceddbaa333c63d6a # master
+    uses: DataDog/integrations-core/.github/workflows/test-results-pr.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933 # master
     if: github.event.workflow_run.conclusion != 'skipped'
     permissions: # For test-results-pr.yml
       checks: write

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   j785d2c9:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: aerospike_enterprise
       target: aerospike_enterprise
@@ -64,7 +64,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j7a4721a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Aqua
       target: aqua
@@ -83,7 +83,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j68e2604:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: AWS Pricing
       target: aws_pricing
@@ -102,7 +102,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd342fce:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: BIND 9
       target: bind9
@@ -121,7 +121,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j9eb5f31:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: celerdata
       target: celerdata
@@ -140,7 +140,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jcb3c31b:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: cfssl
       target: cfssl
@@ -159,7 +159,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j6a8ad70:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: CloudNatix
       target: cloudnatix
@@ -178,7 +178,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja2364fe:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Cloudsmith
       target: cloudsmith
@@ -197,7 +197,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja669dc6:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: cybersixgill_actionable_alerts
       target: cybersixgill_actionable_alerts
@@ -216,7 +216,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j3263e78:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Cyral
       target: cyral
@@ -235,7 +235,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jfe56917:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: emqx
       target: emqx
@@ -254,7 +254,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j8c2c004:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Eventstore
       target: eventstore
@@ -273,7 +273,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jbb3d7c9:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: exim
       target: exim
@@ -292,7 +292,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j0180cad:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: fiddler
       target: fiddler
@@ -311,7 +311,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jec10af8:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Filebeat
       target: filebeat
@@ -330,7 +330,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j77495f2:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: filemage
       target: filemage
@@ -349,7 +349,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd678fea:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Fluent Bit
       target: fluentbit
@@ -368,7 +368,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jb8cf774:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: flume
       target: flume
@@ -387,7 +387,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jb4053fb:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Gatekeeper
       target: gatekeeper
@@ -406,7 +406,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j94cb576:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Gitea
       target: gitea
@@ -425,7 +425,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdb917e1:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Gnatsd
       target: gnatsd
@@ -444,7 +444,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j5bcfa2e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Gnatsd Streaming
       target: gnatsd_streaming
@@ -463,7 +463,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdb696b5:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: go_pprof_scraper
       target: go_pprof_scraper
@@ -482,7 +482,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j0642a7b:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Grafana
       target: grafana
@@ -501,7 +501,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jb27a2a4:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: gRPC Check
       target: grpc_check
@@ -520,7 +520,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j2eba458:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: hikaricp
       target: hikaricp
@@ -539,7 +539,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j43aee0d:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Kepler
       target: kepler
@@ -558,7 +558,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja3e78b9:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Kernelcare
       target: kernelcare
@@ -577,7 +577,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j68bd571:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Lighthouse
       target: lighthouse
@@ -596,7 +596,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j41ca94d:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Logstash
       target: logstash
@@ -615,7 +615,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j1d16977:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Mergify
       target: mergify
@@ -634,7 +634,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j981d202:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Neo4j
       target: neo4j
@@ -653,7 +653,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf1d4aee:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Neutrona
       target: neutrona
@@ -672,7 +672,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j337128a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Nextcloud
       target: nextcloud
@@ -691,7 +691,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j581723e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Netnology SD-WAN
       target: nn_sdwan
@@ -710,7 +710,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j61be2af:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: NS1
       target: ns1
@@ -729,7 +729,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   je41f6a9:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: nvml
       target: nvml
@@ -748,7 +748,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j1018635:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Ocient
       target: ocient
@@ -767,7 +767,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   je2bd36a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: OctoPrint
       target: octoprint
@@ -786,7 +786,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdcde1e7:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: open_policy_agent
       target: open_policy_agent
@@ -805,7 +805,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdcd599a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: PHP APCu
       target: php_apcu
@@ -824,7 +824,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf9ca17e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: PHP OPcache
       target: php_opcache
@@ -843,7 +843,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j7220ce3:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: pihole
       target: pihole
@@ -862,7 +862,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j6a4c3a4:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Ping
       target: ping
@@ -881,7 +881,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jdb59cb8:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Portworx
       target: portworx
@@ -900,7 +900,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j831ad4c:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Puma
       target: puma
@@ -919,7 +919,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j689e0be:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: PureFA
       target: purefa
@@ -938,7 +938,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja269254:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: PureFB
       target: purefb
@@ -957,7 +957,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja7891bb:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Qdrant
       target: qdrant
@@ -976,7 +976,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd4cdbe0:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Radarr
       target: radarr
@@ -995,7 +995,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j473bdb7:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Reboot Required
       target: reboot_required
@@ -1014,7 +1014,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jacbd216:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Redis Cloud
       target: redis_cloud
@@ -1033,7 +1033,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j9989d64:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Redis Enterprise V2
       target: redis_enterprise
@@ -1052,7 +1052,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd9748f1:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Redis Enterprise Prometheus
       target: redis_enterprise_prometheus
@@ -1071,7 +1071,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja8f7203:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Redis Sentinel
       target: redis_sentinel
@@ -1090,7 +1090,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja156788:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Redis Enterprise
       target: redisenterprise
@@ -1109,7 +1109,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jce0dc1a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Redpanda
       target: redpanda
@@ -1128,7 +1128,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j09df637:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Resilience4j
       target: resilience4j
@@ -1147,7 +1147,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jc5ec7c0:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Resin
       target: resin
@@ -1166,7 +1166,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j4accb07:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Riak MDC Replication
       target: riak_repl
@@ -1185,7 +1185,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jfcdbb05:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Robust Intelligence AI Firewall
       target: robust_intelligence_ai_firewall
@@ -1204,7 +1204,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j1ba958b:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Rundeck
       target: rundeck
@@ -1223,7 +1223,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf772a8e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Scalr
       target: scalr
@@ -1242,7 +1242,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jfe697d2:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: scamalytics
       target: scamalytics
@@ -1261,7 +1261,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja91188c:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Scaphandre
       target: scaphandre
@@ -1280,7 +1280,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf44ab67:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Sendmail
       target: sendmail
@@ -1299,7 +1299,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j190d837:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: snmpwalk
       target: snmpwalk
@@ -1318,7 +1318,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jcdba2ca:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Sonarr
       target: sonarr
@@ -1337,7 +1337,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j011590d:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Sortdb
       target: sortdb
@@ -1356,7 +1356,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jfc3e971:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: speedtest
       target: speedtest
@@ -1375,7 +1375,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   je0445d5:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Stardog
       target: stardog
@@ -1394,7 +1394,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j5870f9b:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Storm
       target: storm
@@ -1413,7 +1413,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j9744de5:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Syncthing
       target: syncthing
@@ -1432,7 +1432,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j0c2f158:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: TiDB
       target: tidb
@@ -1451,7 +1451,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jd73ec80:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Trino
       target: trino
@@ -1470,7 +1470,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j6c9fa4e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Unbound
       target: unbound
@@ -1489,7 +1489,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja76fbf3:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Unifi Console
       target: unifi_console
@@ -1508,7 +1508,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jfe85d2e:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Upbound UXP
       target: upbound_uxp
@@ -1527,7 +1527,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j4041974:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: UPSC
       target: upsc
@@ -1546,7 +1546,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j8fcdf27:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Vespa
       target: vespa
@@ -1565,7 +1565,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   je48051a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: warpstream
       target: warpstream
@@ -1584,7 +1584,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   jf287d93:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: wayfinder
       target: wayfinder
@@ -1603,7 +1603,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   ja67c5ea:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Zabbix
       target: zabbix
@@ -1622,7 +1622,7 @@ jobs:
       setup-env-vars: "${{ inputs.setup-env-vars }}"
     secrets: inherit
   j7f4936a:
-    uses: DataDog/integrations-core/.github/workflows/test-target.yml@574d63ba88365ffbab915280ceddbaa333c63d6a
+    uses: DataDog/integrations-core/.github/workflows/test-target.yml@5f6b58dfb609ea0afb37762612dbb6e2c37d2933
     with:
       job-name: Zenoh router
       target: zenoh_router


### PR DESCRIPTION
### What does this PR do?

Pins github workflows to a more recent commit
### Motivation

Keeping CI up to date; we also recently refactored github workflows to use dd-sts so this is confirming everything still works after https://github.com/DataDog/integrations-core/pull/24025/changes

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
