### PR TITLE
Fix ddev config and model validation failures on master

### DIFF
--- a/celerdata/datadog_checks/celerdata/config_models/defaults.py
+++ b/celerdata/datadog_checks/celerdata/config_models/defaults.py
@@ -40,6 +40,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/celerdata/datadog_checks/celerdata/config_models/instance.py
+++ b/celerdata/datadog_checks/celerdata/config_models/instance.py
@@ -9,11 +9,17 @@ from types import MappingProxyType
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
 
 
 class AuthToken(BaseModel):
@@ -93,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -105,7 +112,7 @@ class InstanceConfig(BaseModel):
     ignore_connection_errors: Optional[bool] = None
     ignore_tags: Optional[tuple[str, ...]] = None
     include_labels: Optional[tuple[str, ...]] = None
-    kerberos_auth: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None
     kerberos_force_initiate: Optional[bool] = None
@@ -158,6 +165,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/celerdata/datadog_checks/celerdata/data/conf.yaml.example
+++ b/celerdata/datadog_checks/celerdata/data/conf.yaml.example
@@ -86,6 +86,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/celerdata/pyproject.toml
+++ b/celerdata/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=36.16.0",
+    "datadog-checks-base>=37.33.0",
 ]
 dynamic = [
     "version",

--- a/emqx/datadog_checks/emqx/config_models/defaults.py
+++ b/emqx/datadog_checks/emqx/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/emqx/datadog_checks/emqx/config_models/instance.py
+++ b/emqx/datadog_checks/emqx/config_models/instance.py
@@ -9,11 +9,17 @@ from types import MappingProxyType
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
 
 
 class AuthToken(BaseModel):
@@ -93,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -105,7 +112,7 @@ class InstanceConfig(BaseModel):
     ignore_connection_errors: Optional[bool] = None
     ignore_tags: Optional[tuple[str, ...]] = None
     include_labels: Optional[tuple[str, ...]] = None
-    kerberos_auth: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None
     kerberos_force_initiate: Optional[bool] = None
@@ -158,6 +165,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/emqx/datadog_checks/emqx/data/conf.yaml.example
+++ b/emqx/datadog_checks/emqx/data/conf.yaml.example
@@ -115,6 +115,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/fiddler/assets/configuration/spec.yaml
+++ b/fiddler/assets/configuration/spec.yaml
@@ -34,17 +34,17 @@ files:
         example: 3600
     - name: v1compat
       required: false
-      default: false
       description: The v1compat to use old metrics names for the Fiddler instance.
       value:
         type: boolean
+        default: false
         example: true
     - name: enabled_metrics
       required: false
-      default: ['drift', 'traffic', 'performance', 'statistic', 'service_metrics']
       description: The enabled metric types for the Fiddler instance.
       value:
         type: array
+        default: ['drift', 'traffic', 'performance', 'statistic', 'service_metrics']
         items:
           type: string 
         example:

--- a/fiddler/datadog_checks/fiddler/config_models/defaults.py
+++ b/fiddler/datadog_checks/fiddler/config_models/defaults.py
@@ -20,9 +20,17 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
+def instance_enabled_metrics():
+    return ['drift', 'traffic', 'performance', 'statistic', 'service_metrics']
+
+
 def instance_min_collection_interval():
     return 15
 
 
 def instance_v1compat():
-    return True
+    return False

--- a/fiddler/datadog_checks/fiddler/config_models/instance.py
+++ b/fiddler/datadog_checks/fiddler/config_models/instance.py
@@ -34,6 +34,7 @@ class InstanceConfig(BaseModel):
     delay: Optional[int] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     enabled_metrics: Optional[tuple[str, ...]] = None
     fiddler_api_key: str
     metric_patterns: Optional[MetricPatterns] = None

--- a/fiddler/datadog_checks/fiddler/data/conf.yaml.example
+++ b/fiddler/datadog_checks/fiddler/data/conf.yaml.example
@@ -33,12 +33,12 @@ instances:
     #
     # bin_size: 3600
 
-    ## @param v1compat - boolean - optional - default: true
+    ## @param v1compat - boolean - optional - default: false
     ## The v1compat to use old metrics names for the Fiddler instance.
     #
     # v1compat: true
 
-    ## @param enabled_metrics - list of strings - optional
+    ## @param enabled_metrics - list of strings - optional - default: ['drift', 'traffic', 'performance', 'statistic', 'service_metrics']
     ## The enabled metric types for the Fiddler instance.
     #
     # enabled_metrics:

--- a/fiddler/pyproject.toml
+++ b/fiddler/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=25.1.0",
+    "datadog-checks-base>=37.20.0",
 ]
 dynamic = [
     "version",

--- a/jfrog_platform_self_hosted/datadog_checks/jfrog_platform_self_hosted/data/conf.yaml.example
+++ b/jfrog_platform_self_hosted/datadog_checks/jfrog_platform_self_hosted/data/conf.yaml.example
@@ -503,10 +503,10 @@ instances:
     #
     # read_timeout: <READ_TIMEOUT>
 
-    ## @param request_size - number - optional - default: 10
+    ## @param request_size - number - optional - default: 16
     ## The number of kibibytes (KiB) to read from streaming HTTP responses at a time.
     #
-    # request_size: 10
+    # request_size: 16
 
     ## @param log_requests - boolean - optional - default: false
     ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.

--- a/neo4j/datadog_checks/neo4j/config_models/defaults.py
+++ b/neo4j/datadog_checks/neo4j/config_models/defaults.py
@@ -40,6 +40,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/neo4j/datadog_checks/neo4j/config_models/instance.py
+++ b/neo4j/datadog_checks/neo4j/config_models/instance.py
@@ -9,11 +9,17 @@ from types import MappingProxyType
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
 
 
 class AuthToken(BaseModel):
@@ -93,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -105,7 +112,7 @@ class InstanceConfig(BaseModel):
     ignore_connection_errors: Optional[bool] = None
     ignore_tags: Optional[tuple[str, ...]] = None
     include_labels: Optional[tuple[str, ...]] = None
-    kerberos_auth: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None
     kerberos_force_initiate: Optional[bool] = None
@@ -160,6 +167,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/neo4j/datadog_checks/neo4j/data/conf.yaml.example
+++ b/neo4j/datadog_checks/neo4j/data/conf.yaml.example
@@ -87,6 +87,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/nn_sdwan/datadog_checks/nn_sdwan/config_models/defaults.py
+++ b/nn_sdwan/datadog_checks/nn_sdwan/config_models/defaults.py
@@ -12,5 +12,9 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_min_collection_interval():
     return 15

--- a/nn_sdwan/datadog_checks/nn_sdwan/config_models/instance.py
+++ b/nn_sdwan/datadog_checks/nn_sdwan/config_models/instance.py
@@ -32,6 +32,7 @@ class InstanceConfig(BaseModel):
     )
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     hostname: str
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None

