### PR TITLE
Fix Ping check on non-English Windows by decoding with the OEM code page

### DIFF
--- a/ping/CHANGELOG.md
+++ b/ping/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG - Ping
 
+## 1.0.4 / 2026-08-04
+
+***Fixed***:
+
+* Fix the Ping check still crashing on non-English Windows. The ``chcp 65001`` approach in 1.0.3 did not change the encoding of ping's output, so localized output still failed with ``'utf-8' codec can't decode byte 0x81``. On Windows the check now decodes ping's output using the OEM code page instead of UTF-8 ([#<PR>](https://github.com/DataDog/integrations-extras/pull/<PR>)).
+
 ## 1.0.3 / 2026-07-23
 
 ***Fixed***:

--- a/ping/CHANGELOG.md
+++ b/ping/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Fixed***:
 
-* Fix the Ping check still crashing on non-English Windows. The ``chcp 65001`` approach in 1.0.3 did not change the encoding of ping's output, so localized output still failed with ``'utf-8' codec can't decode byte 0x81``. On Windows the check now decodes ping's output using the OEM code page instead of UTF-8 ([#<PR>](https://github.com/DataDog/integrations-extras/pull/<PR>)).
+* Fix the Ping check still crashing on non-English Windows. The ``chcp 65001`` approach in 1.0.3 did not change the encoding of ping's output, so localized output still failed with ``'utf-8' codec can't decode byte 0x81``. On Windows the check now decodes ping's output using the OEM code page instead of UTF-8 ([#3092](https://github.com/DataDog/integrations-extras/pull/3092)).
 
 ## 1.0.3 / 2026-07-23
 

--- a/ping/README.md
+++ b/ping/README.md
@@ -9,7 +9,7 @@ Ping operates by sending Internet Control Message Protocol (ICMP) echo request p
 
 This check uses the system ping command, rather than generating the ICMP echo request itself, as creating an ICMP packet requires a raw socket. Creating raw sockets requires root privileges, which the Agent does not have. The ping command uses the `setuid` access flag to run with elevated privileges, avoiding this issue.
 
-**Note for Windows users**: Versions prior to 1.0.3 may not work correctly if the installed Windows language is not set to English.
+**Note for Windows users**: Versions prior to 1.0.4 may not work correctly if the installed Windows language is not set to English.
 
 ## Setup
 

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -6,11 +6,12 @@ import subprocess
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.errors import CheckException
-from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 
 class PingCheck(AgentCheck):
     SERVICE_CHECK_NAME = "network.ping.can_connect"
+    WINDOWS_OUTPUT_ENCODING = "oem"
 
     def _load_conf(self, instance):
         # Fetches the conf
@@ -47,6 +48,7 @@ class PingCheck(AgentCheck):
             timeoutOption = "-w"
             # The timeout option is in ms on Windows
             # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/ping
+            subprocess_timeout = timeout + 10
             timeout = timeout * 1000
         elif platform.system() == "Darwin":
             countOption = "-c"
@@ -67,7 +69,7 @@ class PingCheck(AgentCheck):
         self.log.debug("Running: %s", " ".join(command))
 
         if platform.system() == "Windows":  # pragma: nocover
-            lines, err, retcode = self._exec_ping_windows(command)
+            lines, err, retcode = self._exec_ping_windows(command, subprocess_timeout)
         else:
             lines, err, retcode = get_subprocess_output(command, self.log, raise_on_empty_output=True)
 
@@ -77,13 +79,18 @@ class PingCheck(AgentCheck):
 
         return lines
 
-    def _exec_ping_windows(self, command):  # pragma: nocover
+    def _exec_ping_windows(self, command, subprocess_timeout):
         # ping emits localized output in the OEM code page; get_subprocess_output would hardcode a UTF-8 decode.
-        result = subprocess.run(command, capture_output=True)
-        out = result.stdout.decode("oem", errors="replace")
-        err = result.stderr.decode("oem", errors="replace")
+        try:
+            result = subprocess.run(command, capture_output=True, timeout=subprocess_timeout)
+        except OSError as e:  # e.g. an IPv6 host maps to ping6, which has no executable on Windows
+            raise CheckException("unable to run {}: {}".format(command[0], e))
+        except subprocess.TimeoutExpired:
+            raise CheckException("ping timed out after {}s".format(subprocess_timeout))
+        out = result.stdout.decode(self.WINDOWS_OUTPUT_ENCODING, errors="replace")
+        err = result.stderr.decode(self.WINDOWS_OUTPUT_ENCODING, errors="replace")
         if not out:
-            raise SubprocessOutputEmptyError("get_subprocess_output expected output but had none.")
+            raise CheckException("ping produced no output ({})".format(err))
         return out, err, result.returncode
 
     def check(self, instance):

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -2,10 +2,11 @@
 
 import platform
 import re
