### PR TITLE
Document the Redis Sentinel failover event

### DIFF
--- a/redis_sentinel/README.md
+++ b/redis_sentinel/README.md
@@ -42,7 +42,7 @@ See [metadata.csv][11] for a list of metrics provided by this check.
 
 ### Events
 
-The Redis's Sentinel check does not include any events.
+The Redis Sentinel check emits an event when a monitored master fails over to a new IP address. No event is emitted the first time a master is observed, so starting the check does not generate failover events.
 
 ### Service Checks
 

--- a/redis_sentinel/manifest.json
+++ b/redis_sentinel/manifest.json
@@ -31,7 +31,7 @@
       "source_type_name": "Redis Sentinel",
       "configuration": {},
       "events": {
-        "creates_events": false
+        "creates_events": true
       },
       "metrics": {
         "prefix": "redis.",


### PR DESCRIPTION
**Jira:** [TXP-277](https://datadoghq.atlassian.net/browse/TXP-277)

Follow-up to #3101, which added a `redis-sentinel-events` dataflow. That PR surfaced two pieces of metadata that contradict the check's actual behavior. This PR corrects both. No code change.

## The check does emit events

`_process_master_stats` calls `self.event(...)` when a monitored master's IP changes, guarded by `if self._masters[master_name] != ""` so it does not fire on the first observation of a master:

```python
if self._masters[master_name] != stats['ip']:
    if self._masters[master_name] != "":  # avoid check initialization
        self.increment('redis.sentinel.failover', tags=base_tags)
        self.event({... 'msg_title': '%s failover from %s to %s' ...})
```

## What was wrong

| File | Was | Now |
|---|---|---|
| `README.md` | "The Redis's Sentinel check does not include any events." | Describes the failover event and the initialization guard |
| `manifest.json` | `"creates_events": false` | `"creates_events": true` |

The `manifest.json` half was caught by Codex review on this branch: leaving `creates_events: false` while the README documents events would keep catalog pages and any manifest-reading tooling advertising that the integration has no events.

`creates_events: true` matches what other event-emitting integrations in this repo declare (`cloudsmith`, `redisenterprise`, `cybersixgill_actionable_alerts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TXP-277]: https://datadoghq.atlassian.net/browse/TXP-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