### PR TITLE
upsc: Correct two metric names in metadata.csv

### DIFF
--- a/upsc/metadata.csv
+++ b/upsc/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
-upsc.status,gauge,,,,UPS status,1,upsc,status,
+upsc.ups.status,gauge,,,,UPS status,1,upsc,status,
 upsc.battery.charge,gauge,,percent,,UPS battery charge,1,upsc,battery charge %,
 upsc.battery.charge.low,gauge,,percent,,UPS remaining battery level when UPS switches to Low Battery,1,upsc,low charge %,
 upsc.battery.charge.warning,gauge,,percent,,UPS battery level when UPS switches to Warning state,1,upsc,warn charge %,
@@ -10,4 +10,4 @@ upsc.battery.voltage.nominal,gauge,,volt,,UPS Nominal battery voltage,0,upsc,nom
 upsc.input.voltage,gauge,,volt,,UPS input voltage,0,upsc,input voltage,
 upsc.input.voltage.nominal,gauge,,volt,,UPS nominal input voltage,0,upsc,nominal input voltage,
 upsc.output.voltage,gauge,,volt,,UPS output voltage,0,upsc,output voltage,
-upsc.load,gauge,,percent,,UPS load,-1,upsc,load,
+upsc.ups.load,gauge,,percent,,UPS load,-1,upsc,load,


### PR DESCRIPTION
### What does this PR do?

Corrects two metric names in `upsc/metadata.csv`. The check reports `upsc.` followed by the NUT variable name, and the NUT variables are `ups.status` and `ups.load`, so the metrics are `upsc.ups.status` and `upsc.ups.load`. `metadata.csv` listed them as `upsc.status` and `upsc.load`.

### Motivation

Those two metrics are emitted under different names than `metadata.csv` documents, so the units and descriptions there do not reach them.

Verified on a host running the integration:

```
datadog-agent check upsc | grep '"metric"' | sort -u
```

which lists `upsc.ups.status` and `upsc.ups.load`.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors.

### Additional Notes

Metadata only, with no change to the data the check reports, so there is no version bump or changelog entry, matching #2864. The `no-changelog` label is probably needed. No tests, since nothing executable changed.

LLM assistance was used to compare the emitted metric names against `metadata.csv` and to write this description.
