### PR TITLE
Fix failing DDCI status checks 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,16 +6,15 @@ variables:
 stages:
   - release
 
-workflow:
+release-auto:
+  stage: release
+  image: $TAGGER_IMAGE
   rules:
     - if: $CI_COMMIT_MESSAGE =~ /^\[Release\] Update metadata/
       when: never
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: always
-
-release-auto:
-  stage: release
-  image: $TAGGER_IMAGE
+    - when: never
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts


### PR DESCRIPTION
### What does this PR do?

Similar to https://github.com/DataDog/marketplace-internal-ci/pull/4, DDCI has failed on all commits besides release commits.

This PR removes the workflow rules and instead adds job rules so that the workflow always runs but the release auto job only runs on certain commits. This should fix the failing checks.

### Motivation

Failing DDCI checks
### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors. 

### Additional Notes

Anything else we should know when reviewing?
