### PR TITLE
Define dataflows for Datadog-owned integrations (batch 1)

### DIFF
--- a/1e/assets/dataflows.yaml
+++ b/1e/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: one-e-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/ably/assets/dataflows.yaml
+++ b/ably/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: ably-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/agora_analytics/assets/dataflows.yaml
+++ b/agora_analytics/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: agora-analytics-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/aimon/assets/dataflows.yaml
+++ b/aimon/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: aimon-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: aimon-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/akeyless_gateway/assets/dataflows.yaml
+++ b/akeyless_gateway/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: akeyless-gateway-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/algorithmia/assets/dataflows.yaml
+++ b/algorithmia/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: algorithmia-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/anecdote/assets/dataflows.yaml
+++ b/anecdote/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: anecdote-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: anecdote-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/appomni/assets/dataflows.yaml
+++ b/appomni/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: appomni-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/aqua/assets/dataflows.yaml
+++ b/aqua/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: aqua-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: aqua-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/auth0/assets/dataflows.yaml
+++ b/auth0/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: auth0-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: auth0-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/authzed_cloud/assets/dataflows.yaml
+++ b/authzed_cloud/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: authzed-cloud-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/bind9/assets/dataflows.yaml
+++ b/bind9/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: bind9-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: bind9-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/bottomline_recordandreplay/assets/dataflows.yaml
+++ b/bottomline_recordandreplay/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: bottomline-recordandreplay-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: bottomline-recordandreplay-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/buoyant_cloud/assets/dataflows.yaml
+++ b/buoyant_cloud/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: buoyant-cloud-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/celerdata/assets/dataflows.yaml
+++ b/celerdata/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: celerdata-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: celerdata-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/census/assets/dataflows.yaml
+++ b/census/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: census-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/cloudsmith/assets/dataflows.yaml
+++ b/cloudsmith/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: cloudsmith-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/concourse_ci/assets/dataflows.yaml
+++ b/concourse_ci/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: concourse-ci-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/contrast_security_adr/assets/dataflows.yaml
+++ b/contrast_security_adr/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: contrast-security-adr-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/cribl_stream/assets/dataflows.yaml
+++ b/cribl_stream/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: cribl-stream-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/cyral/assets/dataflows.yaml
+++ b/cyral/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: cyral-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/dagster/assets/dataflows.yaml
+++ b/dagster/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: dagster-plus-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/doppler/assets/dataflows.yaml
+++ b/doppler/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: doppler-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/embrace_mobile/assets/dataflows.yaml
+++ b/embrace_mobile/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: embrace-mobile-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/emqx/assets/dataflows.yaml
+++ b/emqx/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: emqx-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/fauna/assets/dataflows.yaml
+++ b/fauna/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: fauna-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/fiddler/assets/dataflows.yaml
+++ b/fiddler/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: fiddler-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/gatling_enterprise/assets/dataflows.yaml
+++ b/gatling_enterprise/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: gatling-enterprise-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/gravitee/assets/dataflows.yaml
+++ b/gravitee/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: gravitee-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: gravitee-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/hasura_cloud/assets/dataflows.yaml
+++ b/hasura_cloud/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: hasura-cloud-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/inngest/assets/dataflows.yaml
+++ b/inngest/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: inngest-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/invary/assets/dataflows.yaml
+++ b/invary/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: invary-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/jfrog_platform_cloud/assets/dataflows.yaml
+++ b/jfrog_platform_cloud/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: jfrog-platform-cloud-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/jfrog_platform_self_hosted/assets/dataflows.yaml
+++ b/jfrog_platform_self_hosted/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: jfrog-platform-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: jfrog-platform-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/lacework/assets/dataflows.yaml
+++ b/lacework/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: lacework-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/lambdatest/assets/dataflows.yaml
+++ b/lambdatest/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: lambdatest-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/lighthouse/assets/dataflows.yaml
+++ b/lighthouse/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: lighthouse-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/mendix/assets/dataflows.yaml
+++ b/mendix/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: mendix-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/n2ws/assets/dataflows.yaml
+++ b/n2ws/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: n2ws-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/neo4j/assets/dataflows.yaml
+++ b/neo4j/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: neo4j-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/neoload/assets/dataflows.yaml
+++ b/neoload/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: neoload-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/ngrok/assets/dataflows.yaml
+++ b/ngrok/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: ngrok-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/nn_sdwan/assets/dataflows.yaml
+++ b/nn_sdwan/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: nn-sdwan-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/ns1/assets/dataflows.yaml
+++ b/ns1/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: ns1-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/oceanbasecloud/assets/dataflows.yaml
+++ b/oceanbasecloud/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: oceanbase-cloud-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/packetfabric/assets/dataflows.yaml
+++ b/packetfabric/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: packetfabric-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/perfectscale/assets/dataflows.yaml
+++ b/perfectscale/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: perfectscale-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/postman/assets/dataflows.yaml
+++ b/postman/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: postman-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/purefa/assets/dataflows.yaml
+++ b/purefa/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: purefa-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/purefb/assets/dataflows.yaml
+++ b/purefb/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: purefb-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/redis_sentinel/assets/dataflows.yaml
+++ b/redis_sentinel/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: redis-sentinel-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/redisenterprise/assets/dataflows.yaml
+++ b/redisenterprise/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: redisenterprise-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/scalr/assets/dataflows.yaml
+++ b/scalr/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: scalr-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/scaphandre/assets/dataflows.yaml
+++ b/scaphandre/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: scaphandre-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/singlestoredb_cloud/assets/dataflows.yaml
+++ b/singlestoredb_cloud/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: singlestoredb-cloud-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/sofy_sofy/assets/dataflows.yaml
+++ b/sofy_sofy/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: sofy-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/sosivio/assets/dataflows.yaml
+++ b/sosivio/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: sosivio-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/sqreen/assets/dataflows.yaml
+++ b/sqreen/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: sqreen-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/starburst_galaxy/assets/dataflows.yaml
+++ b/starburst_galaxy/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: starburst-galaxy-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/statsig/assets/dataflows.yaml
+++ b/statsig/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: statsig-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/stormforge/assets/dataflows.yaml
+++ b/stormforge/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: stormforge-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/superwise/assets/dataflows.yaml
+++ b/superwise/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: superwise-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/tidb/assets/dataflows.yaml
+++ b/tidb/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: tidb-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/tidb_cloud/assets/dataflows.yaml
+++ b/tidb_cloud/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: tidb-cloud-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/twingate/assets/dataflows.yaml
+++ b/twingate/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: twingate-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/typingdna_activelock/assets/dataflows.yaml
+++ b/typingdna_activelock/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: typingdna-activelock-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/unitq/assets/dataflows.yaml
+++ b/unitq/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: unitq-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/upbound_uxp/assets/dataflows.yaml
+++ b/upbound_uxp/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: upbound-uxp-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/upstash/assets/dataflows.yaml
+++ b/upstash/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: upstash-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/vns3/assets/dataflows.yaml
+++ b/vns3/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: vns3-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/watchtower_ziris/assets/dataflows.yaml
+++ b/watchtower_ziris/assets/dataflows.yaml
@@ -1,0 +1,11 @@
+provides:
+  - id: ziris-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound
+  - id: ziris-logs
+    always_on: true
+    granular: false
+    data_type: logs
+    direction: inbound

