### PR TITLE
Temporarily disable Shopify integration public docs before GA

### DIFF
--- a/rum_shopify/manifest.json
+++ b/rum_shopify/manifest.json
@@ -3,7 +3,7 @@
   "app_uuid": "8af53d79-71ee-418a-97db-e2224c590002",
   "app_id": "rum-shopify",
   "owner": "rum-browser",
-  "display_on_public_website": true,
+  "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?

Sets `display_on_public_website` to `false` in `rum_shopify/manifest.json`, temporarily hiding the Shopify integration's public documentation.

### Motivation

The Shopify integration docs were published recently, and no customers have instrumented it according to our monitors. We're currently changing the public API for this integration, so we want to avoid customers instrumenting against docs that will soon be outdated, until GA.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors.

### Additional Notes

Re-enable `display_on_public_website` once the public API changes are finalized and GA is ready.
