### PR TITLE
Rename get_default_config to get_default_metrics in redis_cloud/redis_enterprise checks

### DIFF
--- a/redis_cloud/datadog_checks/redis_cloud/check.py
+++ b/redis_cloud/datadog_checks/redis_cloud/check.py
@@ -16,7 +16,7 @@ class RedisCloudCheck(OpenMetricsBaseCheckV2):
     def _parse_config(self):
         self.scraper_configs = []
         metrics_endpoint = self.instance.get('openmetrics_endpoint')
-        metrics = self.get_default_config()
+        metrics = self.get_default_metrics()
 
         additional = []
         groups = self.instance.get('extra_metrics', [])
@@ -49,7 +49,7 @@ class RedisCloudCheck(OpenMetricsBaseCheckV2):
         config.update(self.instance)
         self.scraper_configs.append(config)
 
-    def get_default_config(self):
+    def get_default_metrics(self):
         metrics = []
         for dm in DEFAULT_METRICS:
             metrics.append(dm)

--- a/redis_enterprise/datadog_checks/redis_enterprise/check.py
+++ b/redis_enterprise/datadog_checks/redis_enterprise/check.py
@@ -17,7 +17,7 @@ class RedisEnterpriseCheck(OpenMetricsBaseCheckV2):
         self.scraper_configs = []
         metrics_endpoint = self.instance.get('openmetrics_endpoint')
         self.instance.setdefault("tls_verify", True)
-        metrics = self.get_default_config()
+        metrics = self.get_default_metrics()
 
         additional = []
         groups = self.instance.get('extra_metrics', [])
@@ -50,7 +50,7 @@ class RedisEnterpriseCheck(OpenMetricsBaseCheckV2):
         config.update(self.instance)
         self.scraper_configs.append(config)
 
-    def get_default_config(self):
+    def get_default_metrics(self):
         metrics = []
         for dm in DEFAULT_METRICS:
             metrics.append(dm)


### PR DESCRIPTION
## What

Renames the `get_default_config()` method on `RedisCloudCheck` and
`RedisEnterpriseCheck` to `get_default_metrics()`.

## Why

Both checks defined their own `get_default_config()` returning a list of
metric groups. A newer `datadog-checks-base` adds its own
`get_default_config()` hook to `OpenMetricsBaseCheckV2`, used internally by
`get_config_with_defaults()` to seed scraper config from the check's
generated `config_models` defaults (expects key/value pairs). Because
`pyproject.toml` pins `datadog-checks-base>=37.20.0` with no upper bound,
CI resolves the latest version, whose base class method gets shadowed by
each check's same-named override — `get_config_with_defaults()` then calls
the check's list-returning method instead and `dict()` raises:

```
ValueError: dictionary update sequence element #0 has length 65; 2 is required
```

Confirmed pre-existing and unrelated to any other open PR: reproduced on an
unmodified checkout of `master` via `uvx --python 3.13 ddev@18.0.0 -x test
redis_cloud` — the failure is byte-for-byte identical. It's only visible in
CI when a PR happens to touch files inside `redis_cloud/` or
`redis_enterprise/`, since `TARGET=changed` scopes the test matrix to
touched directories.

## How

Renamed the check-specific method (and its one call site in
`_parse_config`) in both integrations from `get_default_config` to
`get_default_metrics`, which no longer collides with the base class's
config-defaults hook.

Verified locally with `ddev@18.0.0` (the version CI's `test` workflow
resolves): `redis_cloud` 5/5 passing, `redis_enterprise` 7/7 passing, lint
clean.