--- a/nn_sdwan/pyproject.toml
+++ b/nn_sdwan/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=25.1.0",
+    "datadog-checks-base>=37.20.0",
 ]
 dynamic = [
     "version",

--- a/purefa/assets/configuration/spec.yaml
+++ b/purefa/assets/configuration/spec.yaml
@@ -22,7 +22,6 @@ files:
         min_collection_interval.value.example: 120
         min_collection_interval.enabled: true
         cache_shared_labels.value.example: false
-        share_labels.value.enabled: true
         share_labels.value.example:
           purefa_info:
             labels:

--- a/purefa/datadog_checks/purefa/config_models/defaults.py
+++ b/purefa/datadog_checks/purefa/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/purefa/datadog_checks/purefa/config_models/instance.py
+++ b/purefa/datadog_checks/purefa/config_models/instance.py
@@ -9,11 +9,17 @@ from types import MappingProxyType
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
 
 
 class AuthToken(BaseModel):
@@ -93,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -105,7 +112,7 @@ class InstanceConfig(BaseModel):
     ignore_connection_errors: Optional[bool] = None
     ignore_tags: Optional[tuple[str, ...]] = None
     include_labels: Optional[tuple[str, ...]] = None
-    kerberos_auth: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None
     kerberos_force_initiate: Optional[bool] = None
@@ -158,6 +165,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/purefa/datadog_checks/purefa/data/conf.yaml.example
+++ b/purefa/datadog_checks/purefa/data/conf.yaml.example
@@ -133,6 +133,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/purefa/pyproject.toml
+++ b/purefa/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "datadog-checks-base>=33.1.0",
+    "datadog-checks-base>=37.33.0",
 ]
 dynamic = [
     "version",

--- a/purefb/datadog_checks/purefb/config_models/defaults.py
+++ b/purefb/datadog_checks/purefb/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/purefb/datadog_checks/purefb/config_models/instance.py
+++ b/purefb/datadog_checks/purefb/config_models/instance.py
@@ -9,11 +9,17 @@ from types import MappingProxyType
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
 
 
 class AuthToken(BaseModel):
@@ -93,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -105,7 +112,7 @@ class InstanceConfig(BaseModel):
     ignore_connection_errors: Optional[bool] = None
     ignore_tags: Optional[tuple[str, ...]] = None
     include_labels: Optional[tuple[str, ...]] = None
-    kerberos_auth: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None
     kerberos_force_initiate: Optional[bool] = None
@@ -158,6 +165,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/purefb/datadog_checks/purefb/data/conf.yaml.example
+++ b/purefb/datadog_checks/purefb/data/conf.yaml.example
@@ -133,6 +133,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/scalr/assets/configuration/spec.yaml
+++ b/scalr/assets/configuration/spec.yaml
@@ -16,9 +16,9 @@ files:
     - name: access_token
       required: true
       description: Scalr API access token
+      secret: true
       value:
         type: string
-        secret: true
     - template: instances/default
       overrides:
         min_collection_interval.value.example: 60

--- a/scalr/datadog_checks/scalr/config_models/defaults.py
+++ b/scalr/datadog_checks/scalr/config_models/defaults.py
@@ -12,5 +12,9 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_min_collection_interval():
     return 60

--- a/scalr/datadog_checks/scalr/config_models/instance.py
+++ b/scalr/datadog_checks/scalr/config_models/instance.py
@@ -33,6 +33,7 @@ class InstanceConfig(BaseModel):
     access_token: str
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
     service: Optional[str] = None

--- a/scalr/pyproject.toml
+++ b/scalr/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=25.1.0",
+    "datadog-checks-base>=37.20.0",
 ]
 dynamic = [
     "version",

--- a/scaphandre/datadog_checks/scaphandre/config_models/defaults.py
+++ b/scaphandre/datadog_checks/scaphandre/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/scaphandre/datadog_checks/scaphandre/config_models/instance.py
+++ b/scaphandre/datadog_checks/scaphandre/config_models/instance.py
@@ -9,11 +9,17 @@ from types import MappingProxyType
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
 
 
 class AuthToken(BaseModel):
@@ -93,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -105,7 +112,7 @@ class InstanceConfig(BaseModel):
     ignore_connection_errors: Optional[bool] = None
     ignore_tags: Optional[tuple[str, ...]] = None
     include_labels: Optional[tuple[str, ...]] = None
-    kerberos_auth: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None
     kerberos_force_initiate: Optional[bool] = None
@@ -158,6 +165,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/scaphandre/datadog_checks/scaphandre/data/conf.yaml.example
+++ b/scaphandre/datadog_checks/scaphandre/data/conf.yaml.example
@@ -115,6 +115,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/upbound_uxp/datadog_checks/upbound_uxp/config_models/defaults.py
+++ b/upbound_uxp/datadog_checks/upbound_uxp/config_models/defaults.py
@@ -12,5 +12,9 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_min_collection_interval():
     return 15

--- a/upbound_uxp/datadog_checks/upbound_uxp/config_models/instance.py
+++ b/upbound_uxp/datadog_checks/upbound_uxp/config_models/instance.py
@@ -32,6 +32,7 @@ class InstanceConfig(BaseModel):
     )
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
     service: Optional[str] = None

