### PR TITLE
Sync conf.yaml.example/config models with ddev + fix redis get_default_config collision

### DIFF
--- a/mergify/datadog_checks/mergify/config_models/defaults.py
+++ b/mergify/datadog_checks/mergify/config_models/defaults.py
@@ -12,6 +12,10 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_mergify_api_url():
     return 'https://api.mergify.com'
 

--- a/mergify/datadog_checks/mergify/config_models/instance.py
+++ b/mergify/datadog_checks/mergify/config_models/instance.py
@@ -33,6 +33,7 @@ class InstanceConfig(BaseModel):
     )
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     mergify_api_url: Optional[str] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None

--- a/ocient/datadog_checks/ocient/config_models/defaults.py
+++ b/ocient/datadog_checks/ocient/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/ocient/datadog_checks/ocient/config_models/instance.py
+++ b/ocient/datadog_checks/ocient/config_models/instance.py
@@ -9,11 +9,17 @@ from types import MappingProxyType
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
 
 
 class AuthToken(BaseModel):
@@ -93,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -105,7 +112,7 @@ class InstanceConfig(BaseModel):
     ignore_connection_errors: Optional[bool] = None
     ignore_tags: Optional[tuple[str, ...]] = None
     include_labels: Optional[tuple[str, ...]] = None
-    kerberos_auth: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None
     kerberos_force_initiate: Optional[bool] = None
