### PR TITLE
Track successful releases in the GitHub environment

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -63,3 +63,16 @@ jobs:
     permissions:
       id-token: write
       contents: read
+
+  track:
+    name: Record release deployment
+    needs: dispatch
+    if: ${{ !inputs.dry-run }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions: {}
+    steps:
+      - name: Record successful dispatch
+        env:
+          SOURCE_REPO_REF: ${{ inputs.source-repo-ref }}
+        run: echo "Wheel build dispatch completed for ${SOURCE_REPO_REF}"


### PR DESCRIPTION
## Summary

- record successful wheel-build dispatches in the GitHub `release` environment
- run tracking only after the reusable dispatch succeeds
- skip environment tracking for dry runs and grant the tracking job no token permissions

The repository environment has no required reviewers and allows `master` deployments.

## Verification

- actionlint passed
- static workflow contract checks passed
- `git diff --check`
- GitHub reports the commit signature as valid
