### PR TITLE
Add missing CODEOWNERS entries for fluxcd and traefik

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,6 +85,7 @@ code-coverage.datadog.yml                                  @DataDog/agent-integr
 /flagsmith-rum/                          @benjarom3 support@flagsmith.com @DataDog/ecosystems-review
 /fluentbit/                              @zhenyami
 /flume/                                  @KealanMaas
+/fluxcd/                                 @DataDog/agent-integrations
 /gatekeeper/                             @arapulido ara.pulido@datadoghq.com
 /gigamon/                                @Mrudula-Oruganti-Gigamon
 /gitea/                                  @FlorentClarret
@@ -227,6 +228,7 @@ code-coverage.datadog.yml                                  @DataDog/agent-integr
 /tidb/                                   @SabaPing xuyifan02@pingcap.com @DataDog/ecosystems-review
 /tidb_cloud/                             @SabaPing xuyifan02@pingcap.com @DataDog/ecosystems-review
 /torq/                                   @torqio/rnd support@torq.io
+/traefik/                                @renaudhager @DataDog/documentation
 /trino/                                  @ndrluis
 /twenty_forty_eight/                     @DataDog/apps-sdk @DataDog/ecosystems-review
 /twingate/                               @emrul partnerships@twingate.com @DataDog/ecosystems-review


### PR DESCRIPTION
## Summary
- `fluxcd` and `traefik` were both moved to `integrations-core`, leaving stub directories here with no top-level CODEOWNERS entry (`traefik` had asset-specific lines but no catch-all `/traefik/` entry; `fluxcd` had none at all).
- `ddev validate codeowners` fails on this with "Integration fluxcd/traefik does not have a valid `CODEOWNERS` entry", and since the check runs against every PR touching the repo, it's currently failing CI for unrelated changes across the repo.
- Adds a catch-all entry for each, matching the ownership already used for `traefik`'s other CODEOWNERS lines (`@renaudhager @DataDog/documentation`) and falling back to `@DataDog/agent-integrations` for `fluxcd`, which has no prior entries to match.

## Test plan
- [x] `ddev validate codeowners` passes locally after the change