+import subprocess
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.errors import CheckException
-from datadog_checks.base.utils.subprocess_output import get_subprocess_output
+from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
 
 
 class PingCheck(AgentCheck):
@@ -24,8 +25,6 @@ class PingCheck(AgentCheck):
         return host, custom_tags, timeout, response_time
 
     def _exec_ping(self, timeout, target_host):
-        precmd = []
-
         try:
             split_url = target_host.split(":")
         except Exception:  # Would be raised if url is not a string
@@ -44,7 +43,6 @@ class PingCheck(AgentCheck):
             cmd = "ping"
 
         if platform.system() == "Windows":  # pragma: nocover
-            precmd = ["cmd", "/c", "chcp 65001 &"]
             countOption = "-n"
             timeoutOption = "-w"
             # The timeout option is in ms on Windows
@@ -65,18 +63,28 @@ class PingCheck(AgentCheck):
             countOption = "-c"
             timeoutOption = "-W"
 
-        self.log.debug("Running: %s %s %s %s %s %s", cmd, countOption, "1", timeoutOption, timeout, target_host)
+        command = [cmd, countOption, "1", timeoutOption, str(timeout), target_host]
+        self.log.debug("Running: %s", " ".join(command))
 
-        lines, err, retcode = get_subprocess_output(
-            precmd + [cmd, countOption, "1", timeoutOption, str(timeout), target_host],
-            self.log,
-            raise_on_empty_output=True,
-        )
+        if platform.system() == "Windows":  # pragma: nocover
+            lines, err, retcode = self._exec_ping_windows(command)
+        else:
+            lines, err, retcode = get_subprocess_output(command, self.log, raise_on_empty_output=True)
+
         self.log.debug("ping returned %s - %s - %s", retcode, lines, err)
         if retcode != 0:
             raise CheckException("ping returned {}: {}".format(retcode, err))
 
         return lines
+
+    def _exec_ping_windows(self, command):  # pragma: nocover
+        # ping emits localized output in the OEM code page; get_subprocess_output would hardcode a UTF-8 decode.
+        result = subprocess.run(command, capture_output=True)
+        out = result.stdout.decode("oem", errors="replace")
+        err = result.stderr.decode("oem", errors="replace")
+        if not out:
+            raise SubprocessOutputEmptyError("get_subprocess_output expected output but had none.")
+        return out, err, result.returncode
 
     def check(self, instance):
         host, custom_tags, timeout, response_time = self._load_conf(instance)

--- a/ping/datadog_checks/ping/ping.py
+++ b/ping/datadog_checks/ping/ping.py
@@ -68,7 +68,7 @@ class PingCheck(AgentCheck):
         command = [cmd, countOption, "1", timeoutOption, str(timeout), target_host]
         self.log.debug("Running: %s", " ".join(command))
 
-        if platform.system() == "Windows":  # pragma: nocover
+        if platform.system() == "Windows":
             lines, err, retcode = self._exec_ping_windows(command, subprocess_timeout)
         else:
             lines, err, retcode = get_subprocess_output(command, self.log, raise_on_empty_output=True)

--- a/ping/tests/test_ping.py
+++ b/ping/tests/test_ping.py
@@ -83,11 +83,15 @@ def test_localized_output(aggregator, instance_response_time):
     aggregator.assert_all_metrics_covered()
 
 
-def test_windows_oem_decode(aggregator, instance_response_time):
+def test_windows_oem_decode():
     check = PingCheck("ping", {}, {})
-    run_windows_check(check, instance_response_time, stdout=WINDOWS_GERMAN_OUTPUT)
-    aggregator.assert_service_check("network.ping.can_connect", AgentCheck.OK)
-    aggregator.assert_metric("network.ping.response_time", value=3)
+    check.WINDOWS_OUTPUT_ENCODING = "cp850"
+    proc = mock.Mock(stdout=WINDOWS_GERMAN_OUTPUT, stderr=b"", returncode=0)
+    with mock.patch.object(subprocess, "run", return_value=proc):
+        lines, err, retcode = check._exec_ping_windows(["ping", "-n", "1", "127.0.0.1"], 14)
+    # The actual regression check: a wrong codec turns "ausgeführt" into mojibake / replacement chars.
+    assert "ausgeführt" in lines
+    assert "\ufffd" not in lines
 
 
 def test_windows_missing_executable_is_critical(aggregator, instance):

