### PR TITLE
ci: fix push-triggered release dispatch

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -63,7 +63,7 @@ jobs:
       source-repo: integrations-extras
       packages: ${{ inputs.packages || '' }}
       source-repo-ref: ${{ inputs.source-repo-ref || github.sha }}
-      dry-run: ${{ inputs.dry-run }}
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
       ddev-version: ${{ inputs.ddev-version || '' }}
       is-stable-release: ${{ needs.context.outputs.is-stable-release }}
     permissions:

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -63,7 +63,7 @@ jobs:
       source-repo: integrations-extras
       packages: ${{ inputs.packages || '' }}
       source-repo-ref: ${{ inputs.source-repo-ref || github.sha }}
-      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
+      dry-run: ${{ inputs.dry-run || false }}
       ddev-version: ${{ inputs.ddev-version || '' }}
       is-stable-release: ${{ needs.context.outputs.is-stable-release }}
     permissions:


### PR DESCRIPTION
## Summary

- pass a concrete boolean `false` to the reusable release workflow for `push` events
- continue honoring explicit `true` and `false` values from `workflow_dispatch`
- match integrations-core's explicit `false` fallback so manual `false` cannot be changed back to `true`

## Root cause

[Failed push run 28968202569](https://github.com/DataDog/integrations-extras/actions/runs/28968202569) completed `Detect release context` and `Await release approval`, then failed without creating the reusable `Release` jobs.

`dry-run` exists only as a `workflow_dispatch` input. On `push`, dereferencing the missing property evaluates to an empty string, which the wrapper passed to integrations-core's typed boolean `workflow_call` input. GitHub rejected that value while materializing the reusable job.

The replacement uses integrations-core's established `${{ inputs.dry-run || false }}` pattern and has this behavior:

| Event | Requested dry-run | Passed value |
| --- | --- | --- |
| `push` | unavailable | `false` |
| `workflow_dispatch` | `false` | `false` |
| `workflow_dispatch` | `true` | `true` |

The failed run resolved integrations-core's reusable workflow SHA and completed the caller jobs. Marketplace manual runs with the same wrapper/callee structure successfully materialized reusable jobs with both boolean values, ruling out the reusable-workflow ref, syntax, and permissions.

## Validation

- `actionlint v1.7.7 .github/workflows/release-trigger.yml`
- actionlint against a local copy of integrations-core's current `release-dispatch.yml` to validate the typed `workflow_call` interface
- push/manual truth-table contract check
- normalized diff against marketplace's wrapper

