### PR TITLE
Fix Ping check on non-English Windows

### DIFF
--- a/ping/CHANGELOG.md
+++ b/ping/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - Ping
 
+## 1.0.3 / 2026-07-23
+
+***Fixed***:
+
+* Fix the Ping check on non-English Windows. It no longer crashes on localized output (``'utf-8' codec can't decode byte 0x81``) and no longer reports reachable hosts as down. The check now uses the UTF-8 code page and matches ping's untranslated ``ms`` unit instead of the localized "time" label ([#3075](https://github.com/DataDog/integrations-extras/pull/3075)).
+
 ## 1.0.2 / 2021-09-30
 
 ***Fixed***:

--- a/ping/CHANGELOG.md
+++ b/ping/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Fixed***:
 
-* Fix the Ping check on non-English Windows. It no longer crashes on localized output (``'utf-8' codec can't decode byte 0x81``) and no longer reports reachable hosts as down. The check now uses the UTF-8 code page and matches ping's untranslated ``ms`` unit instead of the localized "time" label ([#3075](https://github.com/DataDog/integrations-extras/pull/3075)).
+* Fix the Ping check on non-English Windows. It no longer crashes on localized output (``'utf-8' codec can't decode byte 0x81``) and no longer reports reachable hosts as down. The check now uses the UTF-8 code page and, when the localized "time" label isn't found, falls back to matching ping's untranslated ``ms`` unit ([#3075](https://github.com/DataDog/integrations-extras/pull/3075)).
 
 ## 1.0.2 / 2021-09-30
 

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -44,7 +44,7 @@ class PingCheck(AgentCheck):
             cmd = "ping"
 
         if platform.system() == "Windows":  # pragma: nocover
-            precmd = ["cmd", "/c", "chcp 437 &"]  # Set code page to English for non-US Windows
+            precmd = ["cmd", "/c", "chcp 65001 &"]  # UTF-8 code page so non-ASCII ping output decodes correctly
             countOption = "-n"
             timeoutOption = "-w"
             # The timeout option is in ms on Windows
@@ -85,12 +85,13 @@ class PingCheck(AgentCheck):
 
         try:
             lines = self._exec_ping(timeout, host)
-            regex = re.compile(r"time[<=]((\d|\.)*)")
+            # Match on the untranslated "ms" unit, since ping localizes the "time" label (e.g. German "Zeit=")
+            regex = re.compile(r"[<=]\s*([\d.]+)\s*ms")
             result = regex.findall(lines)
             if result:
-                length = result[0][0]
+                length = result[0]
             else:
-                raise CheckException("No time= found ({})".format(lines))
+                raise CheckException("No response time found ({})".format(lines))
 
         except CheckException as e:
             self.log.info("%s is DOWN (%s)", host, e)

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -44,7 +44,7 @@ class PingCheck(AgentCheck):
             cmd = "ping"
 
         if platform.system() == "Windows":  # pragma: nocover
-            precmd = ["cmd", "/c", "chcp 65001 &"]  # UTF-8 code page so non-ASCII ping output decodes correctly
+            precmd = ["cmd", "/c", "chcp 65001 &"]
             countOption = "-n"
             timeoutOption = "-w"
             # The timeout option is in ms on Windows
@@ -85,13 +85,15 @@ class PingCheck(AgentCheck):
 
         try:
             lines = self._exec_ping(timeout, host)
-            # Match on the untranslated "ms" unit, since ping localizes the "time" label (e.g. German "Zeit=")
-            regex = re.compile(r"[<=]\s*([\d.]+)\s*ms")
+            regex = re.compile(r"time[<=]((\d|\.)*)")
             result = regex.findall(lines)
             if result:
-                length = result[0]
+                length = result[0][0]
             else:
-                raise CheckException("No response time found ({})".format(lines))
+                result = re.findall(r"[<=]\s*([\d.]+)\s*ms", lines)
+                if not result:
+                    raise CheckException("No response time found ({})".format(lines))
+                length = result[0]
 
         except CheckException as e:
             self.log.info("%s is DOWN (%s)", host, e)

--- a/ping/tests/test_ping.py
+++ b/ping/tests/test_ping.py
@@ -15,6 +15,14 @@ def mock_exec_ping():
 round-trip min/avg/max/stddev = 0.093/0.093/0.093/0.000 ms"""
 
 
+def mock_exec_ping_german():
+    return (
+        "Antwort von 127.0.0.1: Bytes=32 Zeit=3ms TTL=117\n"
+        "Ping-Statistik für 127.0.0.1:\n"
+        "    Minimum = 3ms, Maximum = 3ms, Mittelwert = 3ms"
+    )
+
+
 def test_empty_check(empty_instance):
     check = PingCheck("ping", {}, {})
 
@@ -46,6 +54,17 @@ def test_valid_check_ipv6(aggregator, instance_ipv6):
         check.check(instance_ipv6)
     aggregator.assert_service_check("network.ping.can_connect", AgentCheck.OK)
     aggregator.assert_metric("network.ping.can_connect", value=1)
+    aggregator.assert_all_metrics_covered()
+
+
+def test_localized_output(aggregator, instance_response_time):
+    check = PingCheck("ping", {}, {})
+
+    with mock.patch.object(check, "_exec_ping", return_value=mock_exec_ping_german()):
+        check.check(instance_response_time)
+    aggregator.assert_service_check("network.ping.can_connect", AgentCheck.OK)
+    aggregator.assert_metric("network.ping.can_connect", value=1)
+    aggregator.assert_metric("network.ping.response_time", value=3)
     aggregator.assert_all_metrics_covered()
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes the Ping check on non-English Windows. Windows prints ping's output in the system language, and the check couldn't handle that:

- On German (and other non-English) output it crashed with `'utf-8' codec can't decode byte 0x81`.
- Even when it didn't crash, it looked for the English word `time` to read the response time, which Windows translates (e.g. German `Zeit`) — so it reported reachable hosts as down.

The check now reads the output as UTF-8 and finds the response time by its `ms` unit instead of the English word, so it works in any language. 

### Motivation

Customers were seeing this error ``'utf-8' codec can't decode byte 0x81`` for customers that were utilizing non-english hosts.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