--- a/ping/tests/test_ping.py
+++ b/ping/tests/test_ping.py
@@ -9,8 +9,7 @@ from datadog_checks.base.errors import CheckException
 from datadog_checks.ping import PingCheck
 
 WINDOWS_GERMAN_OUTPUT = (
-    "Ping wird ausgeführt für 127.0.0.1 mit 32 Bytes Daten:\r\n"
-    "Antwort von 127.0.0.1: Bytes=32 Zeit=3ms TTL=117\r\n"
+    "Ping wird ausgeführt für 127.0.0.1 mit 32 Bytes Daten:\r\nAntwort von 127.0.0.1: Bytes=32 Zeit=3ms TTL=117\r\n"
 ).encode("cp850")
 
 
@@ -18,9 +17,7 @@ def run_windows_check(check, instance, stdout=b"", stderr=b"", returncode=0, run
     check.WINDOWS_OUTPUT_ENCODING = "cp850"
     proc = mock.Mock(stdout=stdout, stderr=stderr, returncode=returncode)
     run_mock = mock.Mock(return_value=proc, side_effect=run_side_effect)
-    with mock.patch.object(platform, "system", return_value="Windows"), mock.patch.object(
-        subprocess, "run", run_mock
-    ):
+    with mock.patch.object(platform, "system", return_value="Windows"), mock.patch.object(subprocess, "run", run_mock):
         check.check(instance)
 
 

--- a/ping/tests/test_ping.py
+++ b/ping/tests/test_ping.py
@@ -1,9 +1,27 @@
+import platform
+import subprocess
+
 import mock
 import pytest
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
 from datadog_checks.ping import PingCheck
+
+WINDOWS_GERMAN_OUTPUT = (
+    "Ping wird ausgeführt für 127.0.0.1 mit 32 Bytes Daten:\r\n"
+    "Antwort von 127.0.0.1: Bytes=32 Zeit=3ms TTL=117\r\n"
+).encode("cp850")
+
+
+def run_windows_check(check, instance, stdout=b"", stderr=b"", returncode=0, run_side_effect=None):
+    check.WINDOWS_OUTPUT_ENCODING = "cp850"
+    proc = mock.Mock(stdout=stdout, stderr=stderr, returncode=returncode)
+    run_mock = mock.Mock(return_value=proc, side_effect=run_side_effect)
+    with mock.patch.object(platform, "system", return_value="Windows"), mock.patch.object(
+        subprocess, "run", run_mock
+    ):
+        check.check(instance)
 
 
 def mock_exec_ping():
@@ -66,6 +84,34 @@ def test_localized_output(aggregator, instance_response_time):
     aggregator.assert_metric("network.ping.can_connect", value=1)
     aggregator.assert_metric("network.ping.response_time", value=3)
     aggregator.assert_all_metrics_covered()
+
+
+def test_windows_oem_decode(aggregator, instance_response_time):
+    check = PingCheck("ping", {}, {})
+    run_windows_check(check, instance_response_time, stdout=WINDOWS_GERMAN_OUTPUT)
+    aggregator.assert_service_check("network.ping.can_connect", AgentCheck.OK)
+    aggregator.assert_metric("network.ping.response_time", value=3)
+
+
+def test_windows_missing_executable_is_critical(aggregator, instance):
+    check = PingCheck("ping", {}, {})
+    with pytest.raises(CheckException):
+        run_windows_check(check, instance, run_side_effect=FileNotFoundError("ping6"))
+    aggregator.assert_service_check("network.ping.can_connect", AgentCheck.CRITICAL)
+
+
+def test_windows_nonzero_return_code_is_critical(aggregator, instance):
+    check = PingCheck("ping", {}, {})
+    with pytest.raises(CheckException):
+        run_windows_check(check, instance, stdout=b"Request timed out.\r\n", returncode=1)
+    aggregator.assert_service_check("network.ping.can_connect", AgentCheck.CRITICAL)
+
+
+def test_windows_empty_output_is_critical(aggregator, instance):
+    check = PingCheck("ping", {}, {})
+    with pytest.raises(CheckException):
+        run_windows_check(check, instance, stdout=b"")
+    aggregator.assert_service_check("network.ping.can_connect", AgentCheck.CRITICAL)
 
 
 @pytest.mark.usefixtures("dd_environment")


### PR DESCRIPTION
### What does this PR do?

Fixes the `ping` check crashing on non-English Windows. On Windows the check now runs `ping` via `subprocess.run` and decodes its output with the **OEM code page** (`decode("oem", errors="replace")`) instead of going through `get_subprocess_output`, which hardcodes a UTF-8 decode. The `chcp 65001` approach from 1.0.3 is removed. 

### Motivation

1.0.3 tried to fix this by switching the console to UTF-8 (`chcp 65001`), but that turned out not to change the encoding ping actually uses , so a customer on German Windows still hit the same crash (`'utf-8' codec can't decode byte 0x81`) after updating.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

The code fix was able to be tested on a customer's non-English windows host and we confirmed it resolved the crash.