### PR TITLE
[Shopify] Update integrations docs snippets with plugin approach and enable them back

### DIFF
--- a/rum_shopify/README.md
+++ b/rum_shopify/README.md
@@ -128,7 +128,7 @@ Use this path to cover checkout pages (`/checkouts/*`, `/checkout`). It runs ins
        env: '<YOUR_ENV_NAME>',
        version: '1.0.0',
        sessionSampleRate: 100,
-       shopifyAnalytics: analytics,
+       plugins: [DD_RUM.shopifyPlugin({ shopifyAnalytics: analytics })],
      })
    })
    ```

--- a/rum_shopify/manifest.json
+++ b/rum_shopify/manifest.json
@@ -3,7 +3,7 @@
   "app_uuid": "8af53d79-71ee-418a-97db-e2224c590002",
   "app_id": "rum-shopify",
   "owner": "rum-browser",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?

Updates the Custom Pixel snippet in the Shopify integration docs to use the new `DD_RUM.shopifyPlugin({ shopifyAnalytics })` plugin API instead of passing `shopifyAnalytics` directly to `init()`. Also re-enables `display_on_public_website` in `rum_shopify/manifest.json`, which was temporarily set to `false` in #3138.

### Motivation

We've moved to a dedicated `shopifyPlugin` approach for wiring Shopify analytics into the RUM SDK. The docs' Custom Pixel snippet needs to match this new API before the public docs go back live for GA. The Theme Liquid (Storefront) snippet is unaffected and stays as-is.

### Review checklist

- [x] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [x] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)
- [ ] If this PR includes a log pipeline, please add a description describing the remappers and processors.

### Additional Notes

Ref: [RUM-18245](https://datadoghq.atlassian.net/browse/RUM-18245)


[RUM-18245]: https://datadoghq.atlassian.net/browse/RUM-18245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