--- a/upbound_uxp/pyproject.toml
+++ b/upbound_uxp/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=25.1.0",
+    "datadog-checks-base>=37.20.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
Fixes `ddev validate config` and `ddev validate models`, which fail on `master` today for 11 integrations. Split out of #3100, where the failure surfaced.

## Why it fails on `master`

`.github/workflows/validate.yml` delegates to `DataDog/integrations-core/.github/workflows/run-validations.yml`, which installs ddev with **no version pin**:

```yaml
- name: Install ddev from PyPI
  # When ddev version is empty we install the latest released ddev.
  run: pip install ddev${{ inputs.ddev-version }}
```

So CI always runs the newest released ddev. Its config templates have moved ahead of the generated output committed here, and the drift is invisible until a PR happens to touch one of the affected directories — the job runs with `TARGET: changed`, so it only validates changed integration directories.

That is what happened on #3100: a dataflows-only change (63 files, every one an `assets/dataflows.yaml`) turned the job red without touching a single file it complains about.

Reproduced locally on **CI's exact toolchain, Python 3.13 + ddev 17.0.1**, which matches CI's failure set precisely — 9 config files and 20 model files. Worth noting for anyone else chasing this: on Python 3.10 `pip install ddev` resolves only to 14.4.0, and 14.3.2 does not reproduce the `conf.yaml.example` drift at all. You need Python 3.13 to get ddev 17.

