### PR TITLE
Enable SSL certificate verification in unifi_console

### DIFF
--- a/unifi_console/datadog_checks/unifi_console/unifi.py
+++ b/unifi_console/datadog_checks/unifi_console/unifi.py
@@ -128,7 +128,7 @@ class Unifi:
         self.log.debug("Requesting %s/ to determine API paths", self.config.url)
         try:
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-            resp = requests.get(self.config.url + "/", verify=False, allow_redirects=False)
+            resp = requests.get(self.config.url + "/", verify=True, allow_redirects=False)
             resp.raise_for_status()
             if resp.status_code == 200:
                 self.new = True


### PR DESCRIPTION
## What & why

The check calls `requests.get(...)` with `verify=False` and pre-emptively silences the
resulting urllib3 `InsecureRequestWarning`, disabling SSL/TLS certificate validation
(CWE-295, CVSS 9.0).

- `unifi_console/datadog_checks/unifi_console/unifi.py:131`

## Datadog case addressed

- https://app.datadoghq.com/cases/VMSAST-4

## ⚠️ Please verify before merging

The explicit `disable_warnings(InsecureRequestWarning)` call right before this request strongly
suggests `verify=False` was intentional, not an oversight: self-hosted UniFi controllers commonly
present self-signed certificates on the local network. Flipping to `verify=True` as requested by
the finding may break connectivity for existing installs pointed at such controllers unless they
already use a certificate that chains to a trusted CA, or unless a CA-bundle config option is
added. Please confirm expected certificate setups for UniFi controllers before merging.

This case has no owning team tagged (only an individual code owner), so no reviewer could be
auto-requested — opened without one.

---
Generated from Datadog SAST findings via the `generate-remediation-prs` skill:
https://github.com/ddoghq/dd-source/pull/47645