@@ -158,6 +165,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/ocient/datadog_checks/ocient/data/conf.yaml.example
+++ b/ocient/datadog_checks/ocient/data/conf.yaml.example
@@ -115,6 +115,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/qdrant/datadog_checks/qdrant/config_models/defaults.py
+++ b/qdrant/datadog_checks/qdrant/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/qdrant/datadog_checks/qdrant/config_models/instance.py
+++ b/qdrant/datadog_checks/qdrant/config_models/instance.py
@@ -17,6 +17,11 @@ from datadog_checks.base.utils.models import validation
 from . import defaults, validators
 
 
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
+
+
 class AuthToken(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -94,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -159,6 +165,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/qdrant/datadog_checks/qdrant/data/conf.yaml.example
+++ b/qdrant/datadog_checks/qdrant/data/conf.yaml.example
@@ -116,6 +116,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/redis_cloud/datadog_checks/redis_cloud/check.py
+++ b/redis_cloud/datadog_checks/redis_cloud/check.py
@@ -16,7 +16,7 @@ class RedisCloudCheck(OpenMetricsBaseCheckV2):
     def _parse_config(self):
         self.scraper_configs = []
         metrics_endpoint = self.instance.get('openmetrics_endpoint')
-        metrics = self.get_default_config()
+        metrics = self.get_default_metrics()
 
         additional = []
         groups = self.instance.get('extra_metrics', [])
@@ -49,7 +49,7 @@ class RedisCloudCheck(OpenMetricsBaseCheckV2):
         config.update(self.instance)
         self.scraper_configs.append(config)
 
-    def get_default_config(self):
+    def get_default_metrics(self):
         metrics = []
         for dm in DEFAULT_METRICS:
             metrics.append(dm)

--- a/redis_cloud/datadog_checks/redis_cloud/config_models/defaults.py
+++ b/redis_cloud/datadog_checks/redis_cloud/config_models/defaults.py
@@ -40,6 +40,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/redis_cloud/datadog_checks/redis_cloud/config_models/instance.py
+++ b/redis_cloud/datadog_checks/redis_cloud/config_models/instance.py
@@ -9,11 +9,17 @@ from types import MappingProxyType
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
 
 
 class AuthToken(BaseModel):
@@ -93,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -105,7 +112,7 @@ class InstanceConfig(BaseModel):
     ignore_connection_errors: Optional[bool] = None
     ignore_tags: Optional[tuple[str, ...]] = None
     include_labels: Optional[tuple[str, ...]] = None
-    kerberos_auth: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None
     kerberos_force_initiate: Optional[bool] = None
@@ -158,6 +165,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/redis_cloud/datadog_checks/redis_cloud/data/conf.yaml.example
+++ b/redis_cloud/datadog_checks/redis_cloud/data/conf.yaml.example
@@ -85,6 +85,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/redis_enterprise/datadog_checks/redis_enterprise/check.py
+++ b/redis_enterprise/datadog_checks/redis_enterprise/check.py
@@ -17,7 +17,7 @@ class RedisEnterpriseCheck(OpenMetricsBaseCheckV2):
         self.scraper_configs = []
         metrics_endpoint = self.instance.get('openmetrics_endpoint')
         self.instance.setdefault("tls_verify", True)
-        metrics = self.get_default_config()
+        metrics = self.get_default_metrics()
 
         additional = []
         groups = self.instance.get('extra_metrics', [])
@@ -50,7 +50,7 @@ class RedisEnterpriseCheck(OpenMetricsBaseCheckV2):
         config.update(self.instance)
         self.scraper_configs.append(config)
 
-    def get_default_config(self):
+    def get_default_metrics(self):
         metrics = []
         for dm in DEFAULT_METRICS:
             metrics.append(dm)

--- a/redis_enterprise/datadog_checks/redis_enterprise/config_models/defaults.py
+++ b/redis_enterprise/datadog_checks/redis_enterprise/config_models/defaults.py
@@ -40,6 +40,10 @@ def instance_enable_health_service_check():
     return True
 
 
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
 def instance_histogram_buckets_as_distributions():
     return False
 

--- a/redis_enterprise/datadog_checks/redis_enterprise/config_models/instance.py
+++ b/redis_enterprise/datadog_checks/redis_enterprise/config_models/instance.py
@@ -9,11 +9,17 @@ from types import MappingProxyType
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
 
 from . import defaults, validators
+
+
+SECURE_FIELD_NAMES = frozenset(
+    ['auth_token', 'kerberos_cache', 'kerberos_keytab', 'tls_ca_cert', 'tls_cert', 'tls_private_key']
+)
 
 
 class AuthToken(BaseModel):
@@ -93,6 +99,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
     exclude_labels: Optional[tuple[str, ...]] = None
     exclude_metrics: Optional[tuple[str, ...]] = None
     exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
@@ -105,7 +112,7 @@ class InstanceConfig(BaseModel):
     ignore_connection_errors: Optional[bool] = None
     ignore_tags: Optional[tuple[str, ...]] = None
     include_labels: Optional[tuple[str, ...]] = None
-    kerberos_auth: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None
     kerberos_force_initiate: Optional[bool] = None
@@ -158,6 +165,11 @@ class InstanceConfig(BaseModel):
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
             value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+
+            if info.field_name in SECURE_FIELD_NAMES:
+                validation.security.check_field_trusted_provider(
+                    info.field_name, value, info.context.get('security_config')
+                )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 

--- a/redis_enterprise/datadog_checks/redis_enterprise/data/conf.yaml.example
+++ b/redis_enterprise/datadog_checks/redis_enterprise/data/conf.yaml.example
@@ -85,6 +85,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$

--- a/redpanda/datadog_checks/redpanda/data/conf.yaml.example
+++ b/redpanda/datadog_checks/redpanda/data/conf.yaml.example
@@ -132,6 +132,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ##
     ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$


### PR DESCRIPTION
## What

Regenerates `conf.yaml.example` and `config_models/{defaults,instance}.py` for six integrations whose generated files had drifted out of sync with the `ddev` version CI now runs, and renames a colliding `get_default_config` method in `redis_cloud`/`redis_enterprise`.

## Why

**Drift fix:** The `Validate` workflow's `pip install ddev` is unpinned, so CI validates against whatever the latest `ddev` release is (18.0.0 as of this PR), while these files were last regenerated with an older `ddev`. That mismatch has been failing `ddev validate config`/`ddev validate models` on `master` for a while — it's unrelated to any specific PR's content, but any PR that touches one of these directories (even just adding an unrelated file) drags the whole directory into `TARGET=changed` scope and inherits the failure.

Affected:
- `conf.yaml.example`: `ocient`, `qdrant`, `redis_cloud`, `redis_enterprise`, `redpanda`
- `config_models`: `mergify`, `ocient`, `qdrant`, `redis_cloud`, `redis_enterprise`

**Method collision fix:** `OpenMetricsBaseCheckV2.get_config_with_defaults()` in a newer `datadog_checks_base` calls `self.get_default_config()` to seed scraper config from generated model defaults. `RedisCloudCheck`/`RedisEnterpriseCheck` each pre-existing define their own unrelated `get_default_config()` (returns default metric groups), which shadows the base class's method and causes `ValueError: dictionary update sequence element #0 has length N; 2 is required` at check init. Renamed both to `get_default_metrics` to remove the collision — this is a pre-existing bug, unrelated to the drift fix above, but it also lives in `redis_cloud`/`redis_enterprise` and hits the same `TARGET=changed` scoping problem, so it's combined into this PR rather than split into a separate one (see note below).

## How

- Regenerated with `ddev validate config <check> -s` / `ddev validate models <check> -s` using `ddev` 18.0.0 (matching CI), verified each is back in sync. No manual edits — every changed file is fully autogenerated from `assets/configuration/spec.yaml`.
- Renamed `get_default_config` → `get_default_metrics` in `redis_cloud/datadog_checks/redis_cloud/check.py` and `redis_enterprise/datadog_checks/redis_enterprise/check.py`, updating the one call site in each. Verified locally with `ddev test redis_cloud`/`redis_enterprise` (5/5, 7/7 passing) and `ddev validate config`/`models` for both, using `ddev` 18.0.0.

## Note

This PR was originally split into two (this drift fix, plus a separate PR renaming the colliding method). Both touch the same `redis_cloud`/`redis_enterprise` directories, so under CI's `TARGET=changed` scoping neither could pass independently — whichever one didn't carry the other's fix would fail on the other's pre-existing bug when checked standalone. Combined them here; the separate rename PR (#3128) is closed as superseded.

This PR unblocks #3095 (TXP-277 dataflows.yaml backfill, batch 2), which is stacked on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