## Commit 1 — regenerate stale output (8 integrations)

`ddev validate config -s` and `ddev validate models -s`. Every file changed here is generated; no hand edits.

| What the current template emits | Files |
|---|---|
| a `##` continuation line in the `exclude_metrics` docstring | `conf.yaml.example` |
| `enable_legacy_tags_normalization` | `defaults.py`, `instance.py` |
| `SECURE_FIELD_NAMES` + the `check_field_trusted_provider` hook | `instance.py` |
| `kerberos_auth` narrowed from `str` to `Literal['required', 'optional', 'disabled']` | `instance.py` |
| `request_size` example `10` → `16`, from the shared `instances/http.yaml` template | `conf.yaml.example` |

`celerdata`, `emqx`, `neo4j`, `purefb`, `scaphandre`, `jfrog_platform_self_hosted`, `nn_sdwan`, `upbound_uxp`.

`jfrog_platform_self_hosted` has no `config_models/` package on `master`, and it deliberately still doesn't — `ddev validate models -s` will generate one from scratch if you let it, which is a behavior change well beyond a drift fix. Only its `conf.yaml.example` is synced here, which is all CI asks for. Its `models` validation passed before this PR and still does.

## Commit 2 — three specs place a field at the wrong level

These are genuine spec errors, not template drift; they fail on any recent ddev. In all three cases the misplaced field is **silently ignored today**, so none currently has any effect.

**`fiddler`** declared `default` at option level, where only `value` may carry it. Moved both into `value`. This also settles a live contradiction: the shipped example documented `v1compat` as `default: true` while `check.py` reads `self.instance.get('v1compat', False)`. The regenerated example now documents `false`, matching the code.

**`purefa`** overrode `share_labels.value.enabled`, but `enabled` is option-level. **Removed** rather than relocated — moving it up would uncomment the whole `share_labels` block in the shipped example, newly enabling label sharing for anyone copying it. Removal preserves today's effective behavior exactly.

**`scalr`** marked `access_token` with a value-level `secret`, which is option-level. Moved it up so the credential is marked as intended, matching how `fiddler` declares `fiddler_api_key`. This changes no generated output.

## Commit 3 — raise six `datadog-checks-base` floors

Touching the check code turned on a second job that master never runs: `test-minimum-base-package` installs each integration's *declared floor*, and six of those floors predate the repo's move to Python 3.13 (`bf2df5fe`, #2781). Their transitive dependencies no longer build there, and all six died in `uv pip install` before a single test ran:

| Floor | Fails on |
|---|---|
| `fiddler` `scalr` `nn_sdwan` `upbound_uxp` — `>=25.1.0` | `immutables==0.16` — `pyproject.toml` `missing field 'name'` |
| `purefa` — `>=33.1.0` | `jellyfish==1.0.0` — `project.version` neither set nor dynamic |
| `celerdata` — `>=36.16.0` | `ddtrace==2.10.6` — `ModuleNotFoundError: No module named 'pkg_resources'` |

The split is clean: every integration already at `>=37.20.0` installs fine, every older floor fails. So the four go to `>=37.20.0`.

`celerdata` and `purefa` go to **`>=37.33.0`** instead, because their regenerated models call `validation.security.check_field_trusted_provider`, which first shipped in that version (integrations-core#22226). Their old floors would have installed a base without it.

This follows #2810, "Fix ddev validation and minimum base check", which fixed this same failure with the same combined scope — regenerated models plus floor bumps to `>=37.20.0`, and no version or changelog churn.

## Validation

Every validation extras CI enables, run per integration across all 11 locally, plus CI itself:

| | |
|---|---|
| `config` `models` `imports` `integration-style` | pass |
| `legacy-signature` `metadata` `package` `readmes` `jmx-metrics` | pass |
| `ci` `codeowners` (repo-wide) | pass |
| CI `run / Validate`, `test`, `test-minimum-base-package` | pass |

## Two things I deliberately left alone

**`scalr` fails `ddev validate service-checks`**, pre-existing: `scalr.can_connect: integration name 'Scalr' must match manifest display_name 'Scalr (Community Version)'`. Different files, and extras CI does not enable that validation.

**`ddev validate dep`** fails repo-wide on `master` for unrelated integrations (`aerospike_enterprise`, `aws_pricing`, `filemage`, `neutrona`, …). Also not enabled in extras CI.

No CHANGELOG entries or version bumps, matching #2810: these are regenerated artifacts and dependency floors across third-party integrations, and cutting releases is the owners' call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
