### PR TITLE
Enable SSL certificate verification in redisenterprise and nn_sdwan

### DIFF
--- a/nn_sdwan/datadog_checks/nn_sdwan/net_api.py
+++ b/nn_sdwan/datadog_checks/nn_sdwan/net_api.py
@@ -9,7 +9,7 @@ def get_response(url):
         def inner_wrapper(self):
             initiate_pull_time = datetime.now()
             url1 = "{}://{}{}".format(self.protocol, self.hostname, url)
-            resp = requests.get(url1, auth=(self.username, self.password), verify=False)
+            resp = requests.get(url1, auth=(self.username, self.password), verify=True)
             return func(self, resp, initiate_pull_time, datetime.now())
 
         return inner_wrapper
@@ -148,7 +148,7 @@ class vManageApi:
             url1,
             auth=(self.username, self.password),
             headers=_get_token_and_cookie_headers(token, vmanage_cookie),
-            verify=False,
+            verify=True,
         )
         recieve_time = datetime.now()
         event_time = resp.json()["header"]["generatedOn"]

--- a/redisenterprise/datadog_checks/redisenterprise/check.py
+++ b/redisenterprise/datadog_checks/redisenterprise/check.py
@@ -105,7 +105,7 @@ class RedisenterpriseCheck(AgentCheck):
             auth=HTTPBasicAuth(username, password),
             headers={'Content-Type': 'application/json'},
             allow_redirects=False,
-            verify=False,
+            verify=True,
         )
 
         if r.status_code != 307:


### PR DESCRIPTION
## What & why

Both checks call `requests.get(...)` with `verify=False`, disabling SSL/TLS certificate
validation and exposing the connection to man-in-the-middle attacks (CWE-295, CVSS 9.0).
This flips `verify` to `True` (the safe default) at each flagged call site — no other
behavior changes.

- `redisenterprise/datadog_checks/redisenterprise/check.py:108`
- `nn_sdwan/datadog_checks/nn_sdwan/net_api.py:12`
- `nn_sdwan/datadog_checks/nn_sdwan/net_api.py:151`

## Datadog cases addressed

- https://app.datadoghq.com/cases/VMSAST-6
- https://app.datadoghq.com/cases/VMSAST-5
- https://app.datadoghq.com/cases/VMSAST-3

## ⚠️ Please verify before merging

Flipping `verify=True` is what the finding requests, but it assumes each target host presents a
certificate that validates against the client's trust store. If any of these devices are commonly
reached by IP or with a self-signed/internal CA certificate in the field, this change could break
connectivity for existing installs. Please confirm expected certificate setups for
RedisEnterprise clusters and Cisco/Viptela (nn_sdwan) vManage instances before merging, or add
proper CA-bundle configuration support if self-signed certs are expected.

---
Generated from Datadog SAST findings via the `generate-remediation-prs` skill:
https://github.com/ddoghq/dd-source/pull/47645