### PR TITLE
Add RUM dataflows to the RUM SDK tiles

### DIFF
--- a/rum_android/assets/dataflows.yaml
+++ b/rum_android/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-android-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_angular/assets/dataflows.yaml
+++ b/rum_angular/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-angular-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_cypress/assets/dataflows.yaml
+++ b/rum_cypress/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-cypress-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_expo/assets/dataflows.yaml
+++ b/rum_expo/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-expo-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_flutter/assets/dataflows.yaml
+++ b/rum_flutter/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-flutter-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_ios/assets/dataflows.yaml
+++ b/rum_ios/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-ios-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_javascript/assets/dataflows.yaml
+++ b/rum_javascript/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-javascript-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_nextjs/assets/dataflows.yaml
+++ b/rum_nextjs/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-next-plugin-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_nuxt/assets/dataflows.yaml
+++ b/rum_nuxt/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-nuxt-plugin-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_react/assets/dataflows.yaml
+++ b/rum_react/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-react-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_react_native/assets/dataflows.yaml
+++ b/rum_react_native/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-react-native-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_roku/assets/dataflows.yaml
+++ b/rum_roku/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-roku-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_salesforce_lwc/assets/dataflows.yaml
+++ b/rum_salesforce_lwc/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-salesforce-lwc-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_shopify/assets/dataflows.yaml
+++ b/rum_shopify/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-shopify-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound

--- a/rum_vue/assets/dataflows.yaml
+++ b/rum_vue/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rum-vue-events
+    always_on: true
+    granular: false
+    data_type: rum_events
+    direction: inbound


### PR DESCRIPTION
**Jira:** [TXP-277](https://datadoghq.atlassian.net/browse/TXP-277)

Adds `assets/dataflows.yaml` to the 15 RUM SDK tiles, so each one declares the RUM events its SDK sends to Datadog.

### What each file says

```yaml
provides:
  - id: rum-vue-events
    always_on: true
    granular: false
    data_type: rum_events
    direction: inbound
```

- **`always_on: true`** — the tile exists to describe an installed SDK. Once it's in the page or app it sends RUM events; there's no per-tile toggle to turn that off.
- **`granular: false`** — granular is reserved for product-specific onboarding (`llm_completions`, `cloud_cost`, `mcp_tool_calls`).
- **`direction: inbound`** — data flows into Datadog.
- **One dataflow per tile.** Splitting is for logically distinct data with different toggles; a RUM SDK emits one stream of events.

### Dataflow ids

Ids come from the **manifest `app_id`**, not the directory name — those differ for two tiles: `rum_nextjs` → `rum-next-plugin`, `rum_nuxt` → `rum-nuxt-plugin`. Getting this wrong would have produced ids that don't correspond to any app.

| Tile | Dataflow id |
| --- | --- |
| `rum_android` | `rum-android-events` |
| `rum_angular` | `rum-angular-events` |
| `rum_cypress` | `rum-cypress-events` |
| `rum_expo` | `rum-expo-events` |
| `rum_flutter` | `rum-flutter-events` |
| `rum_ios` | `rum-ios-events` |
| `rum_javascript` | `rum-javascript-events` |
| `rum_nextjs` | `rum-next-plugin-events` |
| `rum_nuxt` | `rum-nuxt-plugin-events` |
| `rum_react` | `rum-react-events` |
| `rum_react_native` | `rum-react-native-events` |
| `rum_roku` | `rum-roku-events` |
| `rum_salesforce_lwc` | `rum-salesforce-lwc-events` |
| `rum_shopify` | `rum-shopify-events` |
| `rum_vue` | `rum-vue-events` |

The documented convention is `{app-id}-{data-type}`, which would give `rum-vue-rum-events`. Since every app_id here already begins with `rum-`, the second one is dropped: the id still ends in the data noun and stays unique. Dataflow ids are globally unique and effectively permanent — the validator refuses to remove a dataflow that another app `uses` — so they're worth getting right the first time.

### Why 15 tiles and not 18

Three tiles match "rum" but do not provide RUM events, and are deliberately excluded: **`flagsmith-rum`**, **`split-rum`**, **`statsig_rum`**.

All three are feature-flag integrations that *enrich* RUM. Their setup instructions have the vendor SDK call `datadogRum.addFeatureFlagEvaluation(...)` — the RUM Browser SDK still does the sending, so the provider of that data is `rum_javascript`, not them. Their manifests agree: they're categorized `Configuration & Deployment` / `Developer Tools`, while the 15 included tiles carry `Metrics` / `Tracing` / `Mobile`. Declaring `provides: rum_events` on them would assert something untrue.

If we want to model the enrichment relationship, `uses` is the right mechanism and a separate change.

### Validation

`ddev` does not validate `dataflows.yaml` at all — the only enforcement is server-side in catalogassets. So rather than trust the schema by eye, I ran all 15 payloads through the **real validator** (`unmarshalDataflowsYAML` + `config.Validate()` from `domains/integrationscatalog/libs/catalogassetslib`) in a throwaway test, asserting for every file: it parses, exactly one `provides` and no `uses`, `data_type == rum_events`, `always_on` true, `granular` false, `direction` inbound, and all 15 ids distinct.

```
=== RUN   TestRumTilesRealFixtures
--- PASS: TestRumTilesRealFixtures (0.00s)
```

That test was temporary and is not part of either PR.

Two further checks:

- **`ddev --here validate all`** output is byte-for-byte identical with and without these 15 files (7 pre-existing errors, 152 files valid, all in unrelated checks) — confirming this change introduces no validation regression, and confirming `ddev` ignores the asset.
- **No id collisions.** No dataflow id beginning with `rum-` exists anywhere in `integrations-extras`, `integrations-core`, or `integrations-internal-core`. Caveat: the core and internal-core clones I scanned are local, so a very recently merged `rum-*` id would not have shown up.

[TXP-277]: https://datadoghq.atlassian.net/browse/TXP-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