### PR TITLE
Add outbound events dataflows for notification/alert-routing tiles

### DIFF
--- a/alertnow/assets/dataflows.yaml
+++ b/alertnow/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: alertnow-events
+    always_on: true
+    granular: false
+    data_type: events
+    direction: outbound

--- a/appkeeper/assets/dataflows.yaml
+++ b/appkeeper/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: appkeeper-events
+    always_on: true
+    granular: false
+    data_type: events
+    direction: outbound

--- a/ilert/assets/dataflows.yaml
+++ b/ilert/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: ilert-events
+    always_on: true
+    granular: false
+    data_type: events
+    direction: outbound

--- a/rundeck/assets/dataflows.yaml
+++ b/rundeck/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: rundeck-events
+    always_on: true
+    granular: false
+    data_type: events
+    direction: outbound

--- a/signl4/assets/dataflows.yaml
+++ b/signl4/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: signl4-events
+    always_on: true
+    granular: false
+    data_type: events
+    direction: outbound

--- a/squadcast/assets/dataflows.yaml
+++ b/squadcast/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: squadcast-events
+    always_on: true
+    granular: false
+    data_type: events
+    direction: outbound

--- a/taskcall/assets/dataflows.yaml
+++ b/taskcall/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: taskcall-events
+    always_on: true
+    granular: false
+    data_type: events
+    direction: outbound

--- a/zenduty/assets/dataflows.yaml
+++ b/zenduty/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: zenduty-events
+    always_on: true
+    granular: false
+    data_type: events
+    direction: outbound


### PR DESCRIPTION
## Summary
- Adds an always-on outbound `events` dataflow to 8 tiles whose own descriptions explicitly say they act on/relay Datadog alerts to a third-party incident/notification target: `alertnow`, `ilert`, `signl4`, `squadcast`, `taskcall`, `zenduty`, `appkeeper`, `rundeck`.
- `events` + `direction: outbound` is already valid per `dataflows_validation_handler.go` in dd-source (no validator change needed), but this specific usage pattern for notification tiles has not yet been formally ratified by `@ddoghq/integrations-experience` — tracked under TXP-277 (https://datadoghq.atlassian.net/browse/TXP-277).
- Opened as a **draft** so it doesn't trigger review requests to third-party maintainers before that decision lands. Intended as a concrete artifact to prompt the ratification discussion (same pattern used for `rum_events` in dd-source#50640).
- Scope deliberately narrow: of ~46 tiles tagged Notification/Incident/Alerting without an existing dataflow, only these 8 have descriptions unambiguously describing a Datadog-alerts-out direction. Excluded tiles like `pagerduty_ui` (whose description is actually inbound: PagerDuty→Datadog) despite appearing in earlier informal lists, and dozens of AIOps/root-cause tools (causely, komodor, cortex, etc.) whose direction can't be confirmed without vendor-specific research.

## Test plan
- [ ] Validate YAML parses and matches schema (done locally via PyYAML — `ddev validate all` does not check `dataflows.yaml` at all, confirmed empirically on a prior PR in this series)
- [ ] Get `@ddoghq/integrations-experience` sign-off on `events` + `direction: outbound` semantics for notification tiles before un-drafting
- [ ] Un-draft once ratified, to trigger third-party maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)