--- a/yugabytedb_managed/assets/dataflows.yaml
+++ b/yugabytedb_managed/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: yugabytedb-managed-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/zebrium/assets/dataflows.yaml
+++ b/zebrium/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: zebrium-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound

--- a/zilliz_cloud_zilliz_cloud/assets/dataflows.yaml
+++ b/zilliz_cloud_zilliz_cloud/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: zilliz-cloud-zilliz-cloud-metrics
+    always_on: true
+    granular: false
+    data_type: metrics
+    direction: inbound


### PR DESCRIPTION
**Jira:** [TXP-277](https://datadoghq.atlassian.net/browse/TXP-277)

Adds `assets/dataflows.yaml` to **74** integrations, declaring **84** dataflows. Mechanical change: no code, no metrics, no manifests touched.

Coverage goes from **14/260 (5.4%)** to **88/260 (33.8%)**.

Precedent: #2925 "Define dataflows for saas-integrations", which created 13 of the 14 existing files in this repo.

## Selection criteria

A directory is in this batch only if **all** of the following hold:

1. It has no `assets/dataflows.yaml` today. (14 already do; untouched.)
2. It has a parseable `manifest.json`. The dataflows validator hard-requires one — `dataflows_validation_handler.go:56`. 5 directories in this repo lack one and cannot carry the asset at all.
3. The correct `data_type` is **mechanically derivable** from a committed artifact, with no judgement call:
   - `metadata.csv` with at least one data row → `metrics`
   - a log pipeline under `assets/logs/*.yaml` → `logs`
   - both → both entries
4. `.github/CODEOWNERS` resolves `<dir>/assets/dataflows.yaml` (last-match-wins) to an owner set containing at least one `@DataDog/…` team.

**Every directory in this batch has a Datadog team CODEOWNER, so no external maintainer approval is required to merge.** The teams involved are `@DataDog/ecosystems-review`, `@DataDog/agent-integrations`, `@DataDog/container-integrations`, and `@DataDog/saas-integrations`. External co-owners are auto-requested on many of these paths, but their approval is not a gate.

## Field values

```yaml
provides:
  - id: <app_id>-<data_type>
    always_on: true
    granular: false
    data_type: <metrics|logs>
    direction: inbound
```

`always_on: true` / `granular: false` / `direction: inbound` matches 14 of the 17 dataflow entries already in the repo. The only deviation in the repo is `vercel`, which is `always_on: false` for a Serverless product-enablement reason that does not apply here.

Dataflow IDs are `<app_id>-<data_type>`, taking `app_id` from `manifest.json` rather than the directory name. This is what all 17 existing entries do — e.g. `logzio/` → `logz-io-events`, `zscaler/` → `z-scaler-logs`, `cockroachdb_dedicated/` → `cockroach-cloud-metrics`. All 84 new IDs were checked for collisions against every existing ID in the repo, and against each other.

## Validation

These files were validated by **executing the real validator**, `DataflowsValidationHandler` from `dd-source/domains/integrationscatalog/libs/catalogassetslib/dataflows_validation_handler.go`, at `ddoghq/dd-source@main`, against all 88 `dataflows.yaml` files in the repo working tree.

Result: **88 files, 101 dataflow IDs, 0 failures**, covering per-file unmarshalling, proto constraint validation, and the cross-file `HandleLibrary` ID-uniqueness check.

The harness was negative-tested first and confirmed to reject: a missing `always_on`; a `data_type` outside `validDataTypes`; an `id` breaking `^[a-z0-9-]+$`; an `id` under 3 characters; a file with neither `provides` nor `uses`; a `.yml` extension; a missing `manifest.json`; and the same dataflow ID provided by two apps.

This matters because APW does not post validator comments on integrations-extras PRs (`enable_validator_comments` is set only for `pub-platform-staging` and `publishing-platform`). A malformed `dataflows.yaml` merges cleanly here and only fails afterwards, in the shared asset pipeline.

## Deferred, and why

| Category | Count | Reason |
|---|---|---|
| RUM SDK tiles | 17 | There is no `rum` value in `validDataTypes`, and no defensible substitute. Needs a schema decision. |
| Service-check-only | 5 | `cfssl`, `cybersixgill_actionable_alerts`, `go_pprof_scraper`, `isdown`, `reboot_required`. Service checks map to no `data_type`. |
| No local data signal | 86 | Mostly outbound notification/webhook tiles and UI Extensions. Determining the right `data_type` needs a README read per integration, plus a ruling on whether outbound tiles are `events` + `direction: outbound` at all. |
| Mechanical but externally owned | 81 | Same derivation as this batch, but no Datadog team CODEOWNER. **Batch 2**, to be split by owner cluster with a heads-up in `#ecosystems-review` first. |
| No parseable `manifest.json` | 5 | `aerospike_enterprise`, `scamalytics`, `warpstream`, plus `fluxcd` and `traefik`, which are README-only and already in APW's `disabled_collections`. |

No `data_type` was guessed anywhere. Any integration whose correct value was not unambiguous is deferred rather than approximated.

## Contents

### Metrics only (51)

| Integration | Dataflow IDs |
|---|---|
| `1e` | `one-e-metrics` |
| `ably` | `ably-metrics` |
| `agora_analytics` | `agora-analytics-metrics` |
| `akeyless_gateway` | `akeyless-gateway-metrics` |
| `algorithmia` | `algorithmia-metrics` |
| `authzed_cloud` | `authzed-cloud-metrics` |
| `buoyant_cloud` | `buoyant-cloud-metrics` |
| `census` | `census-metrics` |
| `cloudsmith` | `cloudsmith-metrics` |
| `concourse_ci` | `concourse-ci-metrics` |
| `cribl_stream` | `cribl-stream-metrics` |
| `cyral` | `cyral-metrics` |
| `embrace_mobile` | `embrace-mobile-metrics` |
| `emqx` | `emqx-metrics` |
| `fiddler` | `fiddler-metrics` |
| `gatling_enterprise` | `gatling-enterprise-metrics` |
| `hasura_cloud` | `hasura-cloud-metrics` |
| `inngest` | `inngest-metrics` |
| `lighthouse` | `lighthouse-metrics` |
| `mendix` | `mendix-metrics` |
| `n2ws` | `n2ws-metrics` |
| `neo4j` | `neo4j-metrics` |
| `neoload` | `neoload-metrics` |
| `nn_sdwan` | `nn-sdwan-metrics` |
| `ns1` | `ns1-metrics` |
| `oceanbasecloud` | `oceanbase-cloud-metrics` |
| `packetfabric` | `packetfabric-metrics` |
| `perfectscale` | `perfectscale-metrics` |
| `postman` | `postman-metrics` |
| `purefa` | `purefa-metrics` |
| `purefb` | `purefb-metrics` |
| `redis_sentinel` | `redis-sentinel-metrics` |
| `redisenterprise` | `redisenterprise-metrics` |
| `scalr` | `scalr-metrics` |
| `scaphandre` | `scaphandre-metrics` |
| `singlestoredb_cloud` | `singlestoredb-cloud-metrics` |
| `sofy_sofy` | `sofy-metrics` |
| `sosivio` | `sosivio-metrics` |
| `starburst_galaxy` | `starburst-galaxy-metrics` |
| `statsig` | `statsig-metrics` |
| `stormforge` | `stormforge-metrics` |
| `superwise` | `superwise-metrics` |
| `tidb` | `tidb-metrics` |
| `tidb_cloud` | `tidb-cloud-metrics` |
| `unitq` | `unitq-metrics` |
| `upbound_uxp` | `upbound-uxp-metrics` |
| `upstash` | `upstash-metrics` |
| `vns3` | `vns3-metrics` |
| `yugabytedb_managed` | `yugabytedb-managed-metrics` |
| `zebrium` | `zebrium-metrics` |
| `zilliz_cloud_zilliz_cloud` | `zilliz-cloud-zilliz-cloud-metrics` |

### Logs only (13)

| Integration | Dataflow IDs |
|---|---|
| `appomni` | `appomni-logs` |
| `contrast_security_adr` | `contrast-security-adr-logs` |
| `dagster` | `dagster-plus-logs` |
| `doppler` | `doppler-logs` |
| `fauna` | `fauna-logs` |
| `invary` | `invary-logs` |
| `jfrog_platform_cloud` | `jfrog-platform-cloud-logs` |
| `lacework` | `lacework-logs` |
| `lambdatest` | `lambdatest-logs` |
| `ngrok` | `ngrok-logs` |
| `sqreen` | `sqreen-logs` |
| `twingate` | `twingate-logs` |
| `typingdna_activelock` | `typingdna-activelock-logs` |

### Metrics and logs (10)

| Integration | Dataflow IDs |
|---|---|
| `aimon` | `aimon-metrics`, `aimon-logs` |
| `anecdote` | `anecdote-metrics`, `anecdote-logs` |
| `aqua` | `aqua-metrics`, `aqua-logs` |
| `auth0` | `auth0-metrics`, `auth0-logs` |
| `bind9` | `bind9-metrics`, `bind9-logs` |
| `bottomline_recordandreplay` | `bottomline-recordandreplay-metrics`, `bottomline-recordandreplay-logs` |
| `celerdata` | `celerdata-metrics`, `celerdata-logs` |
| `gravitee` | `gravitee-metrics`, `gravitee-logs` |
| `jfrog_platform_self_hosted` | `jfrog-platform-metrics`, `jfrog-platform-logs` |
| `watchtower_ziris` | `ziris-metrics`, `ziris-logs` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI status — the red checks are pre-existing, not from this PR

| Check | Verdict |
|---|---|
| `validate-dataflows` (APW) | **pass** — "The `dataflows` assets are valid." This is the check that matters for this PR. |
| `run / Validate` | **pre-existing.** Fails on `ddev validate config` / `ddev validate models` drift in 11 integrations. |
| `validate-assets`, `validate-docs_gitlab` | **infrastructure.** APW reports verbatim: *"A system error occurred while validating `docs_gitlab`. This is not a problem with your assets."* |
| `review-check` | **non-blocking**, and self-described as such. 72 of 74 reviewable; `purefa` and `tidb_cloud` are excluded because other in-flight PRs touch them. |

On `run / Validate`: this PR adds only `assets/dataflows.yaml` files and touches no `conf.yaml.example`, `spec.yaml`, or pydantic model. Extras CI validates only *changed* integrations, so adding a file to these directories pulled them into scope and surfaced drift that was already there.

Evidence: the `Validate repository` workflow has failed on **every one of the last 10 runs on `master`**, including `9c197fe` — this PR's base commit. That master run flags 39 integrations, and the 11 flagged here are a strict subset of those 39:

`celerdata`, `emqx`, `fiddler`, `jfrog_platform_self_hosted`, `neo4j`, `nn_sdwan`, `purefa`, `purefb`, `scalr`, `scaphandre`, `upbound_uxp`

Fixing that drift is a separate change with a different blast radius and different reviewers, so it is deliberately not bundled here.

[TXP-277]: https://datadoghq.atlassian.net/browse/TXP-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