### PR TITLE
Bump minimum datadog-checks-base pin for fiddler, scalr, upbound_uxp

### DIFF
--- a/fiddler/pyproject.toml
+++ b/fiddler/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=25.1.0",
+    "datadog-checks-base>=37.20.0",
 ]
 dynamic = [
     "version",

--- a/scalr/pyproject.toml
+++ b/scalr/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=25.1.0",
+    "datadog-checks-base>=37.20.0",
 ]
 dynamic = [
     "version",

--- a/upbound_uxp/pyproject.toml
+++ b/upbound_uxp/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=25.1.0",
+    "datadog-checks-base>=37.20.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
## Summary
- Follow-up to #3121: fiddler, scalr, and upbound_uxp still pinned `datadog-checks-base>=25.1.0`, whose transitive dependency `immutables==0.16` fails to build under the current `uv`/setuptools toolchain (its old sdist's `pyproject.toml` is missing `project.name`).
- This caused `test-minimum-base-package` to fail for these three, but the job isn't a required check so it didn't block #3121 from merging.
- Bumped to `datadog-checks-base>=37.20.0`, matching the fix already applied to celerdata/nn_sdwan/purefa in #3121 and the floor most other integrations in this repo already use. Confirmed locally via `uv pip install` that the pinned version builds cleanly.

## Test plan
- [x] `uv pip install datadog-checks-base[deps]==37.20.0` succeeds (previously failed for `immutables==0.16` at the old pin)
- [ ] CI `test-minimum-base-package` passes for fiddler, scalr, upbound_uxp

🤖 Generated with [Claude Code](https://claude.com/claude-code)