### PR TITLE
Remove accidentally tracked worktree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ wheelhouse/
 # pyenv versioning
 .python-version
 
+# Local Git worktrees
+.worktrees/
+


### PR DESCRIPTION
### What does this PR do?

Removes the accidentally tracked `.worktrees/octo-sts-migration` gitlink and adds `.worktrees/` to `.gitignore` so local Git worktrees cannot be committed again through normal staging.

### Motivation

The stray mode-160000 entry has no corresponding `.gitmodules` configuration. As a result, `actions/checkout` fails while checking out `integrations-extras` for wheel releases:

```text
fatal: No url found for submodule path '.worktrees/octo-sts-migration' in .gitmodules
```

This blocked the `ping` wheel release in [agent-integration-wheels-release job 94784804336](https://github.com/DataDog/agent-integration-wheels-release/actions/runs/31740069311/job/94784804336). The entry was introduced by the revert in #2946.

### Review checklist

- [x] PR has a meaningful title
- [x] Bugfix has focused regression validation
- [x] Git history is clean
- [x] Documentation is not impacted
- [x] This PR does not include a log pipeline

### Additional Notes

Validation performed:

- Confirmed `git submodule foreach --recursive true` failed with exit code 128 before the change.
- Confirmed the same command succeeds after removing the gitlink.
- Confirmed a fresh sparse clone of the committed tree succeeds.
- Confirmed `.worktrees/` is ignored and no tracked gitlinks remain.

After this merges, the `ping` wheel release must be dispatched against the new fixed source SHA; rerunning the existing release still references the immutable broken SHA.
