### PR TITLE
mongodb_atlas: document queryStats sampling tags and MongoDB 9.0 collection semantics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -126,7 +126,7 @@ code-coverage.datadog.yml                                  @DataDog/agent-integr
 /loadrunner_professional/                @mihneavelinOT
 /logstash/                               @ervansetiawan ervansetiawan@gmail.com
 /logzio/                                 @DataDog/agent-integrations @DataDog/saas-integrations
-/mongodb_atlas/                          @Salil999 @JustinMason frank.sun@mongodb.com tonya.edmonds@mongodb.com
+/mongodb_atlas/                          frank.sun@mongodb.com @aettouat
 /moovingon_ai/                           @tomm24 info@moovingon.com
 /modal/                                  @modal-labs support@modal.com
 /mendix/                                 @mendix/cloud @DataDog/agent-integrations @DataDog/ecosystems-review

--- a/mongodb_atlas/README.md
+++ b/mongodb_atlas/README.md
@@ -30,7 +30,10 @@ You can install the MongoDB Atlas integration by logging in to your Atlas portal
 
 See [metadata.csv][3] for a list of metrics provided by this integration.
 
-Query shape metrics (prefixed `mongodb.atlas.querystats`) carry `samplingstrategy` and `samplingrate` tags that describe how MongoDB Atlas collected the underlying operations. On clusters running MongoDB 9.0 or later with sample-based collection in effect (`samplingstrategy:sampled`), query shape metrics reflect a random sample of read and write operations (1% by default), so metric values represent only the sampled operations. On earlier versions, Atlas records up to 100 read queries per second per host (`samplingstrategy:rate_limited`) and write operations are not collected.
+Query shape metrics (prefixed `mongodb.atlas.querystats`) carry `samplingstrategy` and `samplingrate` tags that describe how MongoDB Atlas collected the underlying operations:
+
+- `samplingstrategy:sampled`: On clusters running MongoDB 9.0 or later with sample-based collection in effect, query shape metrics reflect a random sample of read and write operations, so metric values represent only the sampled operations. `samplingrate` is a floating point number indicating the percentage of operations sampled - for example, `0.01` if 1% sampling (the default) is enabled.
+- `samplingstrategy:rate_limited`: On earlier versions, Atlas records up to a maximum number of read queries per second per host (100 per second by default), and write operations are not collected. `samplingrate` is always `0` when the sampling strategy is `rate_limited`.
 
 ### Events
 

--- a/mongodb_atlas/README.md
+++ b/mongodb_atlas/README.md
@@ -30,6 +30,8 @@ You can install the MongoDB Atlas integration by logging in to your Atlas portal
 
 See [metadata.csv][3] for a list of metrics provided by this integration.
 
+Query shape metrics (prefixed `mongodb.atlas.querystats`) carry `samplingstrategy` and `samplingrate` tags that describe how MongoDB Atlas collected the underlying operations. On clusters running MongoDB 9.0 or later with sample-based collection in effect (`samplingstrategy:sampled`), query shape metrics reflect a random sample of read and write operations (1% by default), so metric values represent only the sampled operations. On earlier versions, Atlas records up to 100 read queries per second per host (`samplingstrategy:rate_limited`) and write operations are not collected.
+
 ### Events
 
 MongoDB Atlas can push [alerts][4] to Datadog as events.


### PR DESCRIPTION
### What does this PR do?

Documents two additions to the query shape metrics that MongoDB Atlas pushes to Datadog (`mongodb.atlas.querystats` prefix):

- New `samplingstrategy` and `samplingrate` tags describing how Atlas collected the underlying operations.
- Collection semantics on MongoDB 9.0+: with sample-based collection in effect, query shape metrics reflect a random sample of read and write operations (1% by default), so metric values represent only the sampled operations. On earlier MongoDB versions, Atlas records up to 100 read queries per second per host and write operations are not collected.

### Motivation

MongoDB 9.0 adds $queryStats support for write commands, and Atlas collects it via percentage-based sampling rather than the pre-9.0 rate limit. Without this note, users comparing metric totals across a MongoDB version upgrade may misread the collection-method change as a workload change.

### Additional Notes

Authored by the MongoDB Atlas team that owns this integration's data pipeline. The tags ship with an upcoming Atlas release; happy to hold merge until they are live — will confirm on this PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Changelog entries must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